### PR TITLE
[FLINK-35038] Bump `org.yaml:snakeyaml` to `2.2`

### DIFF
--- a/flink-connector-kafka/pom.xml
+++ b/flink-connector-kafka/pom.xml
@@ -174,7 +174,7 @@ under the License.
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.31</version>
+            <version>2.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/flink-connector-kafka/pom.xml
+++ b/flink-connector-kafka/pom.xml
@@ -174,7 +174,7 @@ under the License.
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>2.0</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
SnakeYAML introduced breaking API changes and behavior changes between 1.31 and 2.2. This PR uses the updated APIs and explicitly allows the global tag for StreamMetadata (see changed SnakeYAML behavior in https://github.com/snakeyaml/snakeyaml/commit/2b8d47c8bcfd402e7a682b7b2674e8d0cb25e522).

### Notes
* This dependency is only used in tests, so therefore not critical to address.
* Some tests are currently broken. Everything should be green once #90 goes in and this PR is rebased. I verified the change locally.

Closes #85.