### PR TITLE
[FLINK-29398][connector/kafka] Provide rack ID to Kafka Source to take advantage of Rack Awareness

### DIFF
--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -468,24 +468,21 @@ For detailed explanations of security configurations, please refer to
 ## Kafka Rack Awareness
 
 Kafka rack awareness allows Flink to select and control the cloud region and availability zone that Kafka consumers read from, based on the Rack ID. This feature reduces network costs and latency since it allows consumers to connect to the closest Kafka brokers, possibly colocated in the same cloud region and availability zone.
+A client's rack is indicated using the `client.rack` config, and should correspond to a broker's `broker.rack` config.
+
+https://kafka.apache.org/documentation/#consumerconfigs_client.rack
 
 ### RackId
 
-setRackId is the variable where the desired or available availability zones get stored. If provided, the Supplier will be run when the consumer is set up on the Task Manager, and the consumer's client.rack configuration will be set to the value.
-
-https://kafka.apache.org/documentation/#consumerconfigs_client.rack
+setRackIdSupplier() is the Builder method allows us to determine the consumer's rack. If provided, the Supplier will be run when the consumer is set up on the Task Manager, and the consumer's `client.rack` configuration will be set to the value.
 
 One of the ways this can be implemented is by making setRackId equal to an environment variable within your taskManager, for instance:
 
 ```
-.setRackId(() -> System.getenv("TM_NODE_AZ"))
+.setRackIdSupplier(() -> System.getenv("TM_NODE_AZ"))
 ```
 
-The "TM_NODE_AZ" is the name of the environment variable in the TaskManager image that contains the available Network zones we want to use. 
-
-Another implementation option could be extracting the AZ directly from AWS CLI or API.
-
-Additional validation is added to ensure any input to the supplier gets properly configured by the consumer and ensures null values are handled properly.
+The "TM_NODE_AZ" is the name of the environment variable in the TaskManager container that contains the zone we want to use.
 
 ### Behind the Scene
 {{< hint info >}}

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -469,10 +469,9 @@ For detailed explanations of security configurations, please refer to
 
 Kafka Rack Awareness allows flink to select and control the cloud region and availability zone configured by the use of rackId, this feature could allow a significant cost reduction in the cloud provider bill and achieve a better networking performance when connecting to closer and more reliable networks.
 
-### Testing
+### Validation
 
-The test function validates if there a valid rack id supplied, valid rack IDs are:
-
+Additional validation are added to make sure any input to the supplier gets propertly configured by the comsumer and makes sure null values are handled propertly.
 
 ### Behind the Scene
 {{< hint info >}}

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -471,7 +471,21 @@ Kafka Rack Awareness allows flink to select and control the cloud region and ava
 
 ### Validation
 
-Additional validation are added to make sure any input to the supplier gets propertly configured by the comsumer and makes sure null values are handled propertly.
+Additional validation is added to ensure any input to the supplier gets properly configured by the consumer and ensures null values are handled properly.
+
+### RackId
+
+setRackId is the variable where the desired or available availability zones get stored, if this variable is empty Rack Awareness feature simply gets ignored and assigned the AZs that are available to taskmanagers.
+
+One of the ways this can be implemented is by making setRackId equal to an environment variable within your taskManager, for instance:
+
+```
+.setRackId(() -> System.getenv("TM_NODE_AZ"))
+```
+
+The "TM_NODE_AZ" is the name of the environment variable in the TaskManager image that contains the available Network zones we want to use. 
+
+Another option could be extracting the AZ directly from AWS CLI or API.
 
 ### Behind the Scene
 {{< hint info >}}

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -469,13 +469,11 @@ For detailed explanations of security configurations, please refer to
 
 Kafka Rack Awareness allows flink to select and control the cloud region and availability zone configured by the use of rackId, this feature could allow a significant cost reduction in the cloud provider bill and achieve a better networking performance when connecting to closer and more reliable networks.
 
-### Validation
-
-Additional validation is added to ensure any input to the supplier gets properly configured by the consumer and ensures null values are handled properly.
-
 ### RackId
 
-setRackId is the variable where the desired or available availability zones get stored, if this variable is empty Rack Awareness feature simply gets ignored and assigned the AZs that are available to taskmanagers.
+setRackId is the variable where the desired or available availability zones get stored. If provided, the Supplier will be run when the consumer is set up on the Task Manager, and the consumer's client.rack configuration will be set to the value.
+
+https://kafka.apache.org/documentation/#consumerconfigs_client.rack
 
 One of the ways this can be implemented is by making setRackId equal to an environment variable within your taskManager, for instance:
 
@@ -485,7 +483,9 @@ One of the ways this can be implemented is by making setRackId equal to an envir
 
 The "TM_NODE_AZ" is the name of the environment variable in the TaskManager image that contains the available Network zones we want to use. 
 
-Another option could be extracting the AZ directly from AWS CLI or API.
+Another implementation option could be extracting the AZ directly from AWS CLI or API.
+
+Additional validation is added to ensure any input to the supplier gets properly configured by the consumer and ensures null values are handled properly.
 
 ### Behind the Scene
 {{< hint info >}}

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -465,6 +465,15 @@ client dependencies in the job JAR, so you may need to rewrite it with the actua
 For detailed explanations of security configurations, please refer to
 <a href="https://kafka.apache.org/documentation/#security">the "Security" section in Apache Kafka documentation</a>.
 
+## Kafka Rack Awareness
+
+Kafka Rack Awareness allows flink to select and control the cloud region and availability zone configured by the use of rackId, this feature could allow a significant cost reduction in the cloud provider bill and achieve a better networking performance when connecting to closer and more reliable networks.
+
+### Testing
+
+The test function validates if there a valid rack id supplied, valid rack IDs are:
+
+
 ### Behind the Scene
 {{< hint info >}}
 If you are interested in how Kafka source works under the design of new data source API, you may

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -467,7 +467,7 @@ For detailed explanations of security configurations, please refer to
 
 ## Kafka Rack Awareness
 
-Kafka Rack Awareness allows flink to select and control the cloud region and availability zone configured by the use of rackId, this feature could allow a significant cost reduction in the cloud provider bill and achieve a better networking performance when connecting to closer and more reliable networks.
+Kafka rack awareness allows Flink to select and control the cloud region and availability zone that Kafka consumers read from, based on the Rack ID. This feature reduces network costs and latency since it allows consumers to connect to the closest Kafka brokers, possibly colocated in the same cloud region and availability zone.
 
 ### RackId
 

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -57,6 +57,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -167,7 +168,9 @@ public class KafkaSource<OUT>
                                 props,
                                 readerContext,
                                 kafkaSourceReaderMetrics,
-                                rackIdSupplier.get());
+                                Optional.ofNullable(rackIdSupplier)
+                                        .map(Supplier::get)
+                                        .orElse(null));
         KafkaRecordEmitter<OUT> recordEmitter = new KafkaRecordEmitter<>(deserializationSchema);
 
         return new KafkaSourceReader<>(

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -49,6 +49,7 @@ import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitSerializ
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.util.UserCodeClassLoader;
+import org.apache.flink.util.function.SerializableSupplier;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
@@ -99,7 +100,7 @@ public class KafkaSource<OUT>
     // The configurations.
     private final Properties props;
     // Client rackId callback
-    private final Supplier<String> rackIdSupplier;
+    private final SerializableSupplier<String> rackIdSupplier;
 
     KafkaSource(
             KafkaSubscriber subscriber,
@@ -108,7 +109,7 @@ public class KafkaSource<OUT>
             Boundedness boundedness,
             KafkaRecordDeserializationSchema<OUT> deserializationSchema,
             Properties props,
-            Supplier<String> rackIdSupplier) {
+            SerializableSupplier<String> rackIdSupplier) {
         this.subscriber = subscriber;
         this.startingOffsetsInitializer = startingOffsetsInitializer;
         this.stoppingOffsetsInitializer = stoppingOffsetsInitializer;
@@ -163,7 +164,10 @@ public class KafkaSource<OUT>
         Supplier<KafkaPartitionSplitReader> splitReaderSupplier =
                 () ->
                         new KafkaPartitionSplitReader(
-                                props, readerContext, kafkaSourceReaderMetrics, rackIdSupplier);
+                                props,
+                                readerContext,
+                                kafkaSourceReaderMetrics,
+                                rackIdSupplier.get());
         KafkaRecordEmitter<OUT> recordEmitter = new KafkaRecordEmitter<>(deserializationSchema);
 
         return new KafkaSourceReader<>(

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -98,6 +98,8 @@ public class KafkaSource<OUT>
     private final KafkaRecordDeserializationSchema<OUT> deserializationSchema;
     // The configurations.
     private final Properties props;
+    // Client rackId callback
+    private final Supplier<String> rackIdSupplier;
 
     KafkaSource(
             KafkaSubscriber subscriber,
@@ -105,13 +107,15 @@ public class KafkaSource<OUT>
             @Nullable OffsetsInitializer stoppingOffsetsInitializer,
             Boundedness boundedness,
             KafkaRecordDeserializationSchema<OUT> deserializationSchema,
-            Properties props) {
+            Properties props,
+            Supplier<String> rackIdSupplier) {
         this.subscriber = subscriber;
         this.startingOffsetsInitializer = startingOffsetsInitializer;
         this.stoppingOffsetsInitializer = stoppingOffsetsInitializer;
         this.boundedness = boundedness;
         this.deserializationSchema = deserializationSchema;
         this.props = props;
+        this.rackIdSupplier = rackIdSupplier;
     }
 
     /**
@@ -157,7 +161,8 @@ public class KafkaSource<OUT>
                 new KafkaSourceReaderMetrics(readerContext.metricGroup());
 
         Supplier<KafkaPartitionSplitReader> splitReaderSupplier =
-                () -> new KafkaPartitionSplitReader(props, readerContext, kafkaSourceReaderMetrics);
+                () -> new KafkaPartitionSplitReader(props, readerContext, kafkaSourceReaderMetrics,
+                        rackIdSupplier);
         KafkaRecordEmitter<OUT> recordEmitter = new KafkaRecordEmitter<>(deserializationSchema);
 
         return new KafkaSourceReader<>(

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -161,8 +161,9 @@ public class KafkaSource<OUT>
                 new KafkaSourceReaderMetrics(readerContext.metricGroup());
 
         Supplier<KafkaPartitionSplitReader> splitReaderSupplier =
-                () -> new KafkaPartitionSplitReader(props, readerContext, kafkaSourceReaderMetrics,
-                        rackIdSupplier);
+                () ->
+                        new KafkaPartitionSplitReader(
+                                props, readerContext, kafkaSourceReaderMetrics, rackIdSupplier);
         KafkaRecordEmitter<OUT> recordEmitter = new KafkaRecordEmitter<>(deserializationSchema);
 
         return new KafkaSourceReader<>(

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -26,6 +26,7 @@ import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsIni
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializerValidator;
 import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.util.function.SerializableSupplier;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
@@ -40,7 +41,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -103,7 +103,7 @@ public class KafkaSourceBuilder<OUT> {
     // The configurations.
     protected Properties props;
     // Client rackId supplier
-    private Supplier<String> rackIdSupplier;
+    private SerializableSupplier<String> rackIdSupplier;
 
     KafkaSourceBuilder() {
         this.subscriber = null;
@@ -366,7 +366,7 @@ public class KafkaSourceBuilder<OUT> {
      * @param rackIdCallback callback to provide Kafka consumer client.rack
      * @return this KafkaSourceBuilder
      */
-    public KafkaSourceBuilder<OUT> setRackIdSupplier(Supplier<String> rackIdCallback) {
+    public KafkaSourceBuilder<OUT> setRackIdSupplier(SerializableSupplier<String> rackIdCallback) {
         this.rackIdSupplier = rackIdCallback;
         return this;
     }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -366,7 +366,7 @@ public class KafkaSourceBuilder<OUT> {
      * @param rackIdCallback callback to provide Kafka consumer client.rack
      * @return this KafkaSourceBuilder
      */
-    public KafkaSourceBuilder<OUT> setRackId(Supplier<String> rackIdCallback) {
+    public KafkaSourceBuilder<OUT> setRackIdSupplier(Supplier<String> rackIdCallback) {
         this.rackIdSupplier = rackIdCallback;
         return this;
     }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -361,7 +361,7 @@ public class KafkaSourceBuilder<OUT> {
     }
 
     /**
-     * Set the clientRackId supplier to be passed down to the KafkaPartitionSplitReader
+     * Set the clientRackId supplier to be passed down to the KafkaPartitionSplitReader.
      *
      * @param rackIdCallback callback to provide Kafka consumer client.rack
      * @return this KafkaSourceBuilder

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -80,6 +81,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  *     .setTopics(Arrays.asList(TOPIC1, TOPIC2))
  *     .setDeserializer(KafkaRecordDeserializationSchema.valueOnly(StringDeserializer.class))
  *     .setUnbounded(OffsetsInitializer.latest())
+ *     .setRackId(() -> MY_RACK_ID)
  *     .build();
  * }</pre>
  *
@@ -100,6 +102,8 @@ public class KafkaSourceBuilder<OUT> {
     private KafkaRecordDeserializationSchema<OUT> deserializationSchema;
     // The configurations.
     protected Properties props;
+    // Client rackId supplier
+    private Supplier<String> rackIdSupplier;
 
     KafkaSourceBuilder() {
         this.subscriber = null;
@@ -108,6 +112,7 @@ public class KafkaSourceBuilder<OUT> {
         this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
         this.deserializationSchema = null;
         this.props = new Properties();
+        this.rackIdSupplier = null;
     }
 
     /**
@@ -356,6 +361,17 @@ public class KafkaSourceBuilder<OUT> {
     }
 
     /**
+     * Set the clientRackId supplier to be passed down to the KafkaPartitionSplitReader
+     *
+     * @param rackIdCallback callback to provide Kafka consumer client.rack
+     * @return this KafkaSourceBuilder
+     */
+    public KafkaSourceBuilder<OUT> setRackId(Supplier<String> rackIdCallback) {
+        this.rackIdSupplier = rackIdCallback;
+        return this;
+    }
+
+    /**
      * Set an arbitrary property for the KafkaSource and KafkaConsumer. The valid keys can be found
      * in {@link ConsumerConfig} and {@link KafkaSourceOptions}.
      *
@@ -422,7 +438,8 @@ public class KafkaSourceBuilder<OUT> {
                 stoppingOffsetsInitializer,
                 boundedness,
                 deserializationSchema,
-                props);
+                props,
+                rackIdSupplier);
     }
 
     // ------------- private helpers  --------------

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -265,6 +265,11 @@ public class KafkaPartitionSplitReader
 
     // --------------- private helper method ----------------------
 
+    /**
+     * This Method performs Null and empty Rack Id validation and sets the rack id to the client.rack Consumer Config.
+     * @param consumerProps Consumer Property.
+     * @param rackIdSupplier Rack Id's.
+     */
     void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
         if (rackIdSupplier != null) {
             String rackId = rackIdSupplier.get();

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -79,12 +79,14 @@ public class KafkaPartitionSplitReader
     public KafkaPartitionSplitReader(
             Properties props,
             SourceReaderContext context,
-            KafkaSourceReaderMetrics kafkaSourceReaderMetrics) {
+            KafkaSourceReaderMetrics kafkaSourceReaderMetrics,
+            Supplier<String> rackIdSupplier) {
         this.subtaskId = context.getIndexOfSubtask();
         this.kafkaSourceReaderMetrics = kafkaSourceReaderMetrics;
         Properties consumerProps = new Properties();
         consumerProps.putAll(props);
         consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, createConsumerClientId(props));
+        setConsumerClientRack(consumerProps, rackIdSupplier);
         this.consumer = new KafkaConsumer<>(consumerProps);
         this.stoppingOffsets = new HashMap<>();
         this.groupId = consumerProps.getProperty(ConsumerConfig.GROUP_ID_CONFIG);
@@ -255,6 +257,12 @@ public class KafkaPartitionSplitReader
     }
 
     // --------------- private helper method ----------------------
+
+    private void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
+        if (rackIdSupplier != null) {
+            consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackIdSupplier.get());
+        }
+    }
 
     private void parseStartingOffsets(
             KafkaPartitionSplit split,

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -79,6 +79,13 @@ public class KafkaPartitionSplitReader
     public KafkaPartitionSplitReader(
             Properties props,
             SourceReaderContext context,
+            KafkaSourceReaderMetrics kafkaSourceReaderMetrics) {
+        this(props, context, kafkaSourceReaderMetrics, () -> null);
+    }
+
+    public KafkaPartitionSplitReader(
+            Properties props,
+            SourceReaderContext context,
             KafkaSourceReaderMetrics kafkaSourceReaderMetrics,
             Supplier<String> rackIdSupplier) {
         this.subtaskId = context.getIndexOfSubtask();
@@ -260,7 +267,10 @@ public class KafkaPartitionSplitReader
 
     private void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
         if (rackIdSupplier != null) {
-            consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackIdSupplier.get());
+            String rackId = rackIdSupplier.get();
+            if (rackId != null) {
+                consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackId);
+            }
         }
     }
 

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -265,10 +265,10 @@ public class KafkaPartitionSplitReader
 
     // --------------- private helper method ----------------------
 
-    private void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
+    void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
         if (rackIdSupplier != null) {
             String rackId = rackIdSupplier.get();
-            if (rackId != null) {
+            if (rackId != null && !rackId.isEmpty()) {
                 consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackId);
             }
         }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -80,14 +80,14 @@ public class KafkaPartitionSplitReader
             Properties props,
             SourceReaderContext context,
             KafkaSourceReaderMetrics kafkaSourceReaderMetrics) {
-        this(props, context, kafkaSourceReaderMetrics, () -> null);
+        this(props, context, kafkaSourceReaderMetrics, null);
     }
 
     public KafkaPartitionSplitReader(
             Properties props,
             SourceReaderContext context,
             KafkaSourceReaderMetrics kafkaSourceReaderMetrics,
-            Supplier<String> rackIdSupplier) {
+            String rackIdSupplier) {
         this.subtaskId = context.getIndexOfSubtask();
         this.kafkaSourceReaderMetrics = kafkaSourceReaderMetrics;
         Properties consumerProps = new Properties();
@@ -270,15 +270,12 @@ public class KafkaPartitionSplitReader
      * client.rack Consumer Config.
      *
      * @param consumerProps Consumer Property.
-     * @param rackIdSupplier Rack Id's.
+     * @param rackId Rack Id's.
      */
     @VisibleForTesting
-    void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
-        if (rackIdSupplier != null) {
-            String rackId = rackIdSupplier.get();
-            if (rackId != null && !rackId.isEmpty()) {
-                consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackId);
-            }
+    void setConsumerClientRack(Properties consumerProps, String rackId) {
+        if (rackId != null && !rackId.isEmpty()) {
+            consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackId);
         }
     }
 

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -266,7 +266,9 @@ public class KafkaPartitionSplitReader
     // --------------- private helper method ----------------------
 
     /**
-     * This Method performs Null and empty Rack Id validation and sets the rack id to the client.rack Consumer Config.
+     * This Method performs Null and empty Rack Id validation and sets the rack id to the
+     * client.rack Consumer Config.
+     *
      * @param consumerProps Consumer Property.
      * @param rackIdSupplier Rack Id's.
      */

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -272,6 +272,7 @@ public class KafkaPartitionSplitReader
      * @param consumerProps Consumer Property.
      * @param rackIdSupplier Rack Id's.
      */
+    @VisibleForTesting
     void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
         if (rackIdSupplier != null) {
             String rackId = rackIdSupplier.get();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -74,6 +74,7 @@ public class KafkaPartitionSplitReaderTest {
     private static final String TOPIC1 = "topic1";
     private static final String TOPIC2 = "topic2";
     private static final String TOPIC3 = "topic3";
+    private static final String CLIENT_RACK = "use1-az1";
 
     private static Map<Integer, Map<String, KafkaPartitionSplit>> splitsByOwners;
     private static Map<TopicPartition, Long> earliestOffsets;
@@ -394,7 +395,8 @@ public class KafkaPartitionSplitReaderTest {
         return new KafkaPartitionSplitReader(
                 props,
                 new TestingReaderContext(new Configuration(), sourceReaderMetricGroup),
-                kafkaSourceReaderMetrics);
+                kafkaSourceReaderMetrics,
+                () -> CLIENT_RACK);
     }
 
     private Map<String, KafkaPartitionSplit> assignSplits(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -331,11 +331,17 @@ public class KafkaPartitionSplitReaderTest {
                     return rackId;
                 };
         Properties properties = new Properties();
-        createReader(
-                properties,
-                UnregisteredMetricsGroup.createSourceReaderMetricGroup(),
-                rackIdSupplier);
+        KafkaPartitionSplitReader reader =
+                createReader(
+                        properties,
+                        UnregisteredMetricsGroup.createSourceReaderMetricGroup(),
+                        rackIdSupplier);
         assertThat(supplierCalled.get()).isEqualTo(true);
+
+        // Here we call the helper function directly, because the KafkaPartitionSplitReader
+        // doesn't allow us to examine the final ConsumerConfig object
+        reader.setConsumerClientRack(properties, rackIdSupplier);
+        assertThat(properties.get(ConsumerConfig.CLIENT_RACK_CONFIG)).isEqualTo(rackId);
     }
 
     @ParameterizedTest
@@ -348,22 +354,11 @@ public class KafkaPartitionSplitReaderTest {
                         properties,
                         UnregisteredMetricsGroup.createSourceReaderMetricGroup(),
                         rackIdSupplier);
+
+        // Here we call the helper function directly, because the KafkaPartitionSplitReader
+        // doesn't allow us to examine the final ConsumerConfig object
         reader.setConsumerClientRack(properties, rackIdSupplier);
         assertThat(properties.containsKey(ConsumerConfig.CLIENT_RACK_CONFIG)).isFalse();
-    }
-
-    @Test
-    public void testSetConsumerClientRackUsesCorrectParameter() {
-        String rackId = "use1-az1";
-        Properties properties = new Properties();
-        Supplier<String> rackIdSupplier = () -> rackId;
-        KafkaPartitionSplitReader reader =
-                createReader(
-                        properties,
-                        UnregisteredMetricsGroup.createSourceReaderMetricGroup(),
-                        rackIdSupplier);
-        reader.setConsumerClientRack(properties, rackIdSupplier);
-        assertThat(properties.get(ConsumerConfig.CLIENT_RACK_CONFIG)).isEqualTo(rackId);
     }
 
     // ------------------

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -323,10 +323,11 @@ public class KafkaPartitionSplitReaderTest {
     @Test
     public void testConsumerClientRackSupplier() {
         AtomicReference<Boolean> supplierCalled = new AtomicReference<>(false);
+        String rackId = "use-az1";
         Supplier<String> rackIdSupplier =
                 () -> {
                     supplierCalled.set(true);
-                    return "foo";
+                    return rackId;
                 };
         Properties properties = new Properties();
         createReader(
@@ -334,7 +335,7 @@ public class KafkaPartitionSplitReaderTest {
                 UnregisteredMetricsGroup.createSourceReaderMetricGroup(),
                 rackIdSupplier);
         assertThat(supplierCalled.get()).isEqualTo(true);
-        assertThat("foo".equals(properties.getProperty(ConsumerConfig.CLIENT_RACK_CONFIG)));
+        assertThat(rackId.equals(properties.getProperty(ConsumerConfig.CLIENT_RACK_CONFIG)));
     }
 
     // ------------------

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -323,12 +323,18 @@ public class KafkaPartitionSplitReaderTest {
     @Test
     public void testConsumerClientRackSupplier() {
         AtomicReference<Boolean> supplierCalled = new AtomicReference<>(false);
-        Supplier<String> rackIdSupplier = () -> {
-            supplierCalled.set(true);
-            return null;
-        };
-        createReader(new Properties(), UnregisteredMetricsGroup.createSourceReaderMetricGroup(), rackIdSupplier);
+        Supplier<String> rackIdSupplier =
+                () -> {
+                    supplierCalled.set(true);
+                    return "foo";
+                };
+        Properties properties = new Properties();
+        createReader(
+                properties,
+                UnregisteredMetricsGroup.createSourceReaderMetricGroup(),
+                rackIdSupplier);
         assertThat(supplierCalled.get()).isEqualTo(true);
+        assertThat("foo".equals(properties.getProperty(ConsumerConfig.CLIENT_RACK_CONFIG)));
     }
 
     // ------------------
@@ -394,8 +400,7 @@ public class KafkaPartitionSplitReaderTest {
     }
 
     private KafkaPartitionSplitReader createReader(
-            Properties additionalProperties,
-            SourceReaderMetricGroup sourceReaderMetricGroup) {
+            Properties additionalProperties, SourceReaderMetricGroup sourceReaderMetricGroup) {
         return createReader(additionalProperties, sourceReaderMetricGroup, () -> null);
     }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -322,7 +322,6 @@ public class KafkaPartitionSplitReaderTest {
 
     @Test
     public void testConsumerClientRackSupplier() {
-        AtomicReference<Boolean> supplierCalled = new AtomicReference<>(false);
         String rackId = "use1-az1";
         Properties properties = new Properties();
         KafkaPartitionSplitReader reader =
@@ -330,7 +329,6 @@ public class KafkaPartitionSplitReaderTest {
                         properties,
                         UnregisteredMetricsGroup.createSourceReaderMetricGroup(),
                         rackId);
-        assertThat(supplierCalled.get()).isEqualTo(true);
 
         // Here we call the helper function directly, because the KafkaPartitionSplitReader
         // doesn't allow us to examine the final ConsumerConfig object


### PR DESCRIPTION
## What is the purpose of the change

This PR adds a new method to KafkaSourceBuilder that sets the `client.id` config for the KafkaSource to the value returned by the provided Supplier. It needs to be a Supplier because it needs to run on the TaskManager, and can't be determined at Job submit time like other configs.

## Brief change log

  - *Add setRackId to KafkaSourceBuilder*
  - *Plumb rackId into KafkaPartitionSplitReader*
  - *Add rack id tests*
  -  *Document RackId feature*


## Verifying this change
  - *Added tests for the KafkaSplitReader that verify behaviors for null rackId Supplier, null and empty return values, and provided values.*
  - *Manually verified the change by running a 3-node cluster that covered two "racks" (AWS Availability Zones) against an Amazon MSK cluster.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs/Javadocs
