### PR TITLE
[FLINK-31049] [flink-connector-kafka]Add support for Kafka record headers to KafkaSink

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/HeaderProducer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/HeaderProducer.java
@@ -21,6 +21,8 @@ package org.apache.flink.connector.kafka.sink;
 import org.apache.flink.annotation.PublicEvolving;
 
 import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -28,7 +30,7 @@ import java.util.ArrayList;
 /** Creates an {@link Iterable} of {@link Header}s from the input element. */
 @PublicEvolving
 public interface HeaderProducer<IN> extends Serializable {
-    default Iterable<Header> produceHeaders(IN input) {
-        return new ArrayList<>();
+    default Headers produceHeaders(IN input) {
+        return new RecordHeaders(new ArrayList<>());
     }
 }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/HeaderProducer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/HeaderProducer.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import org.apache.kafka.common.header.Header;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+/** Creates an {@link Iterable} of {@link Header}s from the input element. */
+@PublicEvolving
+public interface HeaderProducer<IN> extends Serializable {
+    default Iterable<Header> produceHeaders(IN input) {
+        return new ArrayList<>();
+    }
+}

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilder.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilder.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
 
 import javax.annotation.Nullable;
@@ -340,7 +340,7 @@ public class KafkaRecordSerializationSchemaBuilder<IN> {
                 IN element, KafkaSinkContext context, Long timestamp) {
             final String targetTopic = topicSelector.apply(element);
             final byte[] value = valueSerializationSchema.serialize(element);
-            Iterable<Header> headers = headerProducer.produceHeaders(element);
+            Headers headers = headerProducer.produceHeaders(element);
             byte[] key = null;
             if (keySerializationSchema != null) {
                 key = keySerializationSchema.serialize(element);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
@@ -28,7 +28,8 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Configurable;
-import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -162,19 +163,9 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
         final HeaderProducer<String> headerProducer =
                 new HeaderProducer<String>() {
                     @Override
-                    public Iterable<Header> produceHeaders(String input) {
-                        return ImmutableList.of(
-                                new Header() {
-                                    @Override
-                                    public String key() {
-                                        return input;
-                                    }
-
-                                    @Override
-                                    public byte[] value() {
-                                        return input.getBytes(StandardCharsets.UTF_8);
-                                    }
-                                });
+                    public RecordHeaders produceHeaders(String input) {
+                        return new RecordHeaders(
+                                ImmutableList.of(new RecordHeader("a", "a".getBytes())));
                     }
                 };
         final KafkaRecordSerializationSchema<String> schema =


### PR DESCRIPTION
## What is the purpose of the change

The default `org.apache.flink.connector.kafka.sink.KafkaSink` does not support adding Kafka record headers when using KafkaRecordSerializationSchemaBuilder, which is the most convenient way to create a Kafka sink. This PR adds support for Kafka headers to `KafkaRecordSerializationSchemaBuilder`.


## Brief change log

  - *Implemented a `HeaderProducer` that allows creating `Header`s from the input element*
  - *Added setters to `KafkaRecordSerializationSchemaBuilder` to allow setting a `HeaderProducer`*
  - *Added an optional `HeaderProducer` constructor argument to `KafkaRecordSerializationSchemaWrapper` that now uses a `ProducerRecord` constructor that includes the headers.* 


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - *Added tests to `KafkaRecordSerializationSchemaBuilderTest`*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes?
  - If yes, how is the feature documented? JavaDocs
