### PR TITLE
PoC for supporting unique Kafka producer client ids

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/ClientIdFactory.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/ClientIdFactory.java
@@ -1,0 +1,14 @@
+package org.apache.flink.connector.kafka.sink;
+
+public class ClientIdFactory {
+    private static final String CLIENT_ID_DELIMITER = "-";
+
+    public static String buildClientId(
+            String clientIdPrefix,
+            int subtaskId
+    ) {
+        return clientIdPrefix
+                + CLIENT_ID_DELIMITER
+                + subtaskId;
+    }
+}

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducer.java
@@ -51,13 +51,17 @@ class FlinkKafkaInternalProducer<K, V> extends KafkaProducer<K, V> {
             "org.apache.kafka.clients.producer.internals.TransactionManager$State";
     private static final String PRODUCER_ID_AND_EPOCH_FIELD_NAME = "producerIdAndEpoch";
 
-    @Nullable private String transactionalId;
+    @Nullable
+    private String transactionalId;
     private volatile boolean inTransaction;
     private volatile boolean hasRecordsInTransaction;
     private volatile boolean closed;
 
-    public FlinkKafkaInternalProducer(Properties properties, @Nullable String transactionalId) {
-        super(withTransactionalId(properties, transactionalId));
+    public FlinkKafkaInternalProducer(Properties properties,
+                                      @Nullable String transactionalId,
+                                      @Nullable String clientId
+    ) {
+        super(withClientId(withTransactionalId(properties, transactionalId), ""));
         this.transactionalId = transactionalId;
     }
 
@@ -69,6 +73,17 @@ class FlinkKafkaInternalProducer<K, V> extends KafkaProducer<K, V> {
         Properties props = new Properties();
         props.putAll(properties);
         props.setProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+        return props;
+    }
+
+    private static Properties withClientId(Properties properties, @Nullable String clientId) {
+        if (clientId == null) {
+            return properties;
+        }
+
+        Properties props = new Properties();
+        props.putAll(properties);
+        props.setProperty(ProducerConfig.CLIENT_ID_CONFIG, clientId);
         return props;
     }
 
@@ -223,8 +238,8 @@ class FlinkKafkaInternalProducer<K, V> extends KafkaProducer<K, V> {
                 invoke(
                         transactionManager,
                         "enqueueRequest",
-                        new Class[] {txnRequestHandler.getClass().getSuperclass()},
-                        new Object[] {txnRequestHandler});
+                        new Class[]{txnRequestHandler.getClass().getSuperclass()},
+                        new Object[]{txnRequestHandler});
                 result =
                         (TransactionalRequestResult)
                                 getField(
@@ -344,10 +359,10 @@ class FlinkKafkaInternalProducer<K, V> extends KafkaProducer<K, V> {
             constructor.setAccessible(true);
             return constructor.newInstance(producerId, epoch);
         } catch (InvocationTargetException
-                | InstantiationException
-                | IllegalAccessException
-                | NoSuchFieldException
-                | NoSuchMethodException e) {
+                 | InstantiationException
+                 | IllegalAccessException
+                 | NoSuchFieldException
+                 | NoSuchMethodException e) {
             throw new RuntimeException("Incompatible KafkaProducer version", e);
         }
     }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSink.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSink.java
@@ -61,15 +61,19 @@ public class KafkaSink<IN>
     private final KafkaRecordSerializationSchema<IN> recordSerializer;
     private final Properties kafkaProducerConfig;
     private final String transactionalIdPrefix;
+    private final String clientIdPrefix;
+
 
     KafkaSink(
             DeliveryGuarantee deliveryGuarantee,
             Properties kafkaProducerConfig,
             String transactionalIdPrefix,
+            String clientIdPrefix,
             KafkaRecordSerializationSchema<IN> recordSerializer) {
         this.deliveryGuarantee = deliveryGuarantee;
         this.kafkaProducerConfig = kafkaProducerConfig;
         this.transactionalIdPrefix = transactionalIdPrefix;
+        this.clientIdPrefix = clientIdPrefix;
         this.recordSerializer = recordSerializer;
     }
 
@@ -102,6 +106,7 @@ public class KafkaSink<IN>
                 deliveryGuarantee,
                 kafkaProducerConfig,
                 transactionalIdPrefix,
+                clientIdPrefix,
                 context,
                 recordSerializer,
                 context.asSerializationSchemaInitializationContext(),
@@ -116,6 +121,7 @@ public class KafkaSink<IN>
                 deliveryGuarantee,
                 kafkaProducerConfig,
                 transactionalIdPrefix,
+                clientIdPrefix,
                 context,
                 recordSerializer,
                 context.asSerializationSchemaInitializationContext(),

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilder.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilder.java
@@ -71,6 +71,7 @@ public class KafkaSinkBuilder<IN> {
 
     private DeliveryGuarantee deliveryGuarantee = DeliveryGuarantee.NONE;
     private String transactionalIdPrefix = "kafka-sink";
+    private String clientIdPrefix = null;
 
     private final Properties kafkaProducerConfig;
     private KafkaRecordSerializationSchema<IN> recordSerializer;
@@ -188,6 +189,20 @@ public class KafkaSinkBuilder<IN> {
      */
     public KafkaSinkBuilder<IN> setBootstrapServers(String bootstrapServers) {
         return setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    }
+
+    /**
+     * Set the prefix for all KafkaProducer `client.id` values.
+     * This will overwrite any value set for `client.id` in the provided Kafka producer configuration.
+     * Instead, a value for `client.id` will be derived from the prefix provided.
+     * Using a prefix will create a unique Kafka `client.id` for all producers.
+     *
+     * @param clientIdPrefix Prefix to use
+     * @return {@link KafkaSinkBuilder}
+     */
+    public KafkaSinkBuilder<IN> setClientIdPrefix(String clientIdPrefix) {
+        this.clientIdPrefix = checkNotNull(clientIdPrefix, "clientIdPrefix");
+        return this;
     }
 
     private void sanityCheck() {


### PR DESCRIPTION
This PR came out of debuging a warning we’re seeing in our Flink logs. We’re running Flink 1.18 and have an application that uses Kafka topics as a source and a sink. We’re running with several tasks. The warning we’re seeing in the logs is:

```
WARN org.apache.kafka.common.utils.AppInfoParser - Error registering AppInfo mbean
javax.management.InstanceAlreadyExistsException: kafka.producer:type=app-info,id=kafka producer client id
```

I’ve spent a bit of time debugging, and it looks like the root cause of this warning is the Flink `KafkaSink` creating multiple `KafkaWriter`s that, in turn, create multiple `KafkaProducer`s with the same Kafka producer `client.id`. Since the value for `client.id` is used when registering the `AppInfo` MBean — when multiple `KafkaProducer`s with the same `client.id` are registered we get the above `InstanceAlreadyExistsException`. Since we’re running with several tasks and we get a Kafka producer per task this duplicate registration exception makes sense to me.


This PR proposes a fix that would update the `KafkaSink.builder` by adding a `setClientIdPrefix` method, similar to what we have already on the `KafkaSource.builder`.
