### PR TITLE
[hotfix] Use flink SNAPSHOT version in weekly.yml to check changes quickly

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -33,10 +33,10 @@ jobs:
           flink: 1.18.0,
           branch: v3.0
         }, {
-          flink: 1.17.1,
+          flink: 1.17-SNAPSHOT,
           branch: main
         }, {
-          flink: 1.18.0,
+          flink: 1.18-SNAPSHOT,
           branch: main
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils


### PR DESCRIPTION
I find that some connectors(e.g. ES, mongodb, JDBC) are using the SNAPSHOT flink versions for main branch in `weekly.yml`. I think this will help to check changes in these version quickly.