### PR TITLE
[FLINK-35109] Drop support for Flink 1.17 & 1.18 and fix tests for 1.20-SNAPSHOT

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,13 +28,8 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 1.17.2 ]
-        jdk: [ '8, 11' ]
-        include:
-          - flink: 1.18.1
-            jdk: '8, 11, 17'
-          - flink: 1.19.0
-            jdk: '8, 11, 17, 21'
+        flink: [ 1.19.0, 1.20-SNAPSHOT ]
+        jdk: [ '8, 11, 17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
@@ -42,7 +37,7 @@ jobs:
   python_test:
     strategy:
       matrix:
-        flink: [ 1.17.2, 1.18.1, 1.19.0 ]
+        flink: [ 1.19.0 ]
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -30,13 +30,6 @@ jobs:
     strategy:
       matrix:
         flink_branches: [{
-          flink: 1.17-SNAPSHOT,
-          branch: main
-        }, {
-          flink: 1.18-SNAPSHOT,
-          jdk: '8, 11, 17',
-          branch: main
-        }, {
           flink: 1.19-SNAPSHOT,
           jdk: '8, 11, 17, 21',
           branch: main

--- a/flink-connector-kafka/pom.xml
+++ b/flink-connector-kafka/pom.xml
@@ -133,6 +133,12 @@ under the License.
             <type>test-jar</type>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>fink-migration-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <!-- include kafka server for tests  -->

--- a/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaRecordSerializationSchema.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaRecordSerializationSchema.java
@@ -103,16 +103,12 @@ class DynamicKafkaRecordSerializationSchema implements KafkaRecordSerializationS
                 valueSerialized = null;
             } else {
                 // make the message to be INSERT to be compliant with the INSERT-ONLY format
-                final RowData valueRow =
-                        DynamicKafkaRecordSerializationSchema.createProjectedRow(
-                                consumedRow, kind, valueFieldGetters);
+                final RowData valueRow = createProjectedRow(consumedRow, kind, valueFieldGetters);
                 valueRow.setRowKind(RowKind.INSERT);
                 valueSerialized = valueSerialization.serialize(valueRow);
             }
         } else {
-            final RowData valueRow =
-                    DynamicKafkaRecordSerializationSchema.createProjectedRow(
-                            consumedRow, kind, valueFieldGetters);
+            final RowData valueRow = createProjectedRow(consumedRow, kind, valueFieldGetters);
             valueSerialized = valueSerialization.serialize(valueRow);
         }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/TypeSerializerConditions.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/TypeSerializerConditions.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.testutils;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+
+import org.assertj.core.api.Condition;
+
+import java.util.function.Predicate;
+
+/**
+ * A Collection of useful {@link Condition}s for {@link TypeSerializer} and {@link
+ * TypeSerializerSchemaCompatibility}.
+ */
+public final class TypeSerializerConditions {
+
+    private TypeSerializerConditions() {}
+
+    public static <T> Condition<TypeSerializerSchemaCompatibility<T>> isCompatibleAsIs() {
+        return new Condition<>(
+                TypeSerializerSchemaCompatibility::isCompatibleAsIs,
+                "type serializer schema that is a compatible as is");
+    }
+
+    public static <T> Condition<TypeSerializerSchemaCompatibility<T>> isIncompatible() {
+        return new Condition<>(
+                TypeSerializerSchemaCompatibility::isIncompatible,
+                "type serializer schema that is incompatible");
+    }
+
+    public static <T> Condition<TypeSerializerSchemaCompatibility<T>> isCompatibleAfterMigration() {
+        return new Condition<>(
+                TypeSerializerSchemaCompatibility::isCompatibleAfterMigration,
+                "type serializer schema that is compatible after migration");
+    }
+
+    public static <T>
+            Condition<TypeSerializerSchemaCompatibility<T>>
+                    isCompatibleWithReconfiguredSerializer() {
+        return new Condition<>(
+                TypeSerializerSchemaCompatibility::isCompatibleWithReconfiguredSerializer,
+                "type serializer schema that is compatible with a reconfigured serializer");
+    }
+
+    public static <T>
+            Condition<TypeSerializerSchemaCompatibility<T>> isCompatibleWithReconfiguredSerializer(
+                    Predicate<? super TypeSerializer<T>> reconfiguredSerializerMatcher) {
+        return new Condition<>(
+                compatibility ->
+                        compatibility.isCompatibleWithReconfiguredSerializer()
+                                && reconfiguredSerializerMatcher.test(
+                                        compatibility.getReconfiguredSerializer()),
+                "type serializer schema that is compatible with a reconfigured serializer matching "
+                        + reconfiguredSerializerMatcher);
+    }
+
+    public static <T> Condition<TypeSerializerSchemaCompatibility<T>> hasSameCompatibilityAs(
+            TypeSerializerSchemaCompatibility<T> expectedCompatibility) {
+        return new Condition<>(
+                actual ->
+                        actual.isCompatibleAsIs() == expectedCompatibility.isCompatibleAsIs()
+                                && actual.isIncompatible() == expectedCompatibility.isIncompatible()
+                                && actual.isCompatibleAfterMigration()
+                                        == expectedCompatibility.isCompatibleAfterMigration()
+                                && actual.isCompatibleWithReconfiguredSerializer()
+                                        == expectedCompatibility
+                                                .isCompatibleWithReconfiguredSerializer(),
+                "same compatibility as " + expectedCompatibility);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ under the License.
     </modules>
 
     <properties>
-        <flink.version>1.17.0</flink.version>
+        <flink.version>1.19.0</flink.version>
         <kafka.version>3.4.0</kafka.version>
         <zookeeper.version>3.7.2</zookeeper.version>
         <confluent.version>7.4.4</confluent.version>


### PR DESCRIPTION
This PR drops support for Flink 1.17 & 1.18 and fix tests for 1.20-SNAPSHOT.