### PR TITLE
[hotfix] Synchronize CI pipeline setup

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,19 +25,12 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 1.17.1, 1.18.0 ]
-        jdk: [ 8, 11, 17 ]
-        exclude:
-          - jdk: 17
-            flink: 1.17.1
+        flink: [ 1.17.2 ]
+        jdk: [ '8, 11' ]
+        include:
+          - flink: 1.18.1
+            jdk: '8, 11, 17'
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
       jdk_version: ${{ matrix.jdk }}
-  python_test:
-    strategy:
-      matrix:
-        flink: [ 1.17.1, 1.18.0 ]
-    uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
-    with:
-      flink_version: ${{ matrix.flink }}

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -34,3 +34,10 @@ jobs:
     with:
       flink_version: ${{ matrix.flink }}
       jdk_version: ${{ matrix.jdk }}
+  python_test:
+    strategy:
+      matrix:
+        flink: [ 1.17.2, 1.18.1 ]
+    uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
+    with:
+      flink_version: ${{ matrix.flink }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -27,20 +27,26 @@ jobs:
     strategy:
       matrix:
         flink_branches: [{
+          flink: 1.17-SNAPSHOT,
+          branch: main
+        }, {
+          flink: 1.18-SNAPSHOT,
+          jdk: '8, 11, 17',
+          branch: main
+        }, {
+          flink: 1.19-SNAPSHOT,
+          jdk: '8, 11, 17, 21',
+          branch: main
+        }, {
           flink: 1.17.1,
           branch: v3.0
         }, {
           flink: 1.18.0,
           branch: v3.0
-        }, {
-          flink: 1.17.1,
-          branch: main
-        }, {
-          flink: 1.18.0,
-          branch: main
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink_branches.flink }}
       connector_branch: ${{ matrix.flink_branches.branch }}
+      jdk_version: ${{ matrix.flink_branches.jdk || '8, 11' }}
       run_dependency_convergence: false


### PR DESCRIPTION
The Flink Kafka connector now tests:
- All PRs against `main` are tested against Flink `1.17.2` and `1.18.1`, instead of `1.17.1` and `1.18.0`
- The weekly run tests -- `main` against `1.17-SNAPSHOT, `1.18-SNAPSHOT` and `1.19-SNAPSHOT` (1.19 is newly added) -- `v3.0` against `1.17-SNAPSHOT` and `1.18-SNAPSHOT` (as was before)