### PR TITLE
[FLINK-32020] Enable Dynamic Partition Discovery by Default in Kafka Source based on FLIP-288

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceOptions.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
+import java.time.Duration;
 import java.util.Properties;
 import java.util.function.Function;
 
@@ -38,10 +39,11 @@ public class KafkaSourceOptions {
     public static final ConfigOption<Long> PARTITION_DISCOVERY_INTERVAL_MS =
             ConfigOptions.key("partition.discovery.interval.ms")
                     .longType()
-                    .noDefaultValue()
+                    .defaultValue(Duration.ofMinutes(5).toMillis())
                     .withDescription(
                             "The interval in milliseconds for the Kafka source to discover "
-                                    + "the new partitions. A non-positive value disables the partition discovery.");
+                                    + "the new partitions. A non-positive value disables the partition discovery."
+                                    + "The default value is 5 minutes, which is equal to the default value of metadata.max.age.ms in Kafka.");
 
     public static final ConfigOption<Boolean> REGISTER_KAFKA_CONSUMER_METRICS =
             ConfigOptions.key("register.consumer.metrics")

--- a/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptions.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptions.java
@@ -188,9 +188,11 @@ public class KafkaConnectorOptions {
     public static final ConfigOption<Duration> SCAN_TOPIC_PARTITION_DISCOVERY =
             ConfigOptions.key("scan.topic-partition-discovery.interval")
                     .durationType()
-                    .noDefaultValue()
+                    .defaultValue(Duration.ofMinutes(5))
                     .withDescription(
-                            "Optional interval for consumer to discover dynamically created Kafka partitions periodically.");
+                            "Optional interval for consumer to discover dynamically created Kafka partitions periodically."
+                                    + "The value 0 disables the partition discovery."
+                                    + "The default value is 5 minutes, which is equal to the default value of metadata.max.age.ms in Kafka.");
 
     // --------------------------------------------------------------------------------------------
     // Sink specific options

--- a/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
@@ -201,11 +201,11 @@ public class KafkaDynamicTableFactory
         final Properties properties = getKafkaProperties(context.getCatalogTable().getOptions());
 
         // add topic-partition discovery
-        final Optional<Long> partitionDiscoveryInterval =
-                tableOptions.getOptional(SCAN_TOPIC_PARTITION_DISCOVERY).map(Duration::toMillis);
+        final Duration partitionDiscoveryInterval =
+                tableOptions.get(SCAN_TOPIC_PARTITION_DISCOVERY);
         properties.setProperty(
                 KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(),
-                partitionDiscoveryInterval.orElse(-1L).toString());
+                Long.toString(partitionDiscoveryInterval.toMillis()));
 
         final DataType physicalDataType = context.getPhysicalRowDataType();
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
@@ -519,6 +519,26 @@ public class KafkaEnumeratorTest {
                 .isEqualTo(KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.defaultValue());
     }
 
+    @Test
+    public void testDisablePartitionDiscovery() {
+        Properties props = new Properties();
+        props.setProperty(
+                KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(), String.valueOf(0));
+        KafkaSourceEnumerator enumerator =
+                new KafkaSourceEnumerator(
+                        KafkaSubscriber.getTopicListSubscriber(Arrays.asList(TOPIC1, TOPIC2)),
+                        OffsetsInitializer.earliest(),
+                        new NoStoppingOffsetsInitializer(),
+                        props,
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS),
+                        Boundedness.CONTINUOUS_UNBOUNDED,
+                        new KafkaSourceEnumState(
+                                Collections.emptySet(), Collections.emptySet(), false));
+        long partitionDiscoveryIntervalMs =
+                (long) Whitebox.getInternalState(enumerator, "partitionDiscoveryIntervalMs");
+        assertThat(partitionDiscoveryIntervalMs).isEqualTo(0);
+    }
+
     // -------------- some common startup sequence ---------------
 
     private void startEnumeratorAndRegisterReaders(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
@@ -501,6 +501,24 @@ public class KafkaEnumeratorTest {
         }
     }
 
+    @Test
+    public void testEnablePartitionDiscoveryByDefault() {
+        KafkaSourceEnumerator enumerator =
+                new KafkaSourceEnumerator(
+                        KafkaSubscriber.getTopicListSubscriber(Arrays.asList(TOPIC1, TOPIC2)),
+                        OffsetsInitializer.earliest(),
+                        new NoStoppingOffsetsInitializer(),
+                        new Properties(),
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS),
+                        Boundedness.CONTINUOUS_UNBOUNDED,
+                        new KafkaSourceEnumState(
+                                Collections.emptySet(), Collections.emptySet(), false));
+        long partitionDiscoveryIntervalMs =
+                (long) Whitebox.getInternalState(enumerator, "partitionDiscoveryIntervalMs");
+        assertThat(partitionDiscoveryIntervalMs)
+                .isEqualTo(KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.defaultValue());
+    }
+
     // -------------- some common startup sequence ---------------
 
     private void startEnumeratorAndRegisterReaders(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -1132,6 +1132,45 @@ public class KafkaDynamicTableFactoryTest {
                 actualSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
         assertKafkaSource(provider);
     }
+
+    @Test
+    public void testDisableDiscoverPartition() {
+        Map<String, String> tableSourceOptions =
+                getModifiedOptions(
+                        getBasicSourceOptions(),
+                        options -> options.put("scan.topic-partition-discovery.interval", "0"));
+        final KafkaDynamicSource actualSource =
+                (KafkaDynamicSource) createTableSource(SCHEMA, tableSourceOptions);
+        Properties props = new Properties();
+        props.putAll(KAFKA_SOURCE_PROPERTIES);
+        // Disable discovery if the partition discovery interval is 0 minutes
+        props.setProperty("partition.discovery.interval.ms", "0");
+        final Map<KafkaTopicPartition, Long> specificOffsets = new HashMap<>();
+        specificOffsets.put(new KafkaTopicPartition(TOPIC, PARTITION_0), OFFSET_0);
+        specificOffsets.put(new KafkaTopicPartition(TOPIC, PARTITION_1), OFFSET_1);
+        final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
+                new DecodingFormatMock(",", true);
+        // Test scan source equals
+        final KafkaDynamicSource expectedKafkaSource =
+                createExpectedScanSource(
+                        SCHEMA_DATA_TYPE,
+                        null,
+                        valueDecodingFormat,
+                        new int[0],
+                        new int[] {0, 1, 2},
+                        null,
+                        Collections.singletonList(TOPIC),
+                        null,
+                        props,
+                        StartupMode.SPECIFIC_OFFSETS,
+                        specificOffsets,
+                        0);
+        assertThat(actualSource).isEqualTo(expectedKafkaSource);
+        ScanTableSource.ScanRuntimeProvider provider =
+                actualSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
+        assertKafkaSource(provider);
+    }
+
     // --------------------------------------------------------------------------------------------
     // Utilities
     // --------------------------------------------------------------------------------------------

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -1095,6 +1095,43 @@ public class KafkaDynamicTableFactoryTest {
                                 + " guarantee the semantic of primary key.");
     }
 
+    @Test
+    public void testDiscoverPartitionByDefault() {
+        Map<String, String> tableSourceOptions =
+                getModifiedOptions(
+                        getBasicSourceOptions(),
+                        options -> options.remove("scan.topic-partition-discovery.interval"));
+        final KafkaDynamicSource actualSource =
+                (KafkaDynamicSource) createTableSource(SCHEMA, tableSourceOptions);
+        Properties props = new Properties();
+        props.putAll(KAFKA_SOURCE_PROPERTIES);
+        // The default partition discovery interval is 5 minutes
+        props.setProperty("partition.discovery.interval.ms", "300000");
+        final Map<KafkaTopicPartition, Long> specificOffsets = new HashMap<>();
+        specificOffsets.put(new KafkaTopicPartition(TOPIC, PARTITION_0), OFFSET_0);
+        specificOffsets.put(new KafkaTopicPartition(TOPIC, PARTITION_1), OFFSET_1);
+        final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
+                new DecodingFormatMock(",", true);
+        // Test scan source equals
+        final KafkaDynamicSource expectedKafkaSource =
+                createExpectedScanSource(
+                        SCHEMA_DATA_TYPE,
+                        null,
+                        valueDecodingFormat,
+                        new int[0],
+                        new int[] {0, 1, 2},
+                        null,
+                        Collections.singletonList(TOPIC),
+                        null,
+                        props,
+                        StartupMode.SPECIFIC_OFFSETS,
+                        specificOffsets,
+                        0);
+        assertThat(actualSource).isEqualTo(expectedKafkaSource);
+        ScanTableSource.ScanRuntimeProvider provider =
+                actualSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
+        assertKafkaSource(provider);
+    }
     // --------------------------------------------------------------------------------------------
     // Utilities
     // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
### What is the purpose of the change
As described in [FLIP-288](https://cwiki.apache.org/confluence/display/FLINK/FLIP-288%3A+Enable+Dynamic+Partition+Discovery+by+Default+in+Kafka+Source),  dynamic partition discovery is disabled by default, and users have to specify the interval of discovery in order to turn it on. It will be better if enable partition discovery by default.



### Brief change log
- Kafka table source: "scan.topic-partition-discovery.interval" will be set to 5 minutes by default, aligned with the default value of ["metadata.max.age.ms" in Kafka consumer.](https://kafka.apache.org/documentation/#consumerconfigs_metadata.max.age.ms)
- Kafka stream source: "partition.discovery.interval.ms"  will be set to 5 minutes by default, with discovery interval set to 5 minutes.


### Verifying this change
- See test unit.
-  Start flink with kafka source connector by default, then add kafka partition after a period of time to see if the new partition can be read.