### PR TITLE
[FLINK-32019][Connector/Kafka]  EARLIEST offset strategy for partitions discoveried later based on FLIP-288

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -196,7 +196,7 @@ public class KafkaSource<OUT>
                 props,
                 enumContext,
                 boundedness,
-                checkpoint.assignedPartitions());
+                checkpoint);
     }
 
     @Internal

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/AssignmentStatus.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/AssignmentStatus.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+
+/** status of partition assignment. */
+@Internal
+public enum AssignmentStatus {
+
+    /** Partitions that have been assigned to readers. */
+    ASSIGNED(0),
+    /**
+     * The partitions that have been discovered during initialization but not assigned to readers
+     * yet.
+     */
+    UNASSIGNED_INITIAL(1);
+    private final int statusCode;
+
+    AssignmentStatus(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public static AssignmentStatus ofStatusCode(int statusCode) {
+        for (AssignmentStatus statusEnum : AssignmentStatus.values()) {
+            if (statusEnum.getStatusCode() == statusCode) {
+                return statusEnum;
+            }
+        }
+        throw new IllegalArgumentException("statusCode is invalid.");
+    }
+}

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/TopicPartitionAndAssignmentStatus.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/TopicPartitionAndAssignmentStatus.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.kafka.common.TopicPartition;
+
+/** Kafka partition with assign status. */
+@Internal
+public class TopicPartitionAndAssignmentStatus {
+    private final TopicPartition topicPartition;
+    private final AssignmentStatus assignmentStatus;
+
+    public TopicPartitionAndAssignmentStatus(
+            TopicPartition topicPartition, AssignmentStatus assignStatus) {
+        this.topicPartition = topicPartition;
+        this.assignmentStatus = assignStatus;
+    }
+
+    public TopicPartition topicPartition() {
+        return topicPartition;
+    }
+
+    public AssignmentStatus assignmentStatus() {
+        return assignmentStatus;
+    }
+}


### PR DESCRIPTION
### What is the purpose of the change

As described in [[FLIP-288](https://cwiki.apache.org/confluence/display/FLINK/FLIP-288%3A+Enable+Dynamic+Partition+Discovery+by+Default+in+Kafka+Source)](https://cwiki.apache.org/confluence/display/FLINK/FLIP-288%3A+Enable+Dynamic+Partition+Discovery+by+Default+in+Kafka+Source), the strategy used for new partitions is the same as the initial offset strategy, which is not reasonable.

According to the semantics, if the startup strategy is latest, the consumed data should include all data from the moment of startup, which also includes all messages from new created partitions. However, the latest strategy currently maybe used for new partitions, leading to the loss of some data (thinking a new partition is created and might be discovered by Kafka source several minutes later, and the message produced into the partition within the gap might be dropped if we use for example "latest" as the initial offset strategy).if the data from all new partitions is not read, it does not meet the user's expectations.

Other ploblems see final Section: `User specifies OffsetsInitializer for new partition` .

Therefore,  it’s better to provide an **EARLIEST** strategy for later discovered partitions.

### Brief change log

1. Expand `KafkaSourceEnumState` with `TopicPartitionWithAssignStatus` to distinguish between initial partitions and newly discovered partitions. `TopicPartitionWithAssignStatus` is also better for future expansion, as new statuses can be added without changing the state results.
2. Add a `newDiscoveryOffsetsInitializer`(EARLIEST) to get offsets for newly discovered partitions. 
3. Modify `kafkaSourceEnumStateSerializer` to handle the expanded `KafkaSourceEnumState`.

### Verifying this change

1. Test the backward compatibility of state when deserializing in `KafkaSourceEnumStateSerializerTest`.
2. Expand `KafkaEnumeratorTest#testSnapshotState` method to test snapshot state in more scenarios:
    1. Before first discovery, so the state should be empty
    2. First partition discovery after start, but no assignments to readers
    3. Assign partials partitions to readers
    4. Assign all partitions to readers
3. Expand `KafkaEnumeratorTest#testDiscoverPartitionsPeriodically` method to test whether new partitions use EARLIEST offset while initial partitions use specified offset strategy.