### PR TITLE
[FLINK-34995] flink kafka connector source stuck when partition leade…

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/PartitionSetSubscriber.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/PartitionSetSubscriber.java
@@ -56,7 +56,7 @@ class PartitionSetSubscriber implements KafkaSubscriber {
 
         for (TopicPartition subscribedPartition : this.subscribedPartitions) {
             if (topicMetadata.containsKey(subscribedPartition.topic())
-                    && partitionExistsInTopic(
+                    && partitionExistsInTopicAndValid(
                             subscribedPartition, topicMetadata.get(subscribedPartition.topic()))) {
                 existingSubscribedPartitions.add(subscribedPartition);
             } else {
@@ -70,7 +70,9 @@ class PartitionSetSubscriber implements KafkaSubscriber {
         return existingSubscribedPartitions;
     }
 
-    private boolean partitionExistsInTopic(TopicPartition partition, TopicDescription topic) {
-        return topic.partitions().size() > partition.partition();
+    private boolean partitionExistsInTopicAndValid(
+            TopicPartition partition, TopicDescription topic) {
+        return topic.partitions().stream()
+                .anyMatch(p -> p.leader() != null && p.partition() == partition.partition());
     }
 }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicListSubscriber.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicListSubscriber.java
@@ -54,7 +54,10 @@ class TopicListSubscriber implements KafkaSubscriber {
         Set<TopicPartition> subscribedPartitions = new HashSet<>();
         for (TopicDescription topic : topicMetadata.values()) {
             for (TopicPartitionInfo partition : topic.partitions()) {
-                subscribedPartitions.add(new TopicPartition(topic.name(), partition.partition()));
+                if (partition.leader() != null) {
+                    subscribedPartitions.add(
+                            new TopicPartition(topic.name(), partition.partition()));
+                }
             }
         }
 

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
@@ -53,9 +53,11 @@ class TopicPatternSubscriber implements KafkaSubscriber {
                 (topicName, topicDescription) -> {
                     if (topicPattern.matcher(topicName).matches()) {
                         for (TopicPartitionInfo partition : topicDescription.partitions()) {
-                            subscribedTopicPartitions.add(
-                                    new TopicPartition(
-                                            topicDescription.name(), partition.partition()));
+                            if (partition.leader() != null) {
+                                subscribedTopicPartitions.add(
+                                        new TopicPartition(
+                                                topicDescription.name(), partition.partition()));
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
when partition leader invalid(leader=-1),  the flink streaming job using KafkaSource can't restart or start a new instance with a new groupid,  it will stuck and got following exception:

"org.apache.kafka.common.errors.TimeoutException: Timeout of 60000ms expired before the position for partition aaa-1 could be determined"

when leader=-1,  kafka api like KafkaConsumer.position() will block until either the position could be determined or an unrecoverable error is encountered 

infact,  leader=-1 not easy to avoid,  even replica=3, three disk offline together will trigger the problem, especially when the cluster size is relatively large.    it rely on kafka administrator to fix in time,  but it take risk when in kafka cluster peak period.

This can be addressed by using the invalid leader filter and discovery partition interval.
 





