### PR TITLE
[FLINK-33401][connectors/kafka] Fix the wrong download link and version in the connector doc

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/kafka.md
@@ -36,16 +36,12 @@ Apache Flink 集成了通用的 Kafka 连接器，它会尽力与 Kafka client �
 当前 Kafka client 向后兼容 0.10.0 或更高版本的 Kafka broker。
 有关 Kafka 兼容性的更多细节，请参考 [Kafka 官方文档](https://kafka.apache.org/protocol.html#protocol_compatibility)。
 
-{{< connector_artifact flink-connector-kafka 3.0.0 >}}
-
-如果使用 Kafka source，```flink-connector-base``` 也需要包含在依赖中：
-
-{{< artifact flink-connector-base >}}
+{{< connector_artifact flink-connector-kafka kafka >}}
 
 Flink 目前的流连接器还不是二进制发行版的一部分。
 [在此处]({{< ref "docs/dev/configuration/overview" >}})可以了解到如何链接它们，从而在集群中运行。
 
-{{< py_download_link "kafka" >}}
+{{< py_connector_download_link "kafka" >}}
 
 ## Kafka Source
 {{< hint info >}}

--- a/docs/content.zh/docs/connectors/table/kafka.md
+++ b/docs/content.zh/docs/connectors/table/kafka.md
@@ -34,7 +34,7 @@ Kafka 连接器提供从 Kafka topic 中消费和写入数据的能力。
 依赖
 ------------
 
-{{< sql_download_table "kafka" >}}
+{{< sql_connector_download_table "kafka" >}}
 
 Kafka 连接器目前并不包含在 Flink 的二进制发行版中，请查阅[这里]({{< ref "docs/dev/configuration/overview" >}})了解如何在集群运行中引用 Kafka 连接器。
 

--- a/docs/content.zh/docs/connectors/table/upsert-kafka.md
+++ b/docs/content.zh/docs/connectors/table/upsert-kafka.md
@@ -38,7 +38,7 @@ Upsert Kafka 连接器支持以 upsert 方式从 Kafka topic 中读取数据并�
 依赖
 ------------
 
-{{< sql_download_table "upsert-kafka" >}}
+{{< sql_connector_download_table "kafka" >}}
 
 Upsert Kafka 连接器不是二进制发行版的一部分，请查阅[这里]({{< ref "docs/dev/configuration/overview" >}})了解如何在集群运行中引用 Upsert Kafka 连接器。
 

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -36,12 +36,12 @@ The version of the client it uses may change between Flink releases.
 Modern Kafka clients are backwards compatible with broker versions 0.10.0 or later.
 For details on Kafka compatibility, please refer to the official [Kafka documentation](https://kafka.apache.org/protocol.html#protocol_compatibility).
 
-{{< connector_artifact flink-connector-kafka 3.0.0 >}}
+{{< connector_artifact flink-connector-kafka kafka >}}
 
 Flink's streaming connectors are not part of the binary distribution.
 See how to link with them for cluster execution [here]({{< ref "docs/dev/configuration/overview" >}}).
 
-{{< py_download_link "kafka" >}}
+{{< py_connector_download_link "kafka" >}}
 
 ## Kafka Source
 {{< hint info >}}

--- a/docs/content/docs/connectors/table/upsert-kafka.md
+++ b/docs/content/docs/connectors/table/upsert-kafka.md
@@ -47,7 +47,7 @@ key will fall into the same partition.
 Dependencies
 ------------
 
-{{< sql_connector_download_table "upsert-kafka" >}}
+{{< sql_connector_download_table "kafka" >}}
 
 The Upsert Kafka connector is not part of the binary distribution.
 See how to link with it for cluster execution [here]({{< ref "docs/dev/configuration/overview" >}}).

--- a/docs/data/kafka.yml
+++ b/docs/data/kafka.yml
@@ -1,0 +1,22 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+version: 3.0.1
+variants:
+  - maven: flink-connector-kafka
+    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka/$full_version/flink-sql-connector-kafka-$full_version.jar


### PR DESCRIPTION
Currently, Kafka Connector official documentation has a bug in the download link and the version number.
This is the fix for https://issues.apache.org/jira/browse/FLINK-33401. 

The doc link with the bug is 
https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/connectors/datastream/kafka/