### PR TITLE
[FLINK-32591][Connectors/Kafka] Update document of Kafka Source: Enab…

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/kafka.md
@@ -229,7 +229,7 @@ Kafka consumer 的配置可以参考 [Apache Kafka 文档](http://kafka.apache.o
 
 ### 动态分区检查
 为了在不重启 Flink 作业的情况下处理 Topic 扩容或新建 Topic 等场景，可以将 Kafka Source 配置为在提供的 Topic / Partition 
-订阅模式下定期检查新分区。要启用动态分区检查，请将 ```partition.discovery.interval.ms``` 设置为非负值：
+订阅模式下定期检查新分区。要启用动态分区检查，请将 ```partition.discovery.interval.ms``` 设置为正值：
 
 
 {{< tabs "KafkaSource#PartitionDiscovery" >}}
@@ -248,7 +248,7 @@ KafkaSource.builder() \
 {{< /tabs >}}
 
 {{< hint warning >}}
-分区检查功能默认**不开启**。需要显式地设置分区检查间隔才能启用此功能。
+分区检查间隔默认为5分钟。需要显式地设置分区检查间隔为非正数才能关闭此功能。
 {{< /hint >}}
 
 ### 事件时间和水印

--- a/docs/content.zh/docs/connectors/table/kafka.md
+++ b/docs/content.zh/docs/connectors/table/kafka.md
@@ -338,9 +338,9 @@ CREATE TABLE KafkaTable (
     <tr>
       <td><h5>scan.topic-partition-discovery.interval</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">（无）</td>
+      <td style="word-wrap: break-word;">5分钟</td>
       <td>Duration</td>
-      <td>Consumer 定期探测动态创建的 Kafka topic 和 partition 的时间间隔。</td>
+      <td>Consumer 定期探测动态创建的 Kafka topic 和 partition 的时间间隔。需要显式地设置'scan.topic-partition-discovery.interval'为0才能关闭此功能</td>
     </tr>
     <tr>
       <td><h5>sink.partitioner</h5></td>

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -264,7 +264,7 @@ KafkaSource.builder() \
 {{< /tabs >}}
 
 {{< hint warning >}}
-The partition discovery interval is 5 minutes by default.To **disable** this feature, you need to explicitly set the partition discovery interval to a non-positive value.
+The partition discovery interval is 5 minutes by default. To **disable** this feature, you need to explicitly set the partition discovery interval to a non-positive value.
 {{< /hint >}}
 
 ### Event Time and Watermarks

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -245,7 +245,7 @@ it is configured:
 ### Dynamic Partition Discovery
 In order to handle scenarios like topic scaling-out or topic creation without restarting the Flink
 job, Kafka source can be configured to periodically discover new partitions under provided 
-topic-partition subscribing pattern. To enable partition discovery, set a non-negative value for 
+topic-partition subscribing pattern. To enable partition discovery, set a positive value for 
 property ```partition.discovery.interval.ms```:
 
 {{< tabs "KafkaSource#PartitionDiscovery" >}}
@@ -264,8 +264,7 @@ KafkaSource.builder() \
 {{< /tabs >}}
 
 {{< hint warning >}}
-Partition discovery is **disabled** by default. You need to explicitly set the partition discovery
-interval to enable this feature.
+The partition discovery interval is 5 minutes by default.To **disable** this feature, you need to explicitly set the partition discovery interval to a non-positive value.
 {{< /hint >}}
 
 ### Event Time and Watermarks

--- a/docs/content/docs/connectors/table/kafka.md
+++ b/docs/content/docs/connectors/table/kafka.md
@@ -366,7 +366,7 @@ Connector Options
       <td>yes</td>
       <td style="word-wrap: break-word;">5 minutes</td>
       <td>Duration</td>
-      <td>Interval for consumer to discover dynamically created Kafka topics and partitions periodically.To disable this feature, you need to explicitly set the 'scan.topic-partition-discovery.interval' value to 0.</td>
+      <td>Interval for consumer to discover dynamically created Kafka topics and partitions periodically. To disable this feature, you need to explicitly set the 'scan.topic-partition-discovery.interval' value to 0.</td>
     </tr>
     <tr>
       <td><h5>sink.partitioner</h5></td>

--- a/docs/content/docs/connectors/table/kafka.md
+++ b/docs/content/docs/connectors/table/kafka.md
@@ -364,9 +364,9 @@ Connector Options
       <td><h5>scan.topic-partition-discovery.interval</h5></td>
       <td>optional</td>
       <td>yes</td>
-      <td style="word-wrap: break-word;">(none)</td>
+      <td style="word-wrap: break-word;">5 minutes</td>
       <td>Duration</td>
-      <td>Interval for consumer to discover dynamically created Kafka topics and partitions periodically.</td>
+      <td>Interval for consumer to discover dynamically created Kafka topics and partitions periodically.To disable this feature, you need to explicitly set the 'scan.topic-partition-discovery.interval' value to 0.</td>
     </tr>
     <tr>
       <td><h5>sink.partitioner</h5></td>


### PR DESCRIPTION
### What is the purpose of the change
Based on Flip 288,  dynamic partition discovery is enabled by Default in Kafka Source  now. some corresponding document in Chinese and English should be modified:



### Brief change log
update 4 documents:
- content/docs/datastream/kafka.md
- content/docs/table/kafka.md
- content.zh/docs/datastream/kafka.md
- content.zh/docs/table/kafka.md


### Verifying this change
Just modify documents.