### PR TITLE
[FLINK-31363] Do not checkpoint a KafkaCommittable if the transaction was empty

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducer.java
@@ -17,8 +17,11 @@
 
 package org.apache.flink.connector.kafka.sink;
 
+import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.clients.producer.internals.TransactionManager;
 import org.apache.kafka.clients.producer.internals.TransactionalRequestResult;
 import org.apache.kafka.common.errors.ProducerFencedException;
@@ -33,6 +36,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Properties;
+import java.util.concurrent.Future;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -49,6 +53,7 @@ class FlinkKafkaInternalProducer<K, V> extends KafkaProducer<K, V> {
 
     @Nullable private String transactionalId;
     private volatile boolean inTransaction;
+    private volatile boolean hasRecordsInTransaction;
     private volatile boolean closed;
 
     public FlinkKafkaInternalProducer(Properties properties, @Nullable String transactionalId) {
@@ -65,6 +70,14 @@ class FlinkKafkaInternalProducer<K, V> extends KafkaProducer<K, V> {
         props.putAll(properties);
         props.setProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
         return props;
+    }
+
+    @Override
+    public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback) {
+        if (inTransaction) {
+            hasRecordsInTransaction = true;
+        }
+        return super.send(record, callback);
     }
 
     @Override
@@ -86,6 +99,7 @@ class FlinkKafkaInternalProducer<K, V> extends KafkaProducer<K, V> {
         LOG.debug("abortTransaction {}", transactionalId);
         checkState(inTransaction, "Transaction was not started");
         inTransaction = false;
+        hasRecordsInTransaction = false;
         super.abortTransaction();
     }
 
@@ -94,11 +108,16 @@ class FlinkKafkaInternalProducer<K, V> extends KafkaProducer<K, V> {
         LOG.debug("commitTransaction {}", transactionalId);
         checkState(inTransaction, "Transaction was not started");
         inTransaction = false;
+        hasRecordsInTransaction = false;
         super.commitTransaction();
     }
 
     public boolean isInTransaction() {
         return inTransaction;
+    }
+
+    public boolean hasRecordsInTransaction() {
+        return hasRecordsInTransaction;
     }
 
     @Override
@@ -304,6 +323,7 @@ class FlinkKafkaInternalProducer<K, V> extends KafkaProducer<K, V> {
             transitionTransactionManagerStateTo(transactionManager, "IN_TRANSACTION");
             setField(transactionManager, "transactionStarted", true);
             this.inTransaction = true;
+            this.hasRecordsInTransaction = true;
         }
     }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducerITCase.java
@@ -51,7 +51,6 @@ import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createKafkaCo
 import static org.apache.flink.util.DockerImageVersions.KAFKA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 @Testcontainers
 @ExtendWith(TestLoggerExtension.class)
@@ -129,13 +128,7 @@ class FlinkKafkaInternalProducerITCase {
             resumedProducer.resumeTransaction(
                     snapshottedCommittable.getProducerId(), snapshottedCommittable.getEpoch());
 
-            try {
-                resumedProducer.commitTransaction();
-            } catch (Exception e) {
-                // test assertion success
-                return;
-            }
-            fail("Committing a resumed transaction that is empty should fail.");
+            assertThatThrownBy(resumedProducer::commitTransaction);
         }
     }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
@@ -317,6 +317,7 @@ public class KafkaWriterITCase {
                         getKafkaClientConfiguration(), DeliveryGuarantee.EXACTLY_ONCE)) {
             assertThat(writer.getProducerPool()).hasSize(0);
 
+            writer.write(1, SINK_WRITER_CONTEXT);
             writer.flush(false);
             Collection<KafkaCommittable> committables0 = writer.prepareCommit();
             writer.snapshotState(1);
@@ -336,6 +337,7 @@ public class KafkaWriterITCase {
             committable.getProducer().get().close();
             assertThat(writer.getProducerPool()).hasSize(1);
 
+            writer.write(1, SINK_WRITER_CONTEXT);
             writer.flush(false);
             Collection<KafkaCommittable> committables1 = writer.prepareCommit();
             writer.snapshotState(2);
@@ -346,6 +348,30 @@ public class KafkaWriterITCase {
             assertThat(firstProducer == writer.getCurrentProducer())
                     .as("Expected recycled producer")
                     .isTrue();
+        }
+    }
+
+    /**
+     * Tests that if a pre-commit attempt occurs on an empty transaction, the writer should not emit
+     * a KafkaCommittable, and instead immediately commit the empty transaction and recycle the
+     * producer.
+     */
+    @Test
+    void prepareCommitForEmptyTransaction() throws Exception {
+        try (final KafkaWriter<Integer> writer =
+                createWriterWithConfiguration(
+                        getKafkaClientConfiguration(), DeliveryGuarantee.EXACTLY_ONCE)) {
+            assertThat(writer.getProducerPool()).hasSize(0);
+
+            // no data written to current transaction
+            writer.flush(false);
+            Collection<KafkaCommittable> emptyCommittables = writer.prepareCommit();
+
+            assertThat(emptyCommittables).hasSize(0);
+            assertThat(writer.getProducerPool()).hasSize(1);
+            final FlinkKafkaInternalProducer<?, ?> recycledProducer =
+                    writer.getProducerPool().pop();
+            assertThat(recycledProducer.isInTransaction()).isFalse();
         }
     }
 


### PR DESCRIPTION
This PR fixes FLINK-31363 by changing how we handle empty transactions on `KafkaWriter#prepareCommit()`.

Previously, regardless of whether the current transaction is empty or non-empty, we always emit a `KafkaCommittable` for it to be checkpointed by the `CommitterOperator`. The issue: on restore, when we resume the transaction and commit it, we recreate a `FlinkKafkaInternalProducer` that always has the internal `transactionStarted` flag set to `true`, which means that an `EndTxnRequest` will be sent to the brokers for committing the transaction. This results in an `InvalidTxnState` error since on the broker side the transaction hasn't actually been started yet (transactions are lazily started on brokers on the first record sent).

I've considered two possible ways to address this:

1. Store the `transactionStarted` flag in a `KafkaCommittable` alongside other txn metadata. Then, on restore, on the recreated producer, we set the internal `transactionStarted` accordingly to what the checkpoint says.
2. Never checkpoint a `KafkaCommitable` if the transaction is empty. In this case, any `KafkaCommittable` restored from a checkpoint always has some data in them, and therefore it is correct to always set the internal `transactionStarted` flag to `true` on the recreated producer.

This PR chooses to go with approach 2.

On `prepareCommit`, if the current ongoing transaction is empty, then:

1. Do NOT emit a `KafkaCommittable` (which will be checkpointed by the downstream `CommitterOperator`)
2. Immediately commit the empty transaction (this will be a no-op since the producer would not issue an `EndTxnRequest` at all)
3. Recycle the producer back into the idle pool for future reuse.