### PR TITLE
[hotfix] refer to sql_connector_download_table shortcode in the docs …

### DIFF
--- a/docs/content/docs/connectors/table/kafka.md
+++ b/docs/content/docs/connectors/table/kafka.md
@@ -35,7 +35,7 @@ The Kafka connector allows for reading data from and writing data into Kafka top
 Dependencies
 ------------
 
-{{< sql_download_table "kafka" >}}
+{{< sql_connector_download_table "kafka" >}}
 
 The Kafka connector is not part of the binary distribution.
 See how to link with it for cluster execution [here]({{< ref "docs/dev/configuration/overview" >}}).

--- a/docs/content/docs/connectors/table/upsert-kafka.md
+++ b/docs/content/docs/connectors/table/upsert-kafka.md
@@ -47,7 +47,7 @@ key will fall into the same partition.
 Dependencies
 ------------
 
-{{< sql_download_table "upsert-kafka" >}}
+{{< sql_connector_download_table "upsert-kafka" >}}
 
 The Upsert Kafka connector is not part of the binary distribution.
 See how to link with it for cluster execution [here]({{< ref "docs/dev/configuration/overview" >}}).


### PR DESCRIPTION
…to adhere to new connector versioning format

Clicking through the docs, it looks like all connector moved to using this shortcode except for Kafka