### PR TITLE
[FLINK-34470][Connectors/Kafka] Fix indefinite blocking by adjusting stopping condition in split reader

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -122,31 +122,31 @@ public class KafkaPartitionSplitReader
         KafkaPartitionSplitRecords recordsBySplits =
                 new KafkaPartitionSplitRecords(consumerRecords, kafkaSourceReaderMetrics);
         List<TopicPartition> finishedPartitions = new ArrayList<>();
-        for (TopicPartition tp : consumerRecords.partitions()) {
+        for (TopicPartition tp : consumer.assignment()) {
             long stoppingOffset = getStoppingOffset(tp);
-            final List<ConsumerRecord<byte[], byte[]>> recordsFromPartition =
-                    consumerRecords.records(tp);
-
-            if (recordsFromPartition.size() > 0) {
-                final ConsumerRecord<byte[], byte[]> lastRecord =
-                        recordsFromPartition.get(recordsFromPartition.size() - 1);
-
-                // After processing a record with offset of "stoppingOffset - 1", the split reader
-                // should not continue fetching because the record with stoppingOffset may not
-                // exist. Keep polling will just block forever.
-                if (lastRecord.offset() >= stoppingOffset - 1) {
-                    recordsBySplits.setPartitionStoppingOffset(tp, stoppingOffset);
-                    finishSplitAtRecord(
-                            tp,
-                            stoppingOffset,
-                            lastRecord.offset(),
-                            finishedPartitions,
-                            recordsBySplits);
-                }
+            long consumerPosition = consumer.position(tp);
+            // Stop fetching when the consumer's position reaches the stoppingOffset.
+            // Control messages may follow the last record; therefore, using the last record's
+            // offset as a stopping condition could result in indefinite blocking.
+            if (consumerPosition >= stoppingOffset) {
+                LOG.debug(
+                        "Position of {}: {}, has reached stopping offset: {}",
+                        tp,
+                        consumerPosition,
+                        stoppingOffset);
+                recordsBySplits.setPartitionStoppingOffset(tp, stoppingOffset);
+                finishSplitAtRecord(
+                        tp, stoppingOffset, consumerPosition, finishedPartitions, recordsBySplits);
             }
-            // Track this partition's record lag if it never appears before
-            kafkaSourceReaderMetrics.maybeAddRecordsLagMetric(consumer, tp);
         }
+
+        // Only track non-empty partition's record lag if it never appears before
+        consumerRecords
+                .partitions()
+                .forEach(
+                        trackTp -> {
+                            kafkaSourceReaderMetrics.maybeAddRecordsLagMetric(consumer, trackTp);
+                        });
 
         markEmptySplitsAsFinished(recordsBySplits);
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
@@ -116,7 +116,7 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
                     "Waiting for offsets topic creation failed.");
         }
         KafkaSourceTestEnv.produceToKafka(
-                getRecords(), StringSerializer.class, IntegerSerializer.class);
+                getRecords(), StringSerializer.class, IntegerSerializer.class, null);
     }
 
     @AfterAll

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/KafkaSourceTestEnv.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/KafkaSourceTestEnv.java
@@ -249,7 +249,13 @@ public class KafkaSourceTestEnv extends KafkaTestBase {
 
     public static void produceToKafka(Collection<ProducerRecord<String, Integer>> records)
             throws Throwable {
-        produceToKafka(records, StringSerializer.class, IntegerSerializer.class);
+        produceToKafka(records, StringSerializer.class, IntegerSerializer.class, null);
+    }
+
+    public static void produceToKafka(
+            Collection<ProducerRecord<String, Integer>> records, Properties extraProps)
+            throws Throwable {
+        produceToKafka(records, StringSerializer.class, IntegerSerializer.class, extraProps);
     }
 
     public static void setupTopic(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 
 /** Abstract class providing a Kafka test environment. */
 public abstract class KafkaTestEnvironment {
@@ -112,6 +113,12 @@ public abstract class KafkaTestEnvironment {
         props.put("enable.idempotence", "true");
         props.put("acks", "all");
         props.put("retries", "3");
+        return props;
+    }
+
+    public Properties getTransactionalProducerConfig() {
+        Properties props = new Properties();
+        props.put("transactional.id", UUID.randomUUID().toString());
         return props;
     }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
@@ -54,6 +54,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -350,6 +351,62 @@ public class KafkaTableITCase extends KafkaTableTestBase {
 
         deleteTestTopic(topic1);
         deleteTestTopic(topic2);
+    }
+
+    @Test
+    public void testKafkaSourceEmptyResultOnDeletedOffsets() throws Exception {
+        // we always use a different topic name for each parameterized topic,
+        // in order to make sure the topic can be created.
+        final String topic = "bounded_" + format + "_" + UUID.randomUUID();
+        createTestTopic(topic, 1, 1);
+        // ---------- Produce an event time stream into Kafka -------------------
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
+
+        final String createTable =
+                String.format(
+                        "CREATE TABLE kafka (\n"
+                                + "  `user_id` INT,\n"
+                                + "  `item_id` INT,\n"
+                                + "  `behavior` STRING\n"
+                                + ") WITH (\n"
+                                + "  'connector' = '%s',\n"
+                                + "  'topic' = '%s',\n"
+                                + "  'properties.bootstrap.servers' = '%s',\n"
+                                + "  'properties.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'specific-offsets',\n"
+                                + "  'scan.bounded.mode' = 'specific-offsets',\n"
+                                + "  'scan.startup.specific-offsets' = 'partition:0,offset:1',\n"
+                                + "  'scan.bounded.specific-offsets' = 'partition:0,offset:3',\n"
+                                + "  %s\n"
+                                + ")\n",
+                        KafkaDynamicTableFactory.IDENTIFIER,
+                        topic,
+                        bootstraps,
+                        groupId,
+                        formatOptions());
+        tEnv.executeSql(createTable);
+        List<Row> values =
+                Arrays.asList(
+                        Row.of(1, 1102, "behavior 1"),
+                        Row.of(2, 1103, "behavior 2"),
+                        Row.of(3, 1104, "behavior 3"));
+        tEnv.fromValues(values).insertInto("kafka").execute().await();
+        // ---------- Delete events from Kafka -------------------
+        Map<Integer, Long> partitionOffsetsToDelete = new HashMap<>();
+        partitionOffsetsToDelete.put(0, 3L);
+        deleteRecords(topic, partitionOffsetsToDelete);
+        // ---------- Consume stream from Kafka -------------------
+        List<Row> results = new ArrayList<>();
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
+        tEnv = StreamTableEnvironment.create(env);
+        tEnv.executeSql(createTable);
+        results.addAll(collectAllRows(tEnv.sqlQuery("SELECT * FROM kafka")));
+        assertThat(results).isEmpty();
+
+        // ------------- cleanup -------------------
+
+        deleteTestTopic(topic);
     }
 
     @Test


### PR DESCRIPTION
## Problem 
When using the flink kafka connector in batch scenarios, consuming transactional messages can cause indefinite hanging.
This issue can be easily reproduced with following steps. 
1. Produce transactional messages and commit them.
2. Configure `scan.bounded.mode` to `latest-offset` and run consumer using flink kafka connector

## Cause
The previous stopping condition in the `KafkaPartitionSplitReader` compared the offset of the last record with the `stoppingOffset`. This approach works for streaming use cases and batch processing of non-transactional messages. However, in scenarios involving transactional messages, this is insufficient.      
[Control messages](https://kafka.apache.org/documentation/#controlbatch), which are not visible to clients, can occupy the entire range between the last record's offset and the stoppingOffset which leads to indefinite blocking.

## Workaround
I've modified the stopping condition to use `consumer.position(tp)`, which effectively skips any control messages present in the current poll, pointing directly to the next record's offset. 
To handle edge cases, particularly when `properties.max.poll.records` is set to `1`, I've adjusted the fetch method to always check all assigned partitions, even if no records are returned in a poll.

#### Edge case example 
Consider partition `0`, where offsets `13` and `14` are valid records and `15` is a control record. If `stoppingOffset` is set to 15 for partition `0`and `properties.max.poll.records` is configured to `1`, checking only partitions that return records would miss offset 15. By consistently reviewing all assigned partitions, the consumer’s position jumps control record in the subsequent poll, allowing the system to escape.

## Discussion
To address the metric issue in [FLINK-33484](https://issues.apache.org/jira/browse/FLINK-33484), I think we need to make wrapper class of  `ConsumerRecord` for example `ConsumerRecordWithOffsetJump`.
```java
public ConsumerRecordWithOffsetJump(ConsumerRecord<K, V> record, long offsetJump) {
        this.record = record;
        this.offsetJump = offsetJump;
    }
```
And we may need new `KafkaPartitionSplitReader` that implements     
`SplitReader<ConsumerRecordWithOffsetJump<byte[], byte[]>, KafkaPartitionSplit>`.     
So when record is emitted it should set current offset not just `record.offset()+1` but     
`record.offset() + record.jumpValue` in [here](https://github.com/apache/flink-connector-kafka/blob/369e7be46a70fd50d68746498aed82105741e7d6/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaRecordEmitter.java#L54).  
  `jumpValue` is typically 1, except for the last record of each poll where it's calculated as     
`consumer.position() - lastRecord.offset()`.       
If this sounds good to everyone, I'm happy to work on this.