### PR TITLE
[FLINK-32416] Fix flaky tests by ensuring test utilities produce records w…

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
@@ -132,8 +132,8 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
 
     @Override
     public InputStatus pollNext(ReaderOutput<T> readerOutput) throws Exception {
-        // do not return end of input if no more splits has not yet been signaled
-        if (!isNoMoreSplits && clusterReaderMap.isEmpty()) {
+        // at startup, do not return end of input if metadata event has not been received
+        if (clusterReaderMap.isEmpty()) {
             return logAndReturnInputStatus(InputStatus.NOTHING_AVAILABLE);
         }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorTest.java
@@ -919,11 +919,13 @@ public class DynamicKafkaSourceEnumeratorTest {
 
     private static class TestKafkaEnumContextProxyFactory
             implements StoppableKafkaEnumContextProxy.StoppableKafkaEnumContextProxyFactory {
+
         @Override
         public StoppableKafkaEnumContextProxy create(
                 SplitEnumeratorContext<DynamicKafkaSourceSplit> enumContext,
                 String kafkaClusterId,
-                KafkaMetadataService kafkaMetadataService) {
+                KafkaMetadataService kafkaMetadataService,
+                Runnable signalNoMoreSplitsCallback) {
             return new TestKafkaEnumContextProxy(
                     kafkaClusterId,
                     kafkaMetadataService,
@@ -939,7 +941,7 @@ public class DynamicKafkaSourceEnumeratorTest {
                 String kafkaClusterId,
                 KafkaMetadataService kafkaMetadataService,
                 MockSplitEnumeratorContext<DynamicKafkaSourceSplit> enumContext) {
-            super(kafkaClusterId, kafkaMetadataService, enumContext);
+            super(kafkaClusterId, kafkaMetadataService, enumContext, null);
             this.enumContext = enumContext;
         }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/StoppableKafkaEnumContextProxyTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/StoppableKafkaEnumContextProxyTest.java
@@ -150,7 +150,8 @@ public class StoppableKafkaEnumContextProxyTest {
         return new StoppableKafkaEnumContextProxy(
                 contextKafkaCluster,
                 new MockKafkaMetadataService(Collections.singleton(mockStream)),
-                enumContext);
+                enumContext,
+                null);
     }
 
     // this modeled after `KafkaSourceEnumerator` topic partition subscription to throw the same

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/DynamicKafkaSourceTestHelper.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/DynamicKafkaSourceTestHelper.java
@@ -204,6 +204,7 @@ public class DynamicKafkaSourceTestHelper extends KafkaTestBase {
             throws Throwable {
         Properties props = new Properties();
         props.putAll(clusterProperties);
+        props.setProperty(ProducerConfig.ACKS_CONFIG, "all");
         props.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass.getName());
         props.setProperty(
                 ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializerClass.getName());
@@ -219,8 +220,9 @@ public class DynamicKafkaSourceTestHelper extends KafkaTestBase {
                 };
         try (KafkaProducer<K, V> producer = new KafkaProducer<>(props)) {
             for (ProducerRecord<K, V> record : records) {
-                producer.send(record, callback).get();
+                producer.send(record, callback);
             }
+            producer.flush();
         }
         if (sendingError.get() != null) {
             throw sendingError.get();


### PR DESCRIPTION
…ith consistency and cleanup notify no more splits to ensure it is sent

I have spent the last few days troubleshooting this and found that most issues are related to the bounded mode tests. These problems don't surface locally and I suspect that they are more likely to occur with smaller/busy CI machines. Issues:
1. Test records were not being produced to Kafka. I added the Kafka settings and refactored to the API to ensure all records are sent to all brokers.
2. When I fixed this, I ran into some tests that would exceed the 50 minute CI. This is because the the no more splits signal was not sent properly. I refactored the code a bit to make it clearer.

At this commit, the tests are quite stable. 6/7 CI runs pass.
<img width="329" alt="Screenshot 2024-01-16 at 10 13 43 PM" src="https://github.com/apache/flink-connector-kafka/assets/6834335/c0fae8e0-f8bc-4ad3-8075-ede06a27ef08">

In one CI run that failed, I did see that there was a Flink error, indicating a lost source event. In separate commits, there were other instances that exceeded 50 minutes but this can be solved separately, see https://issues.apache.org/jira/browse/FLINK-34127.

Original issue that Max found after #44 was merged: https://github.com/apache/flink-connector-kafka/actions/runs/7504290046/job/20433204351

cc: @mxm @tzulitai @MartijnVisser 
