### PR TITLE
[hotfix] Update CI strategy

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,7 +25,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 1.17.1 ]
+        flink: [ 1.17.1, 1.18-SNAPSHOT ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -26,8 +26,18 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [1.17-SNAPSHOT, 1.18-SNAPSHOT]
+        flink_branches: [{
+          flink: 1.17.1,
+          branch: v3.0
+        }, {
+          flink: 1.17.1,
+          branch: main
+        }, {
+          flink: 1.18-SNAPSHOT,
+          branch: main
+        }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
-      flink_version: ${{ matrix.flink }}
+      flink_version: ${{ matrix.flink_branches.flink }}
+      connector_branch: ${{ matrix.flink_branches.branch }}
       run_dependency_convergence: false


### PR DESCRIPTION
1. Test all PRs for `main` against all supported versions, meaning 1.17.x and 1.18.x. That's because only PRs run the dependency convergence check, and not nightly builds.
2. Make sure that we test nightlies against all supported versions (currently 1.17.x for the `v3.0` branch plus 1.17.x and 1.18.x against `main`)