### PR TITLE
[FLINK-33238][Formats/Avro] Upgrade used AVRO version to 1.11.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@ under the License.
         <scala-reflect.version>2.12.7</scala-reflect.version>
         <scala-library.version>2.12.7</scala-library.version>
         <snappy-java.version>1.1.10.5</snappy-java.version>
-        <avro.version>1.11.1</avro.version>
+        <avro.version>1.11.3</avro.version>
 
         <japicmp.skip>false</japicmp.skip>
         <japicmp.referenceVersion>1.17.0</japicmp.referenceVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -405,6 +405,13 @@ under the License.
                 <version>2.1</version>
             </dependency>
 
+            <!-- For dependency convergence -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.22</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>


### PR DESCRIPTION
Mitigate scanners flagging Flink or the Flink Kafka connector as vulnerable for CVE-2023-39410