### PR TITLE
[FLINK-28303] Support LatestOffsetsInitializer to avoid latest-offset strategy lose data

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/LatestOffsetsInitializer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/LatestOffsetsInitializer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.initializer;
+
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * An implementation of {@link OffsetsInitializer} to initialize the offsets based on a latest-offset.
+ *
+ * <p>Package private and should be instantiated via {@link OffsetsInitializer}.
+ */
+class LatestOffsetsInitializer implements OffsetsInitializer {
+    private static final long serialVersionUID = 3014700244733286989L;
+
+    @Override
+    public Map<TopicPartition, Long> getPartitionOffsets(
+            Collection<TopicPartition> partitions,
+            PartitionOffsetsRetriever partitionOffsetsRetriever) {
+        return partitionOffsetsRetriever.endOffsets(partitions);
+    }
+
+    @Override
+    public OffsetResetStrategy getAutoOffsetResetStrategy() {
+        return OffsetResetStrategy.LATEST;
+    }
+}

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/LatestOffsetsInitializer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/LatestOffsetsInitializer.java
@@ -25,7 +25,8 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * An implementation of {@link OffsetsInitializer} to initialize the offsets based on a latest-offset.
+ * An implementation of {@link OffsetsInitializer} to initialize the offsets based on a
+ * latest-offset.
  *
  * <p>Package private and should be instantiated via {@link OffsetsInitializer}.
  */

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializer.java
@@ -155,8 +155,7 @@ public interface OffsetsInitializer extends Serializable {
      * @return an {@link OffsetsInitializer} which initializes the offsets to the latest offsets.
      */
     static OffsetsInitializer latest() {
-        return new ReaderHandledOffsetsInitializer(
-                KafkaPartitionSplit.LATEST_OFFSET, OffsetResetStrategy.LATEST);
+        return new LatestOffsetsInitializer();
     }
 
     /**

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
@@ -45,8 +45,8 @@ class ReaderHandledOffsetsInitializer implements OffsetsInitializer, OffsetsInit
 
     /**
      * The only valid value for startingOffset is following. {@link
-     * KafkaPartitionSplit#EARLIEST_OFFSET EARLIEST_OFFSET}, {@link KafkaPartitionSplit#COMMITTED_OFFSET
-     * COMMITTED_OFFSET}
+     * KafkaPartitionSplit#EARLIEST_OFFSET EARLIEST_OFFSET}, {@link
+     * KafkaPartitionSplit#COMMITTED_OFFSET COMMITTED_OFFSET}
      */
     ReaderHandledOffsetsInitializer(long startingOffset, OffsetResetStrategy offsetResetStrategy) {
         this.startingOffset = startingOffset;

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
@@ -45,8 +45,7 @@ class ReaderHandledOffsetsInitializer implements OffsetsInitializer, OffsetsInit
 
     /**
      * The only valid value for startingOffset is following. {@link
-     * KafkaPartitionSplit#EARLIEST_OFFSET EARLIEST_OFFSET}, {@link
-     * KafkaPartitionSplit#LATEST_OFFSET LATEST_OFFSET}, {@link KafkaPartitionSplit#COMMITTED_OFFSET
+     * KafkaPartitionSplit#EARLIEST_OFFSET EARLIEST_OFFSET}, {@link KafkaPartitionSplit#COMMITTED_OFFSET
      * COMMITTED_OFFSET}
      */
     ReaderHandledOffsetsInitializer(long startingOffset, OffsetResetStrategy offsetResetStrategy) {

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
@@ -32,7 +32,7 @@ import java.util.Properties;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
- * A initializer that initialize the partitions to the earliest / latest / last-committed offsets.
+ * A initializer that initialize the partitions to the earliest / last-committed offsets.
  * The offsets initialization are taken care of by the {@code KafkaPartitionSplitReader} instead of
  * by the {@code KafkaSourceEnumerator}.
  *

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/ReaderHandledOffsetsInitializer.java
@@ -32,9 +32,9 @@ import java.util.Properties;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
- * A initializer that initialize the partitions to the earliest / last-committed offsets.
- * The offsets initialization are taken care of by the {@code KafkaPartitionSplitReader} instead of
- * by the {@code KafkaSourceEnumerator}.
+ * A initializer that initialize the partitions to the earliest / last-committed offsets. The
+ * offsets initialization are taken care of by the {@code KafkaPartitionSplitReader} instead of by
+ * the {@code KafkaSourceEnumerator}.
  *
  * <p>Package private and should be instantiated via {@link OffsetsInitializer}.
  */

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -201,8 +201,7 @@ public class KafkaPartitionSplitReader
 
         // Seek on the newly assigned partitions to their stating offsets.
         seekToStartingOffsets(
-                partitionsStartingFromEarliest,
-                partitionsStartingFromSpecifiedOffsets);
+                partitionsStartingFromEarliest, partitionsStartingFromSpecifiedOffsets);
         // Setup the stopping offsets.
         acquireAndSetStoppingOffsets(partitionsStoppingAtCommitted);
 
@@ -268,8 +267,7 @@ public class KafkaPartitionSplitReader
     }
 
     private void parseStoppingOffsets(
-            KafkaPartitionSplit split,
-            Set<TopicPartition> partitionsStoppingAtCommitted) {
+            KafkaPartitionSplit split, Set<TopicPartition> partitionsStoppingAtCommitted) {
         TopicPartition tp = split.getTopicPartition();
         split.getStoppingOffset()
                 .ifPresent(
@@ -305,8 +303,7 @@ public class KafkaPartitionSplitReader
         }
     }
 
-    private void acquireAndSetStoppingOffsets(
-            Set<TopicPartition> partitionsStoppingAtCommitted) {
+    private void acquireAndSetStoppingOffsets(Set<TopicPartition> partitionsStoppingAtCommitted) {
         if (!partitionsStoppingAtCommitted.isEmpty()) {
             retryOnWakeup(
                             () -> consumer.committed(partitionsStoppingAtCommitted),

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
@@ -34,6 +34,9 @@ import java.util.Set;
 @Internal
 public class KafkaPartitionSplit implements SourceSplit {
     public static final long NO_STOPPING_OFFSET = Long.MIN_VALUE;
+    // Indicating the split should consume from the latest.
+    // @deprecated Only be used for compatibility with the history state, see FLINK-28303
+    @Deprecated public static final long LATEST_OFFSET = -1;
     // Indicating the split should consume from the earliest.
     public static final long EARLIEST_OFFSET = -2;
     // Indicating the split should consume from the last committed offset.
@@ -77,7 +80,9 @@ public class KafkaPartitionSplit implements SourceSplit {
     }
 
     public Optional<Long> getStoppingOffset() {
-        return stoppingOffset >= 0 || stoppingOffset == COMMITTED_OFFSET
+        return stoppingOffset >= 0
+                        || stoppingOffset == LATEST_OFFSET
+                        || stoppingOffset == COMMITTED_OFFSET
                 ? Optional.of(stoppingOffset)
                 : Optional.empty();
     }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
@@ -77,8 +77,7 @@ public class KafkaPartitionSplit implements SourceSplit {
     }
 
     public Optional<Long> getStoppingOffset() {
-        return stoppingOffset >= 0
-                        || stoppingOffset == COMMITTED_OFFSET
+        return stoppingOffset >= 0 || stoppingOffset == COMMITTED_OFFSET
                 ? Optional.of(stoppingOffset)
                 : Optional.empty();
     }
@@ -139,10 +138,7 @@ public class KafkaPartitionSplit implements SourceSplit {
                             "Illegal stopping offset %d is specified for partition %s. "
                                     + "It should either be non-negative or be one of the "
                                     + "[%d(committed), %d(Long.MIN_VALUE, no_stopping_offset)].",
-                            stoppingOffset,
-                            tp,
-                            COMMITTED_OFFSET,
-                            NO_STOPPING_OFFSET));
+                            stoppingOffset, tp, COMMITTED_OFFSET, NO_STOPPING_OFFSET));
         }
     }
 }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
@@ -34,8 +34,6 @@ import java.util.Set;
 @Internal
 public class KafkaPartitionSplit implements SourceSplit {
     public static final long NO_STOPPING_OFFSET = Long.MIN_VALUE;
-    // Indicating the split should consume from the latest.
-    public static final long LATEST_OFFSET = -1;
     // Indicating the split should consume from the earliest.
     public static final long EARLIEST_OFFSET = -2;
     // Indicating the split should consume from the last committed offset.
@@ -43,9 +41,9 @@ public class KafkaPartitionSplit implements SourceSplit {
 
     // Valid special starting offsets
     public static final Set<Long> VALID_STARTING_OFFSET_MARKERS =
-            new HashSet<>(Arrays.asList(EARLIEST_OFFSET, LATEST_OFFSET, COMMITTED_OFFSET));
+            new HashSet<>(Arrays.asList(EARLIEST_OFFSET, COMMITTED_OFFSET));
     public static final Set<Long> VALID_STOPPING_OFFSET_MARKERS =
-            new HashSet<>(Arrays.asList(LATEST_OFFSET, COMMITTED_OFFSET, NO_STOPPING_OFFSET));
+            new HashSet<>(Arrays.asList(COMMITTED_OFFSET, NO_STOPPING_OFFSET));
 
     private final TopicPartition tp;
     private final long startingOffset;
@@ -80,7 +78,6 @@ public class KafkaPartitionSplit implements SourceSplit {
 
     public Optional<Long> getStoppingOffset() {
         return stoppingOffset >= 0
-                        || stoppingOffset == LATEST_OFFSET
                         || stoppingOffset == COMMITTED_OFFSET
                 ? Optional.of(stoppingOffset)
                 : Optional.empty();
@@ -132,8 +129,8 @@ public class KafkaPartitionSplit implements SourceSplit {
                     String.format(
                             "Invalid starting offset %d is specified for partition %s. "
                                     + "It should either be non-negative or be one of the "
-                                    + "[%d(earliest), %d(latest), %d(committed)].",
-                            startingOffset, tp, LATEST_OFFSET, EARLIEST_OFFSET, COMMITTED_OFFSET));
+                                    + "[%d(earliest), %d(committed)].",
+                            startingOffset, tp, EARLIEST_OFFSET, COMMITTED_OFFSET));
         }
 
         if (stoppingOffset < 0 && !VALID_STOPPING_OFFSET_MARKERS.contains(stoppingOffset)) {
@@ -141,10 +138,9 @@ public class KafkaPartitionSplit implements SourceSplit {
                     String.format(
                             "Illegal stopping offset %d is specified for partition %s. "
                                     + "It should either be non-negative or be one of the "
-                                    + "[%d(latest), %d(committed), %d(Long.MIN_VALUE, no_stopping_offset)].",
+                                    + "[%d(committed), %d(Long.MIN_VALUE, no_stopping_offset)].",
                             stoppingOffset,
                             tp,
-                            LATEST_OFFSET,
                             COMMITTED_OFFSET,
                             NO_STOPPING_OFFSET));
         }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
@@ -44,9 +44,9 @@ public class KafkaPartitionSplit implements SourceSplit {
 
     // Valid special starting offsets
     public static final Set<Long> VALID_STARTING_OFFSET_MARKERS =
-            new HashSet<>(Arrays.asList(EARLIEST_OFFSET, COMMITTED_OFFSET));
+            new HashSet<>(Arrays.asList(EARLIEST_OFFSET, LATEST_OFFSET, COMMITTED_OFFSET));
     public static final Set<Long> VALID_STOPPING_OFFSET_MARKERS =
-            new HashSet<>(Arrays.asList(COMMITTED_OFFSET, NO_STOPPING_OFFSET));
+            new HashSet<>(Arrays.asList(LATEST_OFFSET, COMMITTED_OFFSET, NO_STOPPING_OFFSET));
 
     private final TopicPartition tp;
     private final long startingOffset;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
@@ -300,7 +300,7 @@ public class KafkaEnumeratorTest {
                     getAllAssignSplits(context, PRE_EXISTING_TOPICS);
             assertThat(initialPartitionAssign)
                     .extracting(KafkaPartitionSplit::getStartingOffset)
-                    .containsOnly(KafkaPartitionSplit.LATEST_OFFSET);
+                    .containsOnly((long) KafkaSourceTestEnv.NUM_RECORDS_PER_PARTITION);
             List<KafkaPartitionSplit> newPartitionAssign =
                     getAllAssignSplits(context, Collections.singleton(DYNAMIC_TOPIC_NAME));
             assertThat(newPartitionAssign)

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
@@ -84,7 +84,7 @@ public class OffsetsInitializerTest {
         assertThat(offsets).hasSameSizeAs(partitions);
         assertThat(offsets.keySet()).containsAll(partitions);
         for (long offset : offsets.values()) {
-            assertThat(offset).isEqualTo(KafkaPartitionSplit.LATEST_OFFSET);
+            assertThat(offset).isEqualTo((long) KafkaSourceTestEnv.NUM_RECORDS_PER_PARTITION);
         }
         assertThat(initializer.getAutoOffsetResetStrategy()).isEqualTo(OffsetResetStrategy.LATEST);
     }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
@@ -84,7 +84,7 @@ public class OffsetsInitializerTest {
         assertThat(offsets).hasSameSizeAs(partitions);
         assertThat(offsets.keySet()).containsAll(partitions);
         for (long offset : offsets.values()) {
-            assertThat(offset).isEqualTo((long) KafkaSourceTestEnv.NUM_RECORDS_PER_PARTITION);
+            assertThat(offset).isEqualTo(KafkaSourceTestEnv.NUM_RECORDS_PER_PARTITION);
         }
         assertThat(initializer.getAutoOffsetResetStrategy()).isEqualTo(OffsetResetStrategy.LATEST);
     }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -245,8 +245,8 @@ public class KafkaPartitionSplitReaderTest {
         final KafkaPartitionSplit emptySplit =
                 new KafkaPartitionSplit(
                         new TopicPartition(TOPIC2, 0),
-                        KafkaPartitionSplit.LATEST_OFFSET,
-                        KafkaPartitionSplit.LATEST_OFFSET);
+                        KafkaSourceTestEnv.NUM_RECORDS_PER_PARTITION,
+                        KafkaSourceTestEnv.NUM_RECORDS_PER_PARTITION);
         final KafkaPartitionSplit emptySplitWithZeroStoppingOffset =
                 new KafkaPartitionSplit(new TopicPartition(TOPIC3, 0), 0, 0);
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
@@ -372,7 +372,9 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
         // Normal split with NUM_RECORDS_PER_SPLIT records
         final KafkaPartitionSplit normalSplit =
                 new KafkaPartitionSplit(
-                        new TopicPartition(TOPIC, 0), 0, KafkaPartitionSplit.LATEST_OFFSET);
+                        new TopicPartition(TOPIC, 0),
+                        0,
+                        KafkaSourceTestEnv.NUM_RECORDS_PER_PARTITION);
         // Empty split with no record
         final KafkaPartitionSplit emptySplit =
                 new KafkaPartitionSplit(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitSerializerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitSerializerTest.java
@@ -38,7 +38,6 @@ public class KafkaPartitionSplitSerializerTest {
         List<Long> stoppingOffsets =
                 Lists.newArrayList(
                         KafkaPartitionSplit.COMMITTED_OFFSET,
-                        KafkaPartitionSplit.LATEST_OFFSET,
                         offsetZero,
                         normalOffset);
         KafkaPartitionSplitSerializer splitSerializer = new KafkaPartitionSplitSerializer();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitSerializerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitSerializerTest.java
@@ -36,10 +36,7 @@ public class KafkaPartitionSplitSerializerTest {
         Long normalOffset = 1L;
         TopicPartition topicPartition = new TopicPartition(topic, 1);
         List<Long> stoppingOffsets =
-                Lists.newArrayList(
-                        KafkaPartitionSplit.COMMITTED_OFFSET,
-                        offsetZero,
-                        normalOffset);
+                Lists.newArrayList(KafkaPartitionSplit.COMMITTED_OFFSET, offsetZero, normalOffset);
         KafkaPartitionSplitSerializer splitSerializer = new KafkaPartitionSplitSerializer();
         for (Long stoppingOffset : stoppingOffsets) {
             KafkaPartitionSplit kafkaPartitionSplit =

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -477,13 +477,15 @@ public class KafkaDynamicTableFactoryTest {
                     OffsetsInitializer offsetsInitializer =
                             KafkaSourceTestUtils.getStoppingOffsetsInitializer(source);
                     TopicPartition partition = new TopicPartition(TOPIC, 0);
+                    long endOffsets = 123L;
                     Map<TopicPartition, Long> partitionOffsets =
                             offsetsInitializer.getPartitionOffsets(
                                     Collections.singletonList(partition),
-                                    MockPartitionOffsetsRetriever.noInteractions());
+                                    MockPartitionOffsetsRetriever.latest(
+                                            (tps) -> Collections.singletonMap(partition, endOffsets)));
                     assertThat(partitionOffsets)
                             .containsOnlyKeys(partition)
-                            .containsEntry(partition, KafkaPartitionSplit.LATEST_OFFSET);
+                            .containsEntry(partition, endOffsets);
                 });
     }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -482,7 +482,9 @@ public class KafkaDynamicTableFactoryTest {
                             offsetsInitializer.getPartitionOffsets(
                                     Collections.singletonList(partition),
                                     MockPartitionOffsetsRetriever.latest(
-                                            (tps) -> Collections.singletonMap(partition, endOffsets)));
+                                            (tps) ->
+                                                    Collections.singletonMap(
+                                                            partition, endOffsets)));
                     assertThat(partitionOffsets)
                             .containsOnlyKeys(partition)
                             .containsEntry(partition, endOffsets);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
@@ -18,12 +18,19 @@
 
 package org.apache.flink.streaming.connectors.kafka.table;
 
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.testutils.FlinkAssertions;
+import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.utils.EncodingUtils;
@@ -937,6 +944,132 @@ public class KafkaTableITCase extends KafkaTableTestBase {
 
         final List<String> expected = Arrays.asList("+I[0, 2]", "+I[1, 2]");
         KafkaTableTestUtils.waitingExpectedResults("MySink", expected, Duration.ofSeconds(5));
+
+        // ------------- cleanup -------------------
+
+        tableResult.getJobClient().ifPresent(JobClient::cancel);
+        deleteTestTopic(topic);
+    }
+
+    @Test
+    public void testLatestOffsetStrategyResume() throws Exception {
+        // we always use a different topic name for each parameterized topic,
+        // in order to make sure the topic can be created.
+        final String topic = "latest_offset_resume_topic_" + format + "_" + UUID.randomUUID();
+        createTestTopic(topic, 6, 1);
+
+        // ---------- Consume stream from Kafka -------------------
+
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
+
+        final String createTable =
+                String.format(
+                        "CREATE TABLE kafka (\n"
+                                + "  `partition_id` INT,\n"
+                                + "  `value` INT\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'kafka',\n"
+                                + "  'topic' = '%s',\n"
+                                + "  'properties.bootstrap.servers' = '%s',\n"
+                                + "  'properties.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'latest-offset',\n"
+                                + "  'sink.partitioner' = '%s',\n"
+                                + "  'format' = '%s'\n"
+                                + ")",
+                        topic, bootstraps, groupId, TestPartitioner.class.getName(), format);
+
+        tEnv.executeSql(createTable);
+
+        env.setParallelism(1);
+        String createSink =
+                "CREATE TABLE MySink(\n"
+                        + "  `id` INT,\n"
+                        + "  `value` INT\n"
+                        + ") WITH (\n"
+                        + "  'connector' = 'values'\n"
+                        + ")";
+        tEnv.executeSql(createSink);
+
+        String executeInsert = "INSERT INTO MySink SELECT `partition_id`, `value` FROM kafka";
+        TableResult tableResult = tEnv.executeSql(executeInsert);
+
+        // ---------- Produce data into Kafka's partition 0-2 -------------------
+
+        String initialValues = "INSERT INTO kafka VALUES (0, 0), (1, 0), (2, 0)";
+        tEnv.executeSql(initialValues).await();
+
+        final List<String> expected = Arrays.asList("+I[0, 0]", "+I[1, 0]", "+I[2, 0]");
+        KafkaTableTestUtils.waitingExpectedResults("MySink", expected, Duration.ofSeconds(5));
+
+        // ---------- Stop the consume job with savepoint  -------------------
+
+        String savepointBasePath = getTempDirPath(topic + "-savepoint");
+        assert tableResult.getJobClient().isPresent();
+        JobClient client = tableResult.getJobClient().get();
+        String savepointPath =
+                client.stopWithSavepoint(false, savepointBasePath, SavepointFormatType.DEFAULT)
+                        .get();
+
+        // ---------- Produce data into Kafka's partition 0-5 -------------------
+
+        String produceValuesBeforeResume =
+                "INSERT INTO kafka VALUES (0, 1), (1, 1), (2, 1), (3, 0), (4, 0), (5, 0)";
+        tEnv.executeSql(produceValuesBeforeResume).await();
+
+        // ---------- Resume the consume job from savepoint  -------------------
+
+        Configuration configuration = new Configuration();
+        configuration.set(SavepointConfigOptions.SAVEPOINT_PATH, savepointPath);
+        configuration.set(CoreOptions.DEFAULT_PARALLELISM, 1);
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+
+        tEnv.executeSql(createTable);
+        tEnv.executeSql(createSink);
+        tableResult = tEnv.executeSql(executeInsert);
+
+        final List<String> afterResumeExpected =
+                Arrays.asList(
+                        "+I[0, 0]",
+                        "+I[1, 0]",
+                        "+I[2, 0]",
+                        "+I[0, 1]",
+                        "+I[1, 1]",
+                        "+I[2, 1]",
+                        "+I[3, 0]",
+                        "+I[4, 0]",
+                        "+I[5, 0]");
+        KafkaTableTestUtils.waitingExpectedResults(
+                "MySink", afterResumeExpected, Duration.ofSeconds(5));
+
+        // ---------- Produce data into Kafka's partition 0-5 -------------------
+
+        String produceValuesAfterResume =
+                "INSERT INTO kafka VALUES (0, 2), (1, 2), (2, 2), (3, 1), (4, 1), (5, 1)";
+        this.tEnv.executeSql(produceValuesAfterResume).await();
+
+        final List<String> afterProduceExpected =
+                Arrays.asList(
+                        "+I[0, 0]",
+                        "+I[1, 0]",
+                        "+I[2, 0]",
+                        "+I[0, 1]",
+                        "+I[1, 1]",
+                        "+I[2, 1]",
+                        "+I[3, 0]",
+                        "+I[4, 0]",
+                        "+I[5, 0]",
+                        "+I[0, 2]",
+                        "+I[1, 2]",
+                        "+I[2, 2]",
+                        "+I[3, 1]",
+                        "+I[4, 1]",
+                        "+I[5, 1]");
+        KafkaTableTestUtils.waitingExpectedResults(
+                "MySink", afterProduceExpected, Duration.ofSeconds(5));
 
         // ------------- cleanup -------------------
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactoryTest.java
@@ -470,7 +470,9 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
                             offsetsInitializer.getPartitionOffsets(
                                     Collections.singletonList(partition),
                                     MockPartitionOffsetsRetriever.latest(
-                                            (tps) -> Collections.singletonMap(partition, endOffsets)));
+                                            (tps) ->
+                                                    Collections.singletonMap(
+                                                            partition, endOffsets)));
                     assertThat(partitionOffsets)
                             .containsOnlyKeys(partition)
                             .containsEntry(partition, endOffsets);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactoryTest.java
@@ -465,13 +465,15 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
                     OffsetsInitializer offsetsInitializer =
                             KafkaSourceTestUtils.getStoppingOffsetsInitializer(source);
                     TopicPartition partition = new TopicPartition(SOURCE_TOPIC, 0);
+                    long endOffsets = 123L;
                     Map<TopicPartition, Long> partitionOffsets =
                             offsetsInitializer.getPartitionOffsets(
                                     Collections.singletonList(partition),
-                                    MockPartitionOffsetsRetriever.noInteractions());
+                                    MockPartitionOffsetsRetriever.latest(
+                                            (tps) -> Collections.singletonMap(partition, endOffsets)));
                     assertThat(partitionOffsets)
                             .containsOnlyKeys(partition)
-                            .containsEntry(partition, KafkaPartitionSplit.LATEST_OFFSET);
+                            .containsEntry(partition, endOffsets);
                 });
     }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/MockPartitionOffsetsRetriever.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/MockPartitionOffsetsRetriever.java
@@ -68,6 +68,17 @@ public final class MockPartitionOffsetsRetriever
                 UNSUPPORTED_RETRIEVAL, endOffsets, UNSUPPORTED_RETRIEVAL, retriever);
     }
 
+    public static MockPartitionOffsetsRetriever latest(OffsetsRetriever endOffsets) {
+        return new MockPartitionOffsetsRetriever(
+                UNSUPPORTED_RETRIEVAL,
+                endOffsets,
+                UNSUPPORTED_RETRIEVAL,
+                partitions -> {
+                    throw new UnsupportedOperationException(
+                            "The method was not supposed to be called");
+                });
+    }
+
     private MockPartitionOffsetsRetriever(
             OffsetsRetriever committedOffsets,
             OffsetsRetriever endOffsets,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, enumerator would send the LATEST_OFFSET marker into reader, when no data is consumed the currentOffset will always equal to -1. This causes the saved currentOffset to be -1 at checkpoint/savepoint, meaning that data is lost between the time the task stops and the time it resumes.

For example:
Assume topic has 3 partitions, A/B/C
1. Start job with `latest-offsets` offsets initializer. A/B/C's `currentOffset` is -1, which means that it will call `seekToEnd` in `KafkaSourceReader`.
2. Write a record to partition A and B, C is empty. The `currentOffset` for three partitions is A=1, B=1, C=-1.
3. Stop the job with savepoint. It will save the `currentOffset` A=1, B=1, C=-1 into savepoint.
4. Write a record for each partition. All partitions get a new record. The `endOffset` for each partition is A=2, B=2, C=1 after written.
5. Restore the job from savepoint. After restore, partition A's and B's consume is ok, but because of the partition C's `currentOffset` is -1, it will call the `seekToEnd` API to restore consume, so data offset=1 lost.

## Brief change log

  - *Implement the LatestOffsetsInitializer for latest-offset strategy.*
  - *Remove KafkaPartitionSplit.LATEST_OFFSET and its dependency.*
  - *Modify the corresponding test case above.*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is already covered by existing tests, such as
  - *KafkaTableITCase#testLatestOffsetStrategyResume.*
  - *OffsetsInitializerTest#testLatestOffsetsInitializer.*
  - *KafkaDynamicTableFactoryTest#testBoundedLatestOffset.*
  - *UpsertKafkaDynamicTableFactoryTest#testBoundedLatestOffset.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No
