### PR TITLE
[FLINK-32289][docs] Fix incorrect metadata column type in examples

### DIFF
--- a/docs/content.zh/docs/connectors/table/kafka.md
+++ b/docs/content.zh/docs/connectors/table/kafka.md
@@ -48,7 +48,7 @@ CREATE TABLE KafkaTable (
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp'
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'
 ) WITH (
   'connector' = 'kafka',
   'topic' = 'user_behavior',
@@ -127,7 +127,7 @@ CREATE TABLE KafkaTable (
 
 ```sql
 CREATE TABLE KafkaTable (
-  `event_time` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `event_time` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `partition` BIGINT METADATA VIRTUAL,
   `offset` BIGINT METADATA VIRTUAL,
   `user_id` BIGINT,
@@ -151,7 +151,7 @@ CREATE TABLE KafkaTable (
 
 ```sql
 CREATE TABLE KafkaTable (
-  `event_time` TIMESTAMP(3) METADATA FROM 'value.source.timestamp' VIRTUAL,  -- from Debezium format
+  `event_time` TIMESTAMP_LTZ(3) METADATA FROM 'value.source.timestamp' VIRTUAL,  -- from Debezium format
   `origin_table` STRING METADATA FROM 'value.source.table' VIRTUAL, -- from Debezium format
   `partition_id` BIGINT METADATA FROM 'partition' VIRTUAL,  -- from Kafka connector
   `offset` BIGINT METADATA VIRTUAL,  -- from Kafka connector
@@ -389,7 +389,7 @@ Kafka 消息的消息键和消息体部分都可以使用某种 [格式]({{< ref
 
 ```sql
 CREATE TABLE KafkaTable (
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING
@@ -415,7 +415,7 @@ ROW<`user_id` BIGINT, `item_id` BIGINT, `behavior` STRING>
 
 ```sql
 CREATE TABLE KafkaTable (
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING
@@ -579,7 +579,7 @@ CREATE TABLE KafkaTable (
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp'
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'
 ) WITH (
   'connector' = 'kafka',
   ...
@@ -594,7 +594,7 @@ CREATE TABLE KafkaTable (
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp'
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'
 ) WITH (
   'connector' = 'kafka',
   ...

--- a/docs/content.zh/docs/connectors/table/upsert-kafka.md
+++ b/docs/content.zh/docs/connectors/table/upsert-kafka.md
@@ -221,7 +221,7 @@ prefixed with either the `'key'` or `'value'` plus format identifier.
 
 ```sql
 CREATE TABLE KafkaTable (
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,

--- a/docs/content/docs/connectors/table/kafka.md
+++ b/docs/content/docs/connectors/table/kafka.md
@@ -50,7 +50,7 @@ CREATE TABLE KafkaTable (
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp'
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'
 ) WITH (
   'connector' = 'kafka',
   'topic' = 'user_behavior',
@@ -129,7 +129,7 @@ The extended `CREATE TABLE` example demonstrates the syntax for exposing these m
 
 ```sql
 CREATE TABLE KafkaTable (
-  `event_time` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `event_time` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `partition` BIGINT METADATA VIRTUAL,
   `offset` BIGINT METADATA VIRTUAL,
   `user_id` BIGINT,
@@ -154,7 +154,7 @@ The following example shows how to access both Kafka and Debezium metadata field
 
 ```sql
 CREATE TABLE KafkaTable (
-  `event_time` TIMESTAMP(3) METADATA FROM 'value.source.timestamp' VIRTUAL,  -- from Debezium format
+  `event_time` TIMESTAMP_LTZ(3) METADATA FROM 'value.source.timestamp' VIRTUAL,  -- from Debezium format
   `origin_table` STRING METADATA FROM 'value.source.table' VIRTUAL, -- from Debezium format
   `partition_id` BIGINT METADATA FROM 'partition' VIRTUAL,  -- from Kafka connector
   `offset` BIGINT METADATA VIRTUAL,  -- from Kafka connector
@@ -435,7 +435,7 @@ options are prefixed with the format identifier.
 
 ```sql
 CREATE TABLE KafkaTable (
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING
@@ -461,7 +461,7 @@ prefixed with either the `'key'` or `'value'` plus format identifier.
 
 ```sql
 CREATE TABLE KafkaTable (
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING
@@ -635,7 +635,7 @@ CREATE TABLE KafkaTable (
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp'
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'
 ) WITH (
   'connector' = 'kafka',
   ...
@@ -650,7 +650,7 @@ CREATE TABLE KafkaTable (
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp'
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp'
 ) WITH (
   'connector' = 'kafka',
   ...

--- a/docs/content/docs/connectors/table/upsert-kafka.md
+++ b/docs/content/docs/connectors/table/upsert-kafka.md
@@ -240,7 +240,7 @@ prefixed with either the `'key'` or `'value'` plus format identifier.
 {{< tab "SQL" >}}
 ```sql
 CREATE TABLE KafkaTable (
-  `ts` TIMESTAMP(3) METADATA FROM 'timestamp',
+  `ts` TIMESTAMP_LTZ(3) METADATA FROM 'timestamp',
   `user_id` BIGINT,
   `item_id` BIGINT,
   `behavior` STRING,


### PR DESCRIPTION
This PR fixes incorrect metadata column type in Kafka connector examples.

## Brief change log

Changed timestamp metadata column type from TIMESTAMP to TIMESTAMP_LTZ (with local timezone) in [Kafka SQL connector examples](https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/connectors/table/kafka/#how-to-create-a-kafka-table) in both English and Chinese docs.