### PR TITLE
[FLINK-33017] Remove dependency on shaded guava

### DIFF
--- a/flink-connector-kafka-e2e-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
+++ b/flink-connector-kafka-e2e-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
@@ -29,8 +29,6 @@ import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.JobSubmission;
 import org.apache.flink.util.TestLoggerExtension;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
-
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -56,6 +54,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -136,12 +135,10 @@ class SmokeKafkaITCase {
 
         // create the required topics
         final short replicationFactor = 1;
-        admin.createTopics(
-                        Lists.newArrayList(
-                                new NewTopic(inputTopic, 1, replicationFactor),
-                                new NewTopic(outputTopic, 1, replicationFactor)))
-                .all()
-                .get();
+        List<NewTopic> topics = new ArrayList<>(2);
+        topics.add(new NewTopic(inputTopic, 1, replicationFactor));
+        topics.add(new NewTopic(outputTopic, 1, replicationFactor));
+        admin.createTopics(topics).all().get();
 
         producer.send(new ProducerRecord<>(inputTopic, 1));
         producer.send(new ProducerRecord<>(inputTopic, 2));

--- a/flink-connector-kafka-e2e-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
+++ b/flink-connector-kafka-e2e-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
@@ -54,7 +54,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -135,10 +135,12 @@ class SmokeKafkaITCase {
 
         // create the required topics
         final short replicationFactor = 1;
-        List<NewTopic> topics = new ArrayList<>(2);
-        topics.add(new NewTopic(inputTopic, 1, replicationFactor));
-        topics.add(new NewTopic(outputTopic, 1, replicationFactor));
-        admin.createTopics(topics).all().get();
+        admin.createTopics(
+                        Arrays.asList(
+                                new NewTopic(inputTopic, 1, replicationFactor),
+                                new NewTopic(outputTopic, 1, replicationFactor)))
+                .all()
+                .get();
 
         producer.send(new ProducerRecord<>(inputTopic, 1));
         producer.send(new ProducerRecord<>(inputTopic, 2));

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
@@ -243,7 +243,8 @@ class KafkaWriter<IN>
         LOG.debug("Closing writer with {}", currentProducer);
         closeAll(this::abortCurrentProducer, producerPool::clear);
         closeAll(producerCloseables);
-        checkState(currentProducer.isClosed());
+        checkState(
+                currentProducer.isClosed(), "Could not close current producer " + currentProducer);
         currentProducer = null;
 
         // Rethrow exception for the case in which close is called before writer() and flush().

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
@@ -31,10 +31,6 @@ import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.streaming.connectors.kafka.internals.metrics.KafkaMetricMutableWrapper;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
-import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
-import org.apache.flink.shaded.guava30.com.google.common.io.Closer;
-
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -49,14 +45,17 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.apache.flink.util.IOUtils.closeAll;
@@ -104,8 +103,9 @@ class KafkaWriter<IN>
     // producer pool only used for exactly once
     private final Deque<FlinkKafkaInternalProducer<byte[], byte[]>> producerPool =
             new ArrayDeque<>();
-    private final Closer closer = Closer.create();
     private long lastCheckpointId;
+
+    private final Set<AutoCloseable> closeables = new HashSet<>();
 
     private boolean closed = false;
     private long lastSync = System.currentTimeMillis();
@@ -178,7 +178,7 @@ class KafkaWriter<IN>
         } else if (deliveryGuarantee == DeliveryGuarantee.AT_LEAST_ONCE
                 || deliveryGuarantee == DeliveryGuarantee.NONE) {
             this.currentProducer = new FlinkKafkaInternalProducer<>(this.kafkaProducerConfig, null);
-            closer.register(this.currentProducer);
+            closeables.add(this.currentProducer);
             initKafkaMetrics(this.currentProducer);
         } else {
             throw new UnsupportedOperationException(
@@ -236,7 +236,7 @@ class KafkaWriter<IN>
             currentProducer = getTransactionalProducer(checkpointId + 1);
             currentProducer.beginTransaction();
         }
-        return ImmutableList.of(kafkaWriterState);
+        return Collections.singletonList(kafkaWriterState);
     }
 
     @Override
@@ -245,12 +245,12 @@ class KafkaWriter<IN>
         LOG.debug("Closing writer with {}", currentProducer);
         closeAll(
                 this::abortCurrentProducer,
-                closer,
                 producerPool::clear,
                 () -> {
                     checkState(currentProducer.isClosed());
                     currentProducer = null;
                 });
+        closeAll(closeables);
 
         // Rethrow exception for the case in which close is called before writer() and flush().
         checkAsyncException();
@@ -279,7 +279,8 @@ class KafkaWriter<IN>
 
     void abortLingeringTransactions(
             Collection<KafkaWriterState> recoveredStates, long startCheckpointId) {
-        List<String> prefixesToAbort = Lists.newArrayList(transactionalIdPrefix);
+        List<String> prefixesToAbort = new ArrayList<>();
+        prefixesToAbort.add(transactionalIdPrefix);
 
         final Optional<KafkaWriterState> lastStateOpt = recoveredStates.stream().findFirst();
         if (lastStateOpt.isPresent()) {
@@ -337,7 +338,7 @@ class KafkaWriter<IN>
         FlinkKafkaInternalProducer<byte[], byte[]> producer = producerPool.poll();
         if (producer == null) {
             producer = new FlinkKafkaInternalProducer<>(kafkaProducerConfig, transactionalId);
-            closer.register(producer);
+            closeables.add(producer);
             producer.initTransactions();
             initKafkaMetrics(producer);
         } else {
@@ -452,12 +453,9 @@ class KafkaWriter<IN>
                     asyncProducerException = decorateException(metadata, exception, producer);
                 }
 
+                // Checking for exceptions from previous writes
                 mailboxExecutor.submit(
-                        () -> {
-                            // Checking for exceptions from previous writes
-                            checkAsyncException();
-                        },
-                        "Update error metric");
+                        KafkaWriter.this::checkAsyncException, "Update error metric");
             }
 
             if (metadataConsumer != null) {

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
@@ -455,7 +455,11 @@ class KafkaWriter<IN>
 
                 // Checking for exceptions from previous writes
                 mailboxExecutor.submit(
-                        KafkaWriter.this::checkAsyncException, "Update error metric");
+                        () -> {
+                            // Checking for exceptions from previous writes
+                            checkAsyncException();
+                        },
+                        "Update error metric");
             }
 
             if (metadataConsumer != null) {

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
@@ -251,7 +251,6 @@ class KafkaWriter<IN>
                     currentProducer = null;
                 });
         closeAll(closeables);
-
         // Rethrow exception for the case in which close is called before writer() and flush().
         checkAsyncException();
     }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -52,8 +52,6 @@ import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TemporaryClassLoaderContext;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
@@ -1200,8 +1198,10 @@ public class FlinkKafkaProducer<IN>
         if (semantic != FlinkKafkaProducer.Semantic.EXACTLY_ONCE) {
             nextTransactionalIdHint = null;
         } else {
-            ArrayList<FlinkKafkaProducer.NextTransactionalIdHint> transactionalIdHints =
-                    Lists.newArrayList(nextTransactionalIdHintState.get());
+            List<FlinkKafkaProducer.NextTransactionalIdHint> transactionalIdHints =
+                    new ArrayList<>();
+            nextTransactionalIdHintState.get().forEach(transactionalIdHints::add);
+
             if (transactionalIdHints.size() > 1) {
                 throw new IllegalStateException(
                         "There should be at most one next transactional id hint written by the first subtask");
@@ -1444,8 +1444,9 @@ public class FlinkKafkaProducer<IN>
                 context.getOperatorStateStore()
                         .getUnionListState(NEXT_TRANSACTIONAL_ID_HINT_DESCRIPTOR_V2);
 
-        ArrayList<NextTransactionalIdHint> oldTransactionalIdHints =
-                Lists.newArrayList(oldNextTransactionalIdHintState.get());
+        List<NextTransactionalIdHint> oldTransactionalIdHints = new ArrayList<>();
+        oldNextTransactionalIdHintState.get().forEach(oldTransactionalIdHints::add);
+
         if (!oldTransactionalIdHints.isEmpty()) {
             nextTransactionalIdHintState.addAll(oldTransactionalIdHints);
             // clear old state

--- a/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/FlinkKafkaInternalProducer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/FlinkKafkaInternalProducer.java
@@ -22,8 +22,6 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.flink.shaded.guava30.com.google.common.base.Joiner;
-
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
@@ -51,10 +49,12 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 /** Internal flink kafka producer. */
 @PublicEvolving
@@ -169,7 +169,9 @@ public class FlinkKafkaInternalProducer<K, V> implements Producer<K, V> {
                 LOG.debug(
                         "Closed internal KafkaProducer {}. Stacktrace: {}",
                         System.identityHashCode(this),
-                        Joiner.on("\n").join(Thread.currentThread().getStackTrace()));
+                        Arrays.stream(Thread.currentThread().getStackTrace())
+                                .map(StackTraceElement::toString)
+                                .collect(Collectors.joining("\n")));
             }
             closed = true;
         }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducerITCase.java
@@ -41,7 +41,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Duration;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.function.Consumer;
@@ -172,10 +172,9 @@ class FlinkKafkaInternalProducerITCase {
     }
 
     private static List<Consumer<FlinkKafkaInternalProducer<?, ?>>> provideTransactionsFinalizer() {
-        List<Consumer<FlinkKafkaInternalProducer<?, ?>>> ret = new ArrayList<>();
-        ret.add(FlinkKafkaInternalProducer::commitTransaction);
-        ret.add(FlinkKafkaInternalProducer::abortTransaction);
-        return ret;
+        return Arrays.asList(
+                FlinkKafkaInternalProducer::commitTransaction,
+                FlinkKafkaInternalProducer::abortTransaction);
     }
 
     private void assertNumTransactions(int numTransactions, String transactionIdPrefix) {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducerITCase.java
@@ -19,8 +19,6 @@ package org.apache.flink.connector.kafka.sink;
 
 import org.apache.flink.util.TestLoggerExtension;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
-
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -43,6 +41,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.function.Consumer;
@@ -173,9 +172,10 @@ class FlinkKafkaInternalProducerITCase {
     }
 
     private static List<Consumer<FlinkKafkaInternalProducer<?, ?>>> provideTransactionsFinalizer() {
-        return Lists.newArrayList(
-                FlinkKafkaInternalProducer::commitTransaction,
-                FlinkKafkaInternalProducer::abortTransaction);
+        List<Consumer<FlinkKafkaInternalProducer<?, ?>>> ret = new ArrayList<>();
+        ret.add(FlinkKafkaInternalProducer::commitTransaction);
+        ret.add(FlinkKafkaInternalProducer::abortTransaction);
+        return ret;
     }
 
     private void assertNumTransactions(int numTransactions, String transactionIdPrefix) {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
@@ -35,7 +35,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -284,18 +284,12 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
                             KafkaRecordSerializationSchemaBuilder<String>,
                             KafkaRecordSerializationSchemaBuilder<String>>>
             valueSerializationSetter() {
-        List<
-                        Function<
-                                KafkaRecordSerializationSchemaBuilder<String>,
-                                KafkaRecordSerializationSchemaBuilder<String>>>
-                ret = new ArrayList<>();
-        ret.add(b -> b.setKafkaValueSerializer(StringSerializer.class));
-        ret.add(b -> b.setValueSerializationSchema(new SimpleStringSchema()));
-        ret.add(
-                b ->
+        return Arrays.asList(
+                (b) -> b.setKafkaValueSerializer(StringSerializer.class),
+                (b) -> b.setValueSerializationSchema(new SimpleStringSchema()),
+                (b) ->
                         b.setKafkaValueSerializer(
                                 ConfigurableStringSerializer.class, Collections.emptyMap()));
-        return ret;
     }
 
     private static List<
@@ -303,19 +297,12 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
                             KafkaRecordSerializationSchemaBuilder<String>,
                             KafkaRecordSerializationSchemaBuilder<String>>>
             keySerializationSetter() {
-        List<
-                        Function<
-                                KafkaRecordSerializationSchemaBuilder<String>,
-                                KafkaRecordSerializationSchemaBuilder<String>>>
-                ret = new ArrayList<>();
-
-        ret.add(b -> b.setKafkaKeySerializer(StringSerializer.class));
-        ret.add(b -> b.setKeySerializationSchema(new SimpleStringSchema()));
-        ret.add(
-                b ->
+        return Arrays.asList(
+                (b) -> b.setKafkaKeySerializer(StringSerializer.class),
+                (b) -> b.setKeySerializationSchema(new SimpleStringSchema()),
+                (b) ->
                         b.setKafkaKeySerializer(
                                 ConfigurableStringSerializer.class, Collections.emptyMap()));
-        return ret;
     }
 
     /**

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
@@ -60,8 +60,6 @@ import org.apache.flink.testutils.junit.SharedReference;
 import org.apache.flink.util.DockerImageVersions;
 import org.apache.flink.util.TestLogger;
 
-import org.apache.flink.shaded.guava30.com.google.common.base.Joiner;
-
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
@@ -88,6 +86,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -624,7 +623,11 @@ public class KafkaSinkITCase extends TestLogger {
     }
 
     private String format(Map.Entry<Thread, StackTraceElement[]> leak) {
-        return leak.getKey().getName() + ":\n" + Joiner.on("\n").join(leak.getValue());
+        String stackTrace =
+                Arrays.stream(leak.getValue())
+                        .map(StackTraceElement::toString)
+                        .collect(Collectors.joining("\n"));
+        return leak.getKey().getName() + ":\n" + stackTrace;
     }
 
     private boolean findAliveKafkaThread(Map.Entry<Thread, StackTraceElement[]> threadStackTrace) {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
@@ -34,8 +34,6 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.UserCodeClassLoader;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
-
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -60,6 +58,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -545,7 +544,7 @@ public class KafkaWriterITCase {
                 new SinkInitContext(sinkWriterMetricGroup, timeService, metadataConsumer),
                 new DummyRecordSerializer(),
                 new DummySchemaContext(),
-                ImmutableList.of());
+                Collections.emptyList());
     }
 
     private KafkaWriter<Integer> createWriterWithConfiguration(
@@ -557,7 +556,7 @@ public class KafkaWriterITCase {
                 sinkInitContext,
                 new DummyRecordSerializer(),
                 new DummySchemaContext(),
-                ImmutableList.of());
+                Collections.emptyList());
     }
 
     private static Properties getKafkaClientConfiguration() {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializationSchemaTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializationSchemaTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.streaming.util.serialization.JSONKeyValueDeserialization
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.jackson.JacksonMapperFactory;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
@@ -38,6 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -116,7 +116,7 @@ public class KafkaRecordDeserializationSchemaTest {
 
     @Test
     public void testKafkaValueDeserializerWrapperWithoutConfigurable() throws Exception {
-        final Map<String, String> config = ImmutableMap.of("simpleKey", "simpleValue");
+        final Map<String, String> config = Collections.singletonMap("simpleKey", "simpleValue");
         KafkaRecordDeserializationSchema<String> schema =
                 KafkaRecordDeserializationSchema.valueOnly(SimpleStringSerializer.class, config);
         schema.open(new TestingDeserializationContext());
@@ -127,7 +127,7 @@ public class KafkaRecordDeserializationSchemaTest {
 
     @Test
     public void testKafkaValueDeserializerWrapperWithConfigurable() throws Exception {
-        final Map<String, String> config = ImmutableMap.of("configKey", "configValue");
+        final Map<String, String> config = Collections.singletonMap("configKey", "configValue");
         KafkaRecordDeserializationSchema<String> schema =
                 KafkaRecordDeserializationSchema.valueOnly(
                         ConfigurableStringSerializer.class, config);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import java.util.Iterator;
 import org.apache.flink.streaming.connectors.kafka.internals.FlinkKafkaInternalProducer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -239,9 +240,11 @@ public class FlinkKafkaInternalProducerITCase extends KafkaTestBase {
                 records = kafkaConsumer.poll(Duration.ofMillis(10000));
             }
 
-            ConsumerRecord<String, String> record = records.iterator().next();
+            final Iterator<ConsumerRecord<String, String>> it = records.iterator();
+            ConsumerRecord<String, String> record = it.next();
             assertThat(record.key()).isEqualTo(expectedKey);
             assertThat(record.value()).isEqualTo(expectedValue);
+            assertThat(it.hasNext()).isFalse();
         }
     }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import java.util.Iterator;
 import org.apache.flink.streaming.connectors.kafka.internals.FlinkKafkaInternalProducer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -34,6 +33,7 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Properties;
 import java.util.UUID;
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
@@ -20,8 +20,6 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.streaming.connectors.kafka.internals.FlinkKafkaInternalProducer;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
-
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -241,7 +239,7 @@ public class FlinkKafkaInternalProducerITCase extends KafkaTestBase {
                 records = kafkaConsumer.poll(Duration.ofMillis(10000));
             }
 
-            ConsumerRecord<String, String> record = Iterables.getOnlyElement(records);
+            ConsumerRecord<String, String> record = records.iterator().next();
             assertThat(record.key()).isEqualTo(expectedKey);
             assertThat(record.value()).isEqualTo(expectedValue);
         }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -80,8 +80,6 @@ import org.apache.flink.testutils.junit.RetryOnException;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.ExceptionUtils;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
-
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
@@ -258,7 +256,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         } while (System.nanoTime() < deadline);
 
         // cancel the job & wait for the job to finish
-        client.cancel(Iterables.getOnlyElement(getRunningJobs(client))).get();
+        client.cancel(getRunningJobs(client).iterator().next()).get();
         runner.join();
 
         final Throwable t = errorRef.get();
@@ -349,7 +347,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         } while (System.nanoTime() < deadline);
 
         // cancel the job & wait for the job to finish
-        client.cancel(Iterables.getOnlyElement(getRunningJobs(client))).get();
+        client.cancel(getRunningJobs(client).iterator().next()).get();
         runner.join();
 
         final Throwable t = errorRef.get();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import java.util.Iterator;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
@@ -103,6 +102,7 @@ import java.util.BitSet;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import java.util.Iterator;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
@@ -256,7 +257,10 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         } while (System.nanoTime() < deadline);
 
         // cancel the job & wait for the job to finish
-        client.cancel(getRunningJobs(client).iterator().next()).get();
+        final Iterator<JobID> it = getRunningJobs(client).iterator();
+        final JobID jobId = it.next();
+        client.cancel(jobId).get();
+        assertThat(it.hasNext()).isFalse();
         runner.join();
 
         final Throwable t = errorRef.get();
@@ -347,7 +351,10 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         } while (System.nanoTime() < deadline);
 
         // cancel the job & wait for the job to finish
-        client.cancel(getRunningJobs(client).iterator().next()).get();
+        final Iterator<JobID> it = getRunningJobs(client).iterator();
+        final JobID jobId = it.next();
+        client.cancel(jobId).get();
+        assertThat(it.hasNext()).isFalse();
         runner.join();
 
         final Throwable t = errorRef.get();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleITCase.java
@@ -34,9 +34,6 @@ import org.apache.flink.streaming.connectors.kafka.internals.KafkaShuffleFetcher
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaShuffleFetcher.KafkaShuffleWatermark;
 import org.apache.flink.util.PropertiesUtil;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
-import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
-
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Rule;
 import org.junit.Test;
@@ -374,17 +371,16 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
 
         // Records in a single partition are kept in order
         Collection<ConsumerRecord<byte[], byte[]>> records =
-                Iterables.getOnlyElement(
-                        testKafkaShuffleProducer(
-                                        topic(
-                                                "test_serde-" + UUID.randomUUID(),
-                                                timeCharacteristic),
-                                        env,
-                                        1,
-                                        1,
-                                        numElementsPerProducer,
-                                        timeCharacteristic)
-                                .values());
+                testKafkaShuffleProducer(
+                                topic("test_serde-" + UUID.randomUUID(), timeCharacteristic),
+                                env,
+                                1,
+                                1,
+                                numElementsPerProducer,
+                                timeCharacteristic)
+                        .values()
+                        .iterator()
+                        .next();
 
         switch (timeCharacteristic) {
             case ProcessingTime:
@@ -516,7 +512,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
                         r -> {
                             final int partition = r.partition();
                             if (!results.containsKey(partition)) {
-                                results.put(partition, Lists.newArrayList());
+                                results.put(partition, new ArrayList<>());
                             }
                             results.get(partition).add(r);
                         });

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -74,8 +74,6 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.TestLoggerExtension;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
-
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.TopicPartition;
@@ -87,6 +85,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -618,7 +617,11 @@ public class KafkaDynamicTableFactoryTest {
 
     @Test
     public void testTableSinkSemanticTranslation() {
-        final List<String> semantics = ImmutableList.of("exactly-once", "at-least-once", "none");
+        final List<String> semantics = new ArrayList<>(3);
+        semantics.add("exactly-once");
+        semantics.add("at-least-once");
+        semantics.add("none");
+
         final EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat =
                 new EncodingFormatMock(",");
         for (final String semantic : semantics) {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -85,7 +85,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -617,11 +616,7 @@ public class KafkaDynamicTableFactoryTest {
 
     @Test
     public void testTableSinkSemanticTranslation() {
-        final List<String> semantics = new ArrayList<>(3);
-        semantics.add("exactly-once");
-        semantics.add("at-least-once");
-        semantics.add("none");
-
+        final List<String> semantics = Arrays.asList("exactly-once", "at-least-once", "none");
         final EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat =
                 new EncodingFormatMock(",");
         for (final String semantic : semantics) {

--- a/pom.xml
+++ b/pom.xml
@@ -82,12 +82,6 @@ under the License.
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-shaded-guava</artifactId>
-            <version>30.1.1-jre-16.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
             <artifactId>flink-shaded-jackson</artifactId>
             <version>2.13.4-16.1</version>
         </dependency>


### PR DESCRIPTION
## Description

The bump in shaded guava in Flink 1.18 changed import paths and caused the class loader fail when loading ManagedMemoryUtils.

Looking at the root cause of the issue, shading was used as a technique to avoid dependency hell. As flink-connector-kafka should work with both flink 1.17 and 1.18 that use different guava versions (and hence library import paths), shading did not really solve the problem it was introduced for in the first place.

There are several several options to work around the problem. First, we could introduce our own shading for guava. Second, we could see if the dependency on guava is necessary at all and maybe remove it completely.

This patch takes the latter route and removes dependency on guava from this connector.

## Testing strategy

Ran locally 

```
mvn clean install \
  -U -B --no-transfer-progress -Dflink.version=1.18-SNAPSHOT \
  -Dscala-2.12 \
  -Prun-end-to-end-tests -DdistDir=/Users/asorokoumov/projects/flink-connector-kafka/flink-1.18-SNAPSHOT
```

and no longer observed `Could not initialize class org.apache.flink.runtime.util.config.memory.ManagedMemoryUtils` in the logs.