### PR TITLE
[FLINK-31559][connector/kafka] Update the flink version to 1.18-SNAPSHOT and drop support for 1.16

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,4 +25,4 @@ jobs:
   compile_and_test:
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
-      flink_version: 1.17-SNAPSHOT
+      flink_version: 1.18-SNAPSHOT

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT]
+        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT, 1.18-SNAPSHOT]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT, 1.18-SNAPSHOT]
+        flink: [1.17-SNAPSHOT, 1.18-SNAPSHOT]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -936,7 +936,7 @@ public class KafkaDynamicTableFactoryTest {
 
     private SerializationSchema<RowData> createDebeziumAvroSerSchema(
             RowType rowType, String subject) {
-        return new DebeziumAvroSerializationSchema(rowType, TEST_REGISTRY_URL, subject, null);
+        return new DebeziumAvroSerializationSchema(rowType, TEST_REGISTRY_URL, subject, null, null);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@ under the License.
     </modules>
 
     <properties>
-        <flink.version>1.17-SNAPSHOT</flink.version>
+        <flink.version>1.18-SNAPSHOT</flink.version>
         <flink.shaded.version>16.1</flink.shaded.version>
         <kafka.version>3.4.0</kafka.version>
         <zookeeper.version>3.5.9</zookeeper.version>


### PR DESCRIPTION
This PR updates the flink version to 1.18-SNAPSHOT.