### PR TITLE
[hotfix] fix_kafka_sasl_ssl_example in the docs 

### DIFF
--- a/docs/content/docs/connectors/table/kafka.md
+++ b/docs/content/docs/connectors/table/kafka.md
@@ -666,7 +666,7 @@ CREATE TABLE KafkaTable (
   /* Set SASL mechanism as SCRAM-SHA-256 */
   'properties.sasl.mechanism' = 'SCRAM-SHA-256',
   /* Set JAAS configurations */
-  'properties.sasl.jaas.config' = 'org.apache.kafka.common.security.scram.ScramLoginModule required username=\"username\" password=\"password\";'
+  'properties.sasl.jaas.config' = 'org.apache.kafka.common.security.scram.ScramLoginModule required username="username" password="password";'
 )
 ```
 


### PR DESCRIPTION
- Removing unnecessary transition symbols'/'in  the document 

`  'properties.sasl.jaas.config' = 'org.apache.kafka.common.security.scram.ScramLoginModule required username=\"username\" password=\"password\";'`

![图片](https://github.com/apache/flink-connector-kafka/assets/33744252/b7cc3f6c-6e1e-476f-af5c-089061e7b6f7)


- using transition characters can cause "Value not specified for key 'username' in JAAS config" error,The examples in the document can mislead users
![图片](https://github.com/apache/flink-connector-kafka/assets/33744252/dc63ed71-1742-4451-890a-e60eb9b656b1)

