### PR TITLE
[FLINK-31953][Connector/Kafka] EARLIEST offset strategy for partitions discoveried later based on FLIP-288

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -196,7 +196,9 @@ public class KafkaSource<OUT>
                 props,
                 enumContext,
                 boundedness,
-                checkpoint.assignedPartitions());
+                checkpoint.assignedPartitions(),
+                checkpoint.unassignedInitialPartitons(),
+                checkpoint.initialDiscoveryFinished());
     }
 
     @Internal

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/TopicPartitionWithAssignStatus.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/TopicPartitionWithAssignStatus.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.kafka.common.TopicPartition;
+
+/** Kafka partition with assign status. */
+@Internal
+public class TopicPartitionWithAssignStatus {
+    private final TopicPartition topicPartition;
+    private final long assignStatus;
+
+    /** Partitions that have been assigned to readers. */
+    public static final long ASSIGNED = -1;
+    /**
+     * The partitions that have been discovered during initialization but not assigned to readers
+     * yet.
+     */
+    public static final long UNASSIGNED_INITIAL = -2;
+
+    public TopicPartitionWithAssignStatus(TopicPartition topicPartition, long assignStatus) {
+        this.topicPartition = topicPartition;
+        this.assignStatus = assignStatus;
+    }
+
+    public TopicPartition topicPartition() {
+        return topicPartition;
+    }
+
+    public long assignStatus() {
+        return assignStatus;
+    }
+}

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumState.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumState.java
@@ -19,21 +19,80 @@
 package org.apache.flink.connector.kafka.source.enumerator;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.kafka.source.TopicPartitionWithAssignStatus;
 
 import org.apache.kafka.common.TopicPartition;
 
+import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /** The state of Kafka source enumerator. */
 @Internal
 public class KafkaSourceEnumState {
-    private final Set<TopicPartition> assignedPartitions;
+    /** Partitions with status: ASSIGNED or UNASSIGNED_INITIAL. */
+    private final Set<TopicPartitionWithAssignStatus> partitions;
+    /**
+     * this flag will be marked as true if inital partitions are discovered after enumerator starts.
+     */
+    private final boolean initialDiscoveryFinished;
 
-    KafkaSourceEnumState(Set<TopicPartition> assignedPartitions) {
-        this.assignedPartitions = assignedPartitions;
+    KafkaSourceEnumState(
+            Set<TopicPartition> assignPartitions,
+            Set<TopicPartition> unAssignInitialPartitions,
+            boolean initialDiscoveryFinished) {
+        this.partitions = new HashSet<>();
+        partitions.addAll(
+                assignPartitions.stream()
+                        .map(
+                                topicPartition ->
+                                        new TopicPartitionWithAssignStatus(
+                                                topicPartition,
+                                                TopicPartitionWithAssignStatus.ASSIGNED))
+                        .collect(Collectors.toSet()));
+        partitions.addAll(
+                unAssignInitialPartitions.stream()
+                        .map(
+                                topicPartition ->
+                                        new TopicPartitionWithAssignStatus(
+                                                topicPartition,
+                                                TopicPartitionWithAssignStatus.UNASSIGNED_INITIAL))
+                        .collect(Collectors.toSet()));
+        this.initialDiscoveryFinished = initialDiscoveryFinished;
+    }
+
+    public Set<TopicPartitionWithAssignStatus> partitions() {
+        return partitions;
     }
 
     public Set<TopicPartition> assignedPartitions() {
+        HashSet<TopicPartition> assignedPartitions = new HashSet<TopicPartition>();
+        assignedPartitions.addAll(
+                partitions.stream()
+                        .filter(
+                                partitionWithStatus ->
+                                        partitionWithStatus.assignStatus()
+                                                == TopicPartitionWithAssignStatus.ASSIGNED)
+                        .map(TopicPartitionWithAssignStatus::topicPartition)
+                        .collect(Collectors.toSet()));
         return assignedPartitions;
+    }
+
+    public Set<TopicPartition> unassignedInitialPartitons() {
+        HashSet<TopicPartition> unassignedInitialPartitons = new HashSet<TopicPartition>();
+        unassignedInitialPartitons.addAll(
+                partitions.stream()
+                        .filter(
+                                partitionWithStatus ->
+                                        partitionWithStatus.assignStatus()
+                                                == TopicPartitionWithAssignStatus
+                                                        .UNASSIGNED_INITIAL)
+                        .map(TopicPartitionWithAssignStatus::topicPartition)
+                        .collect(Collectors.toSet()));
+        return unassignedInitialPartitons;
+    }
+
+    public boolean initialDiscoveryFinished() {
+        return initialDiscoveryFinished;
     }
 }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -65,6 +65,7 @@ public class KafkaSourceEnumerator
     private final KafkaSubscriber subscriber;
     private final OffsetsInitializer startingOffsetInitializer;
     private final OffsetsInitializer stoppingOffsetInitializer;
+    private OffsetsInitializer newDiscoveryOffsetsInitializer;
     private final Properties properties;
     private final long partitionDiscoveryIntervalMs;
     private final SplitEnumeratorContext<KafkaPartitionSplit> context;
@@ -72,6 +73,12 @@ public class KafkaSourceEnumerator
 
     /** Partitions that have been assigned to readers. */
     private final Set<TopicPartition> assignedPartitions;
+
+    /**
+     * The partitions that have been discovered during initialization but not assigned to readers
+     * yet.
+     */
+    private final Set<TopicPartition> unassignedInitialPartitons;
 
     /**
      * The discovered and initialized partition splits that are waiting for owner reader to be
@@ -88,6 +95,8 @@ public class KafkaSourceEnumerator
     // This flag will be marked as true if periodically partition discovery is disabled AND the
     // initializing partition discovery has finished.
     private boolean noMoreNewPartitionSplits = false;
+    // this flag will be marked as true if inital partitions are discovered after enumerator starts
+    private boolean initialDiscoveryFinished;
 
     public KafkaSourceEnumerator(
             KafkaSubscriber subscriber,
@@ -103,7 +112,9 @@ public class KafkaSourceEnumerator
                 properties,
                 context,
                 boundedness,
-                Collections.emptySet());
+                Collections.emptySet(),
+                Collections.emptySet(),
+                false);
     }
 
     public KafkaSourceEnumerator(
@@ -113,10 +124,13 @@ public class KafkaSourceEnumerator
             Properties properties,
             SplitEnumeratorContext<KafkaPartitionSplit> context,
             Boundedness boundedness,
-            Set<TopicPartition> assignedPartitions) {
+            Set<TopicPartition> assignedPartitions,
+            Set<TopicPartition> unassignedInitialPartitons,
+            boolean initialDiscoveryFinished) {
         this.subscriber = subscriber;
         this.startingOffsetInitializer = startingOffsetInitializer;
         this.stoppingOffsetInitializer = stoppingOffsetInitializer;
+        this.newDiscoveryOffsetsInitializer = OffsetsInitializer.earliest();
         this.properties = properties;
         this.context = context;
         this.boundedness = boundedness;
@@ -129,6 +143,8 @@ public class KafkaSourceEnumerator
                         KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS,
                         Long::parseLong);
         this.consumerGroupId = properties.getProperty(ConsumerConfig.GROUP_ID_CONFIG);
+        this.unassignedInitialPartitons = new HashSet<>(unassignedInitialPartitons);
+        this.initialDiscoveryFinished = initialDiscoveryFinished;
     }
 
     /**
@@ -195,7 +211,8 @@ public class KafkaSourceEnumerator
 
     @Override
     public KafkaSourceEnumState snapshotState(long checkpointId) throws Exception {
-        return new KafkaSourceEnumState(assignedPartitions);
+        return new KafkaSourceEnumState(
+                assignedPartitions, unassignedInitialPartitons, initialDiscoveryFinished);
     }
 
     @Override
@@ -234,6 +251,12 @@ public class KafkaSourceEnumerator
             throw new FlinkRuntimeException(
                     "Failed to list subscribed topic partitions due to ", t);
         }
+
+        if (!initialDiscoveryFinished) {
+            unassignedInitialPartitons.addAll(fetchedPartitions);
+            initialDiscoveryFinished = true;
+        }
+
         final PartitionChange partitionChange = getPartitionChange(fetchedPartitions);
         if (partitionChange.isEmpty()) {
             return;
@@ -266,10 +289,18 @@ public class KafkaSourceEnumerator
     private PartitionSplitChange initializePartitionSplits(PartitionChange partitionChange) {
         Set<TopicPartition> newPartitions =
                 Collections.unmodifiableSet(partitionChange.getNewPartitions());
-        OffsetsInitializer.PartitionOffsetsRetriever offsetsRetriever = getOffsetsRetriever();
 
-        Map<TopicPartition, Long> startingOffsets =
-                startingOffsetInitializer.getPartitionOffsets(newPartitions, offsetsRetriever);
+        OffsetsInitializer.PartitionOffsetsRetriever offsetsRetriever = getOffsetsRetriever();
+        // intial partitions use OffsetsInitializer specified by the user while new partitions use
+        // EARLIEST
+        Map<TopicPartition, Long> startingOffsets = new HashMap<>();
+        startingOffsets.putAll(
+                newDiscoveryOffsetsInitializer.getPartitionOffsets(
+                        newPartitions, offsetsRetriever));
+        startingOffsets.putAll(
+                startingOffsetInitializer.getPartitionOffsets(
+                        unassignedInitialPartitons, offsetsRetriever));
+
         Map<TopicPartition, Long> stoppingOffsets =
                 stoppingOffsetInitializer.getPartitionOffsets(newPartitions, offsetsRetriever);
 
@@ -344,7 +375,10 @@ public class KafkaSourceEnumerator
 
                 // Mark pending partitions as already assigned
                 pendingAssignmentForReader.forEach(
-                        split -> assignedPartitions.add(split.getTopicPartition()));
+                        split -> {
+                            assignedPartitions.add(split.getTopicPartition());
+                            unassignedInitialPartitons.remove(split.getTopicPartition());
+                        });
             }
         }
 
@@ -539,9 +573,9 @@ public class KafkaSourceEnumerator
          * the beginning offset, end offset as well as the offset matching a timestamp in
          * partitions.
          *
-         * @see KafkaAdminClient#listOffsets(Map)
          * @param topicPartitionOffsets The mapping from partition to the OffsetSpec to look up.
          * @return The list offsets result.
+         * @see KafkaAdminClient#listOffsets(Map)
          */
         private Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> listOffsets(
                 Map<TopicPartition, OffsetSpec> topicPartitionOffsets) {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.connector.kafka.source.enumerator;
 
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.ReaderInfo;
+import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
 import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.NoStoppingOffsetsInitializer;
@@ -50,6 +51,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -255,7 +257,8 @@ public class KafkaEnumeratorTest {
                         createEnumerator(
                                 context,
                                 ENABLE_PERIODIC_PARTITION_DISCOVERY,
-                                INCLUDE_DYNAMIC_TOPIC);
+                                INCLUDE_DYNAMIC_TOPIC,
+                                OffsetsInitializer.latest());
                 AdminClient adminClient = KafkaSourceTestEnv.getAdminClient()) {
 
             startEnumeratorAndRegisterReaders(context, enumerator);
@@ -291,6 +294,19 @@ public class KafkaEnumeratorTest {
                     Arrays.asList(READER0, READER1),
                     Collections.singleton(DYNAMIC_TOPIC_NAME),
                     3);
+
+            // new partitions use EARLIEST_OFFSET, while initial partitions use LATEST_OFFSET
+            List<KafkaPartitionSplit> initialPartitionAssign =
+                    getAllAssignSplits(context, PRE_EXISTING_TOPICS);
+            assertThat(initialPartitionAssign)
+                    .extracting(KafkaPartitionSplit::getStartingOffset)
+                    .containsOnly(KafkaPartitionSplit.LATEST_OFFSET);
+            List<KafkaPartitionSplit> newPartitionAssign =
+                    getAllAssignSplits(context, Collections.singleton(DYNAMIC_TOPIC_NAME));
+            assertThat(newPartitionAssign)
+                    .extracting(KafkaPartitionSplit::getStartingOffset)
+                    .containsOnly(KafkaPartitionSplit.EARLIEST_OFFSET);
+
         } finally {
             try (AdminClient adminClient = KafkaSourceTestEnv.getAdminClient()) {
                 adminClient.deleteTopics(Collections.singleton(DYNAMIC_TOPIC_NAME)).all().get();
@@ -343,6 +359,7 @@ public class KafkaEnumeratorTest {
                         createEnumerator(
                                 context2,
                                 ENABLE_PERIODIC_PARTITION_DISCOVERY ? 1 : -1,
+                                OffsetsInitializer.earliest(),
                                 PRE_EXISTING_TOPICS,
                                 preexistingAssignments,
                                 Collections.emptySet(),
@@ -374,6 +391,7 @@ public class KafkaEnumeratorTest {
                         createEnumerator(
                                 context,
                                 ENABLE_PERIODIC_PARTITION_DISCOVERY ? 1 : -1,
+                                OffsetsInitializer.earliest(),
                                 PRE_EXISTING_TOPICS,
                                 Collections.emptySet(),
                                 Collections.emptySet(),
@@ -514,19 +532,27 @@ public class KafkaEnumeratorTest {
             MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
             boolean enablePeriodicPartitionDiscovery) {
         return createEnumerator(
-                enumContext, enablePeriodicPartitionDiscovery, EXCLUDE_DYNAMIC_TOPIC);
+                enumContext,
+                enablePeriodicPartitionDiscovery,
+                EXCLUDE_DYNAMIC_TOPIC,
+                OffsetsInitializer.earliest());
     }
 
     private KafkaSourceEnumerator createEnumerator(
             MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
             long partitionDiscoveryIntervalMs) {
-        return createEnumerator(enumContext, partitionDiscoveryIntervalMs, EXCLUDE_DYNAMIC_TOPIC);
+        return createEnumerator(
+                enumContext,
+                partitionDiscoveryIntervalMs,
+                EXCLUDE_DYNAMIC_TOPIC,
+                OffsetsInitializer.earliest());
     }
 
     private KafkaSourceEnumerator createEnumerator(
             MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
             boolean enablePeriodicPartitionDiscovery,
-            boolean includeDynamicTopic) {
+            boolean includeDynamicTopic,
+            OffsetsInitializer startingOffsetsInitializer) {
         List<String> topics = new ArrayList<>(PRE_EXISTING_TOPICS);
         if (includeDynamicTopic) {
             topics.add(DYNAMIC_TOPIC_NAME);
@@ -534,6 +560,7 @@ public class KafkaEnumeratorTest {
         return createEnumerator(
                 enumContext,
                 enablePeriodicPartitionDiscovery ? 1 : -1,
+                startingOffsetsInitializer,
                 topics,
                 Collections.emptySet(),
                 Collections.emptySet(),
@@ -544,7 +571,8 @@ public class KafkaEnumeratorTest {
     private KafkaSourceEnumerator createEnumerator(
             MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
             long partitionDiscoveryIntervalMs,
-            boolean includeDynamicTopic) {
+            boolean includeDynamicTopic,
+            OffsetsInitializer startingOffsetsInitializer) {
         List<String> topics = new ArrayList<>(PRE_EXISTING_TOPICS);
         if (includeDynamicTopic) {
             topics.add(DYNAMIC_TOPIC_NAME);
@@ -552,6 +580,7 @@ public class KafkaEnumeratorTest {
         return createEnumerator(
                 enumContext,
                 partitionDiscoveryIntervalMs,
+                startingOffsetsInitializer,
                 topics,
                 Collections.emptySet(),
                 Collections.emptySet(),
@@ -566,6 +595,7 @@ public class KafkaEnumeratorTest {
     private KafkaSourceEnumerator createEnumerator(
             MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
             long partitionDiscoveryIntervalMs,
+            OffsetsInitializer startingOffsetsInitializer,
             Collection<String> topicsToSubscribe,
             Set<TopicPartition> assignedPartitions,
             Set<TopicPartition> unassignedInitialPartitons,
@@ -578,7 +608,6 @@ public class KafkaEnumeratorTest {
         Pattern topicPattern = Pattern.compile(topicNameJoiner.toString());
         KafkaSubscriber subscriber = KafkaSubscriber.getTopicPatternSubscriber(topicPattern);
 
-        OffsetsInitializer startingOffsetsInitializer = OffsetsInitializer.earliest();
         OffsetsInitializer stoppingOffsetsInitializer = new NoStoppingOffsetsInitializer();
 
         Properties props =
@@ -672,6 +701,31 @@ public class KafkaEnumeratorTest {
                 (reader, topicPartitions) ->
                         allTopicPartitionsFromAssignment.addAll(topicPartitions));
         assertThat(actualTopicPartitions).isEqualTo(allTopicPartitionsFromAssignment);
+    }
+
+    /**
+     * get all assigned partition splits of topics.
+     *
+     * @param context
+     * @param topics
+     * @return
+     */
+    private List<KafkaPartitionSplit> getAllAssignSplits(
+            MockSplitEnumeratorContext<KafkaPartitionSplit> context, Set<String> topics) {
+
+        List<KafkaPartitionSplit> allSplits = new ArrayList<>();
+        List<SplitsAssignment<KafkaPartitionSplit>> splitsAssignmentSequence =
+                context.getSplitsAssignmentSequence();
+        for (SplitsAssignment<KafkaPartitionSplit> splitsAssignment : splitsAssignmentSequence) {
+            List<KafkaPartitionSplit> splitsOfOnceAssignment =
+                    splitsAssignment.assignment().values().stream()
+                            .flatMap(splits -> splits.stream())
+                            .filter(split -> topics.contains(split.getTopic()))
+                            .collect(Collectors.toList());
+            allSplits.addAll(splitsOfOnceAssignment);
+        }
+
+        return allSplits;
     }
 
     private Set<TopicPartition> asEnumState(Map<Integer, List<KafkaPartitionSplit>> assignments) {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
@@ -344,6 +344,8 @@ public class KafkaEnumeratorTest {
                                 ENABLE_PERIODIC_PARTITION_DISCOVERY ? 1 : -1,
                                 PRE_EXISTING_TOPICS,
                                 preexistingAssignments,
+                                Collections.emptySet(),
+                                true,
                                 new Properties())) {
             enumerator.start();
             runPeriodicPartitionDiscovery(context2);
@@ -373,6 +375,8 @@ public class KafkaEnumeratorTest {
                                 ENABLE_PERIODIC_PARTITION_DISCOVERY ? 1 : -1,
                                 PRE_EXISTING_TOPICS,
                                 Collections.emptySet(),
+                                Collections.emptySet(),
+                                false,
                                 properties)) {
             enumerator.start();
 
@@ -502,6 +506,8 @@ public class KafkaEnumeratorTest {
                 enablePeriodicPartitionDiscovery ? 1 : -1,
                 topics,
                 Collections.emptySet(),
+                Collections.emptySet(),
+                false,
                 new Properties());
     }
 
@@ -518,6 +524,8 @@ public class KafkaEnumeratorTest {
                 partitionDiscoveryIntervalMs,
                 topics,
                 Collections.emptySet(),
+                Collections.emptySet(),
+                false,
                 new Properties());
     }
 
@@ -530,6 +538,8 @@ public class KafkaEnumeratorTest {
             long partitionDiscoveryIntervalMs,
             Collection<String> topicsToSubscribe,
             Set<TopicPartition> assignedPartitions,
+            Set<TopicPartition> unassignedInitialPartitons,
+            boolean initialDiscoveryFinished,
             Properties overrideProperties) {
         // Use a TopicPatternSubscriber so that no exception if a subscribed topic hasn't been
         // created yet.
@@ -555,7 +565,9 @@ public class KafkaEnumeratorTest {
                 props,
                 enumContext,
                 Boundedness.CONTINUOUS_UNBOUNDED,
-                assignedPartitions);
+                assignedPartitions,
+                unassignedInitialPartitons,
+                initialDiscoveryFinished);
     }
 
     // ---------------------


### PR DESCRIPTION
# EARLIEST offset strategy for partitions discoveried later based on FLIP-288

### What is the purpose of the change

As described in [FLIP-288](https://cwiki.apache.org/confluence/display/FLINK/FLIP-288%3A+Enable+Dynamic+Partition+Discovery+by+Default+in+Kafka+Source), the strategy used for new partitions is the same as the initial offset strategy, which is not reasonable.

According to the semantics, if the startup strategy is latest, the consumed data should include all data from the moment of startup, which also includes all messages from new created partitions. However, the latest strategy currently maybe used for new partitions, leading to the loss of some data (thinking a new partition is created and might be discovered by Kafka source several minutes later, and the message produced into the partition within the gap might be dropped if we use for example "latest" as the initial offset strategy).if the data from all new partitions is not read, it does not meet the user's expectations.

Other ploblems see final Section of [FLIP-288](https://cwiki.apache.org/confluence/display/FLINK/FLIP-288%3A+Enable+Dynamic+Partition+Discovery+by+Default+in+Kafka+Source): `User specifies OffsetsInitializer for new partition` .

Therefore,  it’s better to provide an **EARLIEST** strategy for later discovered partitions.

### Brief change log

1. Expand `KafkaSourceEnumState` with `TopicPartitionWithAssignStatus` to distinguish between initial partitions and newly discovered partitions. `TopicPartitionWithAssignStatus` is also better for future expansion, as new statuses can be added without changing the state results.
2. Add a `newDiscoveryOffsetsInitializer`(EARLIEST) to get offsets for newly discovered partitions. 
3. Modify `kafkaSourceEnumStateSerializer` to handle the expanded `KafkaSourceEnumState`.

### Verifying this change
1. Test the backward compatibility of state when deserializing in `KafkaSourceEnumStateSerializerTest`.
2. Expand `KafkaEnumeratorTest#testSnapshotState` method to test snapshot state in more scenarios:
    1. Before first discovery, so the state should be empty
    2. First partition discovery after start, but no assignments to readers
    3. Assign partials partitions to readers
    4. Assign all partitions to readers
3. Expand `KafkaEnumeratorTest#testDiscoverPartitionsPeriodically` method to test whether new partitions use EARLIEST offset while initial partitions use specified offset strategy.
