### PR TITLE
[FLINK-32450] Update Kafka CI setup to latest version for PRs and nightly builds

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -23,6 +23,9 @@ concurrency:
   cancel-in-progress: true
 jobs:
   compile_and_test:
+    strategy:
+      matrix:
+        flink: [1.17.1, 1.18-SNAPSHOT]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
-      flink_version: 1.17.0
+      flink_version: ${{ matrix.flink }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -26,8 +26,21 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [1.17-SNAPSHOT, 1.18-SNAPSHOT]
+        flink_branches: [{
+          flink: 1.17.1,
+          branch: main
+        }, {
+          flink: 1.18-SNAPSHOT,
+          branch: main
+        }, {
+          flink: 1.17.1,
+          branch: v3.0
+        }, {
+          flink: 1.18-SNAPSHOT,
+          branch: v3.0
+        }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
-      flink_version: ${{ matrix.flink }}
+      flink_version: ${{ matrix.flink_branches.flink }}
+      connector_branch: ${{ matrix.flink_branches.branch }}
       run_dependency_convergence: false


### PR DESCRIPTION
1. PRs for `main` will be tested against Flink 1.17.1 and 1.18-SNAPSHOT, assuming this should be compatible for both

2a. Nightlies for `main` will be tested against Flink 1.17-SNAPSHOT and Flink 1.18-SNAPSHOT
2b. Nightlies for `v3.0` will be tested against 1.17.1 only