### PR TITLE
[FLINK-33173] Support currentFetchEventTimeLag metrics for KafkaSource

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetrics.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetrics.java
@@ -110,10 +110,10 @@ public class KafkaSourceReaderMetrics {
     /** Number of bytes consumed total at the latest {@link #updateNumBytesInCounter()}. */
     private long latestBytesConsumedTotal;
 
-    /** The last event time of consumption */
+    /** The last event time of consumption. */
     private long lastEventTime = TimestampAssigner.NO_TIMESTAMP;
 
-    /** The last consumption time */
+    /** The last consumption time. */
     private long lastFetchedTime = TimestampAssigner.NO_TIMESTAMP;
 
     public KafkaSourceReaderMetrics(SourceReaderMetricGroup sourceReaderMetricGroup) {

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -110,6 +110,13 @@ public class KafkaPartitionSplitReader
             markEmptySplitsAsFinished(recordsBySplits);
             return recordsBySplits;
         }
+
+        // Track the record fetch lag
+        consumerRecords
+                .iterator()
+                .forEachRemaining(
+                        record -> kafkaSourceReaderMetrics.recordFetched(record.timestamp()));
+
         KafkaPartitionSplitRecords recordsBySplits =
                 new KafkaPartitionSplitRecords(consumerRecords, kafkaSourceReaderMetrics);
         List<TopicPartition> finishedPartitions = new ArrayList<>();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetricsTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetricsTest.java
@@ -127,6 +127,22 @@ public class KafkaSourceReaderMetricsTest {
         assertThat(commitsFailedCounter.get().getCount()).isEqualTo(1L);
     }
 
+    @Test
+    public void testCurrentFetchTimeLag() {
+        MetricListener metricListener = new MetricListener();
+        final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
+                new KafkaSourceReaderMetrics(
+                        InternalSourceReaderMetricGroup.mock(metricListener.getMetricGroup()));
+        assertThat(kafkaSourceReaderMetrics.getFetchTimeLag())
+                .isEqualTo(InternalSourceReaderMetricGroup.UNDEFINED);
+        kafkaSourceReaderMetrics.recordFetched(-1696075536284L);
+        assertThat(kafkaSourceReaderMetrics.getFetchTimeLag())
+                .isEqualTo(InternalSourceReaderMetricGroup.UNDEFINED);
+        kafkaSourceReaderMetrics.recordFetched(1696075536284L);
+        assertThat(kafkaSourceReaderMetrics.getFetchTimeLag())
+                .isNotEqualTo(InternalSourceReaderMetricGroup.UNDEFINED);
+    }
+
     // ----------- Assertions --------------
 
     private void assertCurrentOffset(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.

  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In the connector specifications of [FLIP-33](https://cwiki.apache.org/confluence/display/FLINK/FLIP-33), `currentFetchEventTimeLag` metrics is the time in milliseconds from the record event timestamp to the timestamp Flink fetched the record. It can reflect the consupition latency before deserialization.

## Brief change log

  - *Add statistics for `currentFetchEventTimeLag`*


## Verifying this change

  - *org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetricsTest#testCurrentFetchTimeLag*

