### PR TITLE
[FLINK-32021][Connectors/Kafka] Improvement the Javadoc for SpecifiedOffsetsInitializer and TimestampOffsetsInitializer

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializer.java
@@ -38,6 +38,11 @@ import static org.apache.flink.util.Preconditions.checkState;
  * An implementation of {@link OffsetsInitializer} which initializes the offsets of the partition
  * according to the user specified offsets.
  *
+ * <p>Use specified offsets for specified partitions while use commit offsets or offsetResetStrategy
+ * for unspecified partitions. Specified partition's offset should be less than its latest offset,
+ * otherwise it will start from the offsetResetStrategy. The default value of offsetResetStrategy is
+ * earliest.
+ *
  * <p>Package private and should be instantiated via {@link OffsetsInitializer}.
  */
 class SpecifiedOffsetsInitializer implements OffsetsInitializer, OffsetsInitializerValidator {

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/TimestampOffsetsInitializer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/TimestampOffsetsInitializer.java
@@ -28,6 +28,8 @@ import java.util.Map;
 
 /**
  * An implementation of {@link OffsetsInitializer} to initialize the offsets based on a timestamp.
+ * If the message meeting the requirement of the timestamp have not been produced to Kafka yet, just
+ * use the latest offset.
  *
  * <p>Package private and should be instantiated via {@link OffsetsInitializer}.
  */


### PR DESCRIPTION
### What is the purpose of the change

As described in [[FLIP-288](https://cwiki.apache.org/confluence/display/FLINK/FLIP-288%3A+Enable+Dynamic+Partition+Discovery+by+Default+in+Kafka+Source)](https://cwiki.apache.org/confluence/display/FLINK/FLIP-288%3A+Enable+Dynamic+Partition+Discovery+by+Default+in+Kafka+Source), Current JavaDoc does not fully explain the behavior of OffsetsInitializers. When the partition does not meet the condition, there will be a different offset strategy. 

This may lead to misunderstandings in the design and usage.

### Brief change log

Add to SpecifiedOffsetsInitializer: "Use Specified offset for specified partitions while use commit offset or Earliest for unspecified partitions. Specified partition offset should be less than the latest offset, otherwise it will start from the earliest."

Add to TimestampOffsetsInitializer:Initialize the offsets based on a timestamp. If the message meeting the requirement of the timestamp have not been produced to Kafka yet, just use the latest offset.

### Verifying this change

no code changes.