### PR TITLE
[FLINK-25538][Connectors/Kafka] Migration flink-connector-kafka from Junit4 to Junit5

### DIFF
--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaCommittableSerializerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaCommittableSerializerTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.connector.kafka.sink;
 
 import org.apache.flink.util.TestLoggerExtension;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaCommittableSerializerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaCommittableSerializerTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.flink.connector.kafka.sink;
 
-import org.apache.flink.util.TestLogger;
-
-import org.junit.Test;
+import org.apache.flink.util.TestLoggerExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 
@@ -29,12 +29,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for serializing and deserialzing {@link KafkaCommittable} with {@link
  * KafkaCommittableSerializer}.
  */
-public class KafkaCommittableSerializerTest extends TestLogger {
+@ExtendWith({TestLoggerExtension.class})
+class KafkaCommittableSerializerTest {
 
     private static final KafkaCommittableSerializer SERIALIZER = new KafkaCommittableSerializer();
 
     @Test
-    public void testCommittableSerDe() throws IOException {
+    void testCommittableSerDe() throws IOException {
         final String transactionalId = "test-id";
         final short epoch = 5;
         final KafkaCommittable committable = new KafkaCommittable(1L, epoch, transactionalId, null);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaCommitterTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaCommitterTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link KafkaCommitter}. */
 @ExtendWith({TestLoggerExtension.class})
-public class KafkaCommitterTest {
+class KafkaCommitterTest {
 
     private static final int PRODUCER_ID = 0;
     private static final short EPOCH = 0;
@@ -44,7 +44,7 @@ public class KafkaCommitterTest {
 
     /** Causes a network error by inactive broker and tests that a retry will happen. */
     @Test
-    public void testRetryCommittableOnRetriableError() throws IOException, InterruptedException {
+    void testRetryCommittableOnRetriableError() throws IOException, InterruptedException {
         Properties properties = getProperties();
         try (final KafkaCommitter committer = new KafkaCommitter(properties);
                 FlinkKafkaInternalProducer<Object, Object> producer =
@@ -66,7 +66,7 @@ public class KafkaCommitterTest {
     }
 
     @Test
-    public void testFailJobOnUnknownFatalError() throws IOException, InterruptedException {
+    void testFailJobOnUnknownFatalError() throws IOException, InterruptedException {
         Properties properties = getProperties();
         try (final KafkaCommitter committer = new KafkaCommitter(properties);
                 FlinkKafkaInternalProducer<Object, Object> producer =
@@ -87,7 +87,7 @@ public class KafkaCommitterTest {
     }
 
     @Test
-    public void testKafkaCommitterClosesProducer() throws IOException, InterruptedException {
+    void testKafkaCommitterClosesProducer() throws IOException, InterruptedException {
         Properties properties = getProperties();
         FlinkKafkaInternalProducer<Object, Object> producer =
                 new FlinkKafkaInternalProducer(properties, TRANSACTIONAL_ID) {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
@@ -21,8 +21,8 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.connector.testutils.formats.DummyInitializationContext;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
-import org.apache.flink.util.TestLogger;
 
+import org.apache.flink.util.TestLoggerExtension;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.header.Header;
@@ -31,8 +31,9 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -47,7 +48,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link KafkaRecordSerializationSchemaBuilder}. */
-public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
+@ExtendWith({TestLoggerExtension.class})
+class KafkaRecordSerializationSchemaBuilderTest {
 
     private static final String DEFAULT_TOPIC = "test";
 
@@ -55,25 +57,25 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
     private static Map<String, ?> configuration;
     private static boolean isKeySerializer;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         configurableConfiguration = new HashMap<>();
         configuration = new HashMap<>();
         isKeySerializer = false;
     }
 
     @Test
-    public void testDoNotAllowMultipleKeySerializer() {
+    void testDoNotAllowMultipleKeySerializer() {
         assertOnlyOneSerializerAllowed(keySerializationSetter());
     }
 
     @Test
-    public void testDoNotAllowMultipleValueSerializer() {
+    void testDoNotAllowMultipleValueSerializer() {
         assertOnlyOneSerializerAllowed(valueSerializationSetter());
     }
 
     @Test
-    public void testDoNotAllowMultipleTopicSelector() {
+    void testDoNotAllowMultipleTopicSelector() {
         assertThatThrownBy(
                         () ->
                                 KafkaRecordSerializationSchema.builder()
@@ -89,7 +91,7 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
     }
 
     @Test
-    public void testExpectTopicSelector() {
+    void testExpectTopicSelector() {
         assertThatThrownBy(
                         KafkaRecordSerializationSchema.builder()
                                         .setValueSerializationSchema(new SimpleStringSchema())
@@ -98,13 +100,13 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
     }
 
     @Test
-    public void testExpectValueSerializer() {
+    void testExpectValueSerializer() {
         assertThatThrownBy(KafkaRecordSerializationSchema.builder().setTopic(DEFAULT_TOPIC)::build)
                 .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    public void testSerializeRecordWithTopicSelector() {
+    void testSerializeRecordWithTopicSelector() {
         final TopicSelector<String> topicSelector =
                 (e) -> {
                     if (e.equals("a")) {
@@ -129,7 +131,7 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
     }
 
     @Test
-    public void testSerializeRecordWithPartitioner() throws Exception {
+    void testSerializeRecordWithPartitioner() throws Exception {
         AtomicBoolean opened = new AtomicBoolean(false);
         final int partition = 5;
         final FlinkKafkaPartitioner<Object> partitioner =
@@ -148,7 +150,7 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
     }
 
     @Test
-    public void testSerializeRecordWithHeaderProvider() throws Exception {
+    void testSerializeRecordWithHeaderProvider() throws Exception {
         final HeaderProvider<String> headerProvider =
                 (ignored) ->
                         new RecordHeaders(
@@ -169,7 +171,7 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
     }
 
     @Test
-    public void testSerializeRecordWithKey() {
+    void testSerializeRecordWithKey() {
         final SerializationSchema<String> serializationSchema = new SimpleStringSchema();
         final KafkaRecordSerializationSchema<String> schema =
                 KafkaRecordSerializationSchema.builder()
@@ -184,7 +186,7 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
     }
 
     @Test
-    public void testKafkaKeySerializerWrapperWithoutConfigurable() throws Exception {
+    void testKafkaKeySerializerWrapperWithoutConfigurable() throws Exception {
         final Map<String, String> config = Collections.singletonMap("simpleKey", "simpleValue");
         final KafkaRecordSerializationSchema<String> schema =
                 KafkaRecordSerializationSchema.builder()
@@ -201,7 +203,7 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
     }
 
     @Test
-    public void testKafkaValueSerializerWrapperWithoutConfigurable() throws Exception {
+    void testKafkaValueSerializerWrapperWithoutConfigurable() throws Exception {
         final Map<String, String> config = Collections.singletonMap("simpleKey", "simpleValue");
         final KafkaRecordSerializationSchema<String> schema =
                 KafkaRecordSerializationSchema.builder()
@@ -215,7 +217,7 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
     }
 
     @Test
-    public void testSerializeRecordWithKafkaSerializer() throws Exception {
+    void testSerializeRecordWithKafkaSerializer() throws Exception {
         final Map<String, String> config = Collections.singletonMap("configKey", "configValue");
         final KafkaRecordSerializationSchema<String> schema =
                 KafkaRecordSerializationSchema.builder()
@@ -231,7 +233,7 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
     }
 
     @Test
-    public void testSerializeRecordWithTimestamp() {
+    void testSerializeRecordWithTimestamp() {
         final SerializationSchema<String> serializationSchema = new SimpleStringSchema();
         final KafkaRecordSerializationSchema<String> schema =
                 KafkaRecordSerializationSchema.builder()

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
@@ -21,8 +21,8 @@ import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.connector.testutils.formats.DummyInitializationContext;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
-
 import org.apache.flink.util.TestLoggerExtension;
+
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.header.Header;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilderTest.java
@@ -41,7 +41,7 @@ public class KafkaSinkBuilderTest extends TestLogger {
             };
 
     @Test
-    public void testPropertyHandling() {
+    void testPropertyHandling() {
         validateProducerConfig(
                 getBasicBuilder(),
                 p -> {
@@ -78,7 +78,7 @@ public class KafkaSinkBuilderTest extends TestLogger {
     }
 
     @Test
-    public void testBootstrapServerSetting() {
+    void testBootstrapServerSetting() {
         Properties testConf1 = new Properties();
         testConf1.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "testServer");
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
@@ -59,30 +59,28 @@ import org.apache.flink.test.util.TestUtils;
 import org.apache.flink.testutils.junit.SharedObjects;
 import org.apache.flink.testutils.junit.SharedReference;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
-import org.apache.flink.util.DockerImageVersions;
-import org.apache.flink.util.TestLogger;
-
 import org.apache.flink.util.TestLoggerExtension;
+
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.testcontainers.junit.jupiter.Container;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.utility.DockerImageName;
 
 import javax.annotation.Nullable;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaTransactionLogITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaTransactionLogITCase.java
@@ -18,9 +18,8 @@
 package org.apache.flink.connector.kafka.sink;
 
 import org.apache.flink.connector.kafka.sink.KafkaTransactionLog.TransactionRecord;
-import org.apache.flink.util.TestLogger;
-
 import org.apache.flink.util.TestLoggerExtension;
+
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaTransactionLogITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaTransactionLogITCase.java
@@ -20,18 +20,20 @@ package org.apache.flink.connector.kafka.sink;
 import org.apache.flink.connector.kafka.sink.KafkaTransactionLog.TransactionRecord;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.flink.util.TestLoggerExtension;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
-import org.junit.After;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,25 +51,26 @@ import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createKafkaCo
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link KafkaTransactionLog} to retrieve abortable Kafka transactions. */
-public class KafkaTransactionLogITCase extends TestLogger {
+@ExtendWith({TestLoggerExtension.class})
+class KafkaTransactionLogITCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaSinkITCase.class);
     private static final String TOPIC_NAME = "kafkaTransactionLogTest";
     private static final String TRANSACTIONAL_ID_PREFIX = "kafka-log";
 
-    @ClassRule
+    @Container
     public static final KafkaContainer KAFKA_CONTAINER =
             createKafkaContainer(KAFKA, LOG).withEmbeddedZookeeper();
 
     private final List<Producer<byte[], Integer>> openProducers = new ArrayList<>();
 
-    @After
-    public void tearDown() {
+    @AfterEach
+    void tearDown() {
         openProducers.forEach(Producer::close);
     }
 
     @Test
-    public void testGetTransactions() {
+    void testGetTransactions() {
         committedTransaction(1);
         abortedTransaction(2);
         lingeringTransaction(3);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterStateSerializerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterStateSerializerTest.java
@@ -17,9 +17,7 @@
 
 package org.apache.flink.connector.kafka.sink;
 
-import org.apache.flink.util.TestLogger;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -29,12 +27,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for serializing and deserialzing {@link KafkaWriterState} with {@link
  * KafkaWriterStateSerializer}.
  */
-public class KafkaWriterStateSerializerTest extends TestLogger {
+class KafkaWriterStateSerializerTest {
 
     private static final KafkaWriterStateSerializer SERIALIZER = new KafkaWriterStateSerializer();
 
     @Test
-    public void testStateSerDe() throws IOException {
+    void testStateSerDe() throws IOException {
         final KafkaWriterState state = new KafkaWriterState("idPrefix");
         final byte[] serialized = SERIALIZER.serialize(state);
         assertThat(SERIALIZER.deserialize(1, serialized)).isEqualTo(state);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/TransactionIdFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/TransactionIdFactoryTest.java
@@ -19,15 +19,18 @@ package org.apache.flink.connector.kafka.sink;
 
 import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.apache.flink.util.TestLoggerExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link TransactionalIdFactory}. */
-public class TransactionIdFactoryTest extends TestLogger {
+@ExtendWith(TestLoggerExtension.class)
+class TransactionIdFactoryTest {
 
     @Test
-    public void testBuildTransactionalId() {
+    void testBuildTransactionalId() {
         final String expected = "prefix-0-2";
         assertThat(TransactionalIdFactory.buildTransactionalId("prefix", 0, 2L))
                 .isEqualTo(expected);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/TransactionIdFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/TransactionIdFactoryTest.java
@@ -17,9 +17,8 @@
 
 package org.apache.flink.connector.kafka.sink;
 
-import org.apache.flink.util.TestLogger;
-
 import org.apache.flink.util.TestLoggerExtension;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/TransactionToAbortCheckerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/TransactionToAbortCheckerTest.java
@@ -17,9 +17,7 @@
 
 package org.apache.flink.connector.kafka.sink;
 
-import org.apache.flink.util.TestLogger;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,13 +27,13 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link TransactionsToAbortChecker}. */
-public class TransactionToAbortCheckerTest extends TestLogger {
+class TransactionToAbortCheckerTest {
 
     public static final String ABORT = "abort";
     public static final String KEEP = "keep";
 
     @Test
-    public void testMustAbortTransactionsWithSameSubtaskIdAndHigherCheckpointOffset() {
+    void testMustAbortTransactionsWithSameSubtaskIdAndHigherCheckpointOffset() {
         Map<Integer, Long> offsetMapping = new HashMap<>(2);
         offsetMapping.put(0, 1L);
         offsetMapping.put(2, 3L);
@@ -63,7 +61,7 @@ public class TransactionToAbortCheckerTest extends TestLogger {
     }
 
     @Test
-    public void testMustAbortTransactionsIfLowestCheckpointOffsetIsMinimumOffset() {
+    void testMustAbortTransactionsIfLowestCheckpointOffsetIsMinimumOffset() {
         final TransactionsToAbortChecker checker =
                 new TransactionsToAbortChecker(2, Collections.singletonMap(0, 1L), 0);
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilderTest.java
@@ -42,10 +42,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link KafkaSourceBuilder}. */
 @ExtendWith(TestLoggerExtension.class)
-public class KafkaSourceBuilderTest {
+class KafkaSourceBuilderTest {
 
     @Test
-    public void testBuildSourceWithGroupId() {
+    void testBuildSourceWithGroupId() {
         final KafkaSource<String> kafkaSource = getBasicBuilder().setGroupId("groupId").build();
         // Commit on checkpoint should be enabled by default
         assertThat(
@@ -65,7 +65,7 @@ public class KafkaSourceBuilderTest {
     }
 
     @Test
-    public void testBuildSourceWithoutGroupId() {
+    void testBuildSourceWithoutGroupId() {
         final KafkaSource<String> kafkaSource = getBasicBuilder().build();
         // Commit on checkpoint and auto commit should be disabled because group.id is not specified
         assertThat(
@@ -84,7 +84,7 @@ public class KafkaSourceBuilderTest {
     }
 
     @Test
-    public void testEnableCommitOnCheckpointWithoutGroupId() {
+    void testEnableCommitOnCheckpointWithoutGroupId() {
         assertThatThrownBy(
                         () ->
                                 getBasicBuilder()
@@ -99,7 +99,7 @@ public class KafkaSourceBuilderTest {
     }
 
     @Test
-    public void testEnableAutoCommitWithoutGroupId() {
+    void testEnableAutoCommitWithoutGroupId() {
         assertThatThrownBy(
                         () ->
                                 getBasicBuilder()
@@ -112,7 +112,7 @@ public class KafkaSourceBuilderTest {
     }
 
     @Test
-    public void testDisableOffsetCommitWithoutGroupId() {
+    void testDisableOffsetCommitWithoutGroupId() {
         getBasicBuilder()
                 .setProperty(KafkaSourceOptions.COMMIT_OFFSETS_ON_CHECKPOINT.key(), "false")
                 .build();
@@ -120,7 +120,7 @@ public class KafkaSourceBuilderTest {
     }
 
     @Test
-    public void testUsingCommittedOffsetsInitializerWithoutGroupId() {
+    void testUsingCommittedOffsetsInitializerWithoutGroupId() {
         // Using OffsetsInitializer#committedOffsets as starting offsets
         assertThatThrownBy(
                         () ->
@@ -158,7 +158,7 @@ public class KafkaSourceBuilderTest {
     }
 
     @Test
-    public void testSettingCustomKafkaSubscriber() {
+    void testSettingCustomKafkaSubscriber() {
         ExampleCustomSubscriber exampleCustomSubscriber = new ExampleCustomSubscriber();
         KafkaSourceBuilder<String> customKafkaSubscriberBuilder =
                 new KafkaSourceBuilder<String>()

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
@@ -167,7 +167,7 @@ class KafkaSourceITCase {
             executeAndVerify(env, stream);
         }
 
-        @Test
+    @Test
     void testValueOnlyDeserializer() throws Exception {
             KafkaSource<Integer> source =
                     KafkaSource.<Integer>builder()
@@ -264,7 +264,7 @@ class KafkaSourceITCase {
             executeAndVerify(env, stream);
         }
 
-        @Test
+    @Test
     void testPerPartitionWatermark() throws Throwable {
             String watermarkTopic = "watermarkTestTopic-" + UUID.randomUUID();
             KafkaSourceTestEnv.createTestTopic(watermarkTopic, 2, 1);
@@ -311,7 +311,7 @@ class KafkaSourceITCase {
             env.execute();
         }
 
-        @Test
+    @Test
     void testConsumingEmptyTopic() throws Throwable {
             String emptyTopic = "emptyTopic-" + UUID.randomUUID();
             KafkaSourceTestEnv.createTestTopic(emptyTopic, 3, 1);
@@ -336,7 +336,7 @@ class KafkaSourceITCase {
             }
         }
 
-        @Test
+    @Test
     void testConsumingTopicWithEmptyPartitions() throws Throwable {
             String topicWithEmptyPartitions = "topicWithEmptyPartitions-" + UUID.randomUUID();
             KafkaSourceTestEnv.createTestTopic(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceITCase.java
@@ -83,7 +83,7 @@ import static org.apache.flink.connector.kafka.testutils.KafkaSourceExternalCont
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unite test class for {@link KafkaSource}. */
-public class KafkaSourceITCase {
+class KafkaSourceITCase {
     private static final String TOPIC1 = "topic1";
     private static final String TOPIC2 = "topic2";
 
@@ -168,7 +168,7 @@ public class KafkaSourceITCase {
         }
 
         @Test
-        public void testValueOnlyDeserializer() throws Exception {
+    void testValueOnlyDeserializer() throws Exception {
             KafkaSource<Integer> source =
                     KafkaSource.<Integer>builder()
                             .setBootstrapServers(KafkaSourceTestEnv.brokerConnectionStrings)
@@ -265,7 +265,7 @@ public class KafkaSourceITCase {
         }
 
         @Test
-        public void testPerPartitionWatermark() throws Throwable {
+    void testPerPartitionWatermark() throws Throwable {
             String watermarkTopic = "watermarkTestTopic-" + UUID.randomUUID();
             KafkaSourceTestEnv.createTestTopic(watermarkTopic, 2, 1);
             List<ProducerRecord<String, Integer>> records =
@@ -312,7 +312,7 @@ public class KafkaSourceITCase {
         }
 
         @Test
-        public void testConsumingEmptyTopic() throws Throwable {
+    void testConsumingEmptyTopic() throws Throwable {
             String emptyTopic = "emptyTopic-" + UUID.randomUUID();
             KafkaSourceTestEnv.createTestTopic(emptyTopic, 3, 1);
             KafkaSource<PartitionAndValue> source =
@@ -337,7 +337,7 @@ public class KafkaSourceITCase {
         }
 
         @Test
-        public void testConsumingTopicWithEmptyPartitions() throws Throwable {
+    void testConsumingTopicWithEmptyPartitions() throws Throwable {
             String topicWithEmptyPartitions = "topicWithEmptyPartitions-" + UUID.randomUUID();
             KafkaSourceTestEnv.createTestTopic(
                     topicWithEmptyPartitions, KafkaSourceTestEnv.NUM_PARTITIONS, 1);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceLegacyITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceLegacyITCase.java
@@ -23,75 +23,75 @@ import org.apache.flink.streaming.connectors.kafka.KafkaConsumerTestBase;
 import org.apache.flink.streaming.connectors.kafka.KafkaProducerTestBase;
 import org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironmentImpl;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * An IT case class that runs all the IT cases of the legacy {@link
  * org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer} with the new {@link KafkaSource}.
  */
-public class KafkaSourceLegacyITCase extends KafkaConsumerTestBase {
+class KafkaSourceLegacyITCase extends KafkaConsumerTestBase {
 
     public KafkaSourceLegacyITCase() throws Exception {
         super(true);
     }
 
-    @BeforeClass
-    public static void prepare() throws Exception {
+    @BeforeAll
+    protected static void prepare() throws Exception {
         KafkaProducerTestBase.prepare();
         ((KafkaTestEnvironmentImpl) kafkaServer)
                 .setProducerSemantic(FlinkKafkaProducer.Semantic.AT_LEAST_ONCE);
     }
 
     @Test
-    public void testFailOnNoBroker() throws Exception {
+    void testFailOnNoBroker() throws Exception {
         runFailOnNoBrokerTest();
     }
 
     @Test
-    public void testConcurrentProducerConsumerTopology() throws Exception {
+    void testConcurrentProducerConsumerTopology() throws Exception {
         runSimpleConcurrentProducerConsumerTopology();
     }
 
     @Test
-    public void testKeyValueSupport() throws Exception {
+    void testKeyValueSupport() throws Exception {
         runKeyValueTest();
     }
 
     // --- canceling / failures ---
 
     @Test
-    public void testCancelingEmptyTopic() throws Exception {
+    void testCancelingEmptyTopic() throws Exception {
         runCancelingOnEmptyInputTest();
     }
 
     @Test
-    public void testCancelingFullTopic() throws Exception {
+    void testCancelingFullTopic() throws Exception {
         runCancelingOnFullInputTest();
     }
 
     // --- source to partition mappings and exactly once ---
 
     @Test
-    public void testOneToOneSources() throws Exception {
+    void testOneToOneSources() throws Exception {
         runOneToOneExactlyOnceTest();
     }
 
     @Test
-    public void testOneSourceMultiplePartitions() throws Exception {
+    void testOneSourceMultiplePartitions() throws Exception {
         runOneSourceMultiplePartitionsExactlyOnceTest();
     }
 
     @Test
-    public void testMultipleSourcesOnePartition() throws Exception {
+    void testMultipleSourcesOnePartition() throws Exception {
         runMultipleSourcesOnePartitionExactlyOnceTest();
     }
 
     // --- broker failure ---
 
     @Test
-    @Ignore("FLINK-28267")
+    @Disabled("FLINK-28267")
     public void testBrokerFailure() throws Exception {
         runBrokerFailureTest();
     }
@@ -99,66 +99,66 @@ public class KafkaSourceLegacyITCase extends KafkaConsumerTestBase {
     // --- special executions ---
 
     @Test
-    public void testBigRecordJob() throws Exception {
+    void testBigRecordJob() throws Exception {
         runBigRecordTestTopology();
     }
 
     @Test
-    public void testMultipleTopicsWithLegacySerializer() throws Exception {
+    void testMultipleTopicsWithLegacySerializer() throws Exception {
         runProduceConsumeMultipleTopics(true);
     }
 
     @Test
-    public void testMultipleTopicsWithKafkaSerializer() throws Exception {
+    void testMultipleTopicsWithKafkaSerializer() throws Exception {
         runProduceConsumeMultipleTopics(false);
     }
 
     @Test
-    public void testAllDeletes() throws Exception {
+    void testAllDeletes() throws Exception {
         runAllDeletesTest();
     }
 
     // --- startup mode ---
 
     @Test
-    public void testStartFromEarliestOffsets() throws Exception {
+    void testStartFromEarliestOffsets() throws Exception {
         runStartFromEarliestOffsets();
     }
 
     @Test
-    public void testStartFromLatestOffsets() throws Exception {
+    void testStartFromLatestOffsets() throws Exception {
         runStartFromLatestOffsets();
     }
 
     @Test
-    public void testStartFromGroupOffsets() throws Exception {
+    void testStartFromGroupOffsets() throws Exception {
         runStartFromGroupOffsets();
     }
 
     @Test
-    public void testStartFromSpecificOffsets() throws Exception {
+    void testStartFromSpecificOffsets() throws Exception {
         runStartFromSpecificOffsets();
     }
 
     @Test
-    public void testStartFromTimestamp() throws Exception {
+    void testStartFromTimestamp() throws Exception {
         runStartFromTimestamp();
     }
 
     // --- offset committing ---
 
     @Test
-    public void testCommitOffsetsToKafka() throws Exception {
+    void testCommitOffsetsToKafka() throws Exception {
         runCommitOffsetsToKafka();
     }
 
     @Test
-    public void testAutoOffsetRetrievalAndCommitToKafka() throws Exception {
+    void testAutoOffsetRetrievalAndCommitToKafka() throws Exception {
         runAutoOffsetRetrievalAndCommitToKafka();
     }
 
     @Test
-    public void testCollectingSchema() throws Exception {
+    void testCollectingSchema() throws Exception {
         runCollectingSchemaTest();
     }
 }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
@@ -35,9 +35,10 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,7 +57,7 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for {@link KafkaSourceEnumerator}. */
-public class KafkaEnumeratorTest {
+class KafkaEnumeratorTest {
     private static final int NUM_SUBTASKS = 3;
     private static final String DYNAMIC_TOPIC_NAME = "dynamic_topic";
     private static final int NUM_PARTITIONS_DYNAMIC_TOPIC = 4;
@@ -75,20 +76,20 @@ public class KafkaEnumeratorTest {
     private static final boolean INCLUDE_DYNAMIC_TOPIC = true;
     private static final boolean EXCLUDE_DYNAMIC_TOPIC = false;
 
-    @BeforeClass
-    public static void setup() throws Throwable {
+    @BeforeAll
+    static void setup() throws Throwable {
         KafkaSourceTestEnv.setup();
         KafkaSourceTestEnv.setupTopic(TOPIC1, true, true, KafkaSourceTestEnv::getRecordsForTopic);
         KafkaSourceTestEnv.setupTopic(TOPIC2, true, true, KafkaSourceTestEnv::getRecordsForTopic);
     }
 
-    @AfterClass
-    public static void tearDown() throws Exception {
+    @AfterAll
+    static void tearDown() throws Exception {
         KafkaSourceTestEnv.tearDown();
     }
 
     @Test
-    public void testStartWithDiscoverPartitionsOnce() throws Exception {
+    void testStartWithDiscoverPartitionsOnce() throws Exception {
         try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 KafkaSourceEnumerator enumerator =
@@ -109,7 +110,7 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testStartWithPeriodicPartitionDiscovery() throws Exception {
+    void testStartWithPeriodicPartitionDiscovery() throws Exception {
         try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 KafkaSourceEnumerator enumerator =
@@ -130,7 +131,7 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testDiscoverPartitionsTriggersAssignments() throws Throwable {
+    void testDiscoverPartitionsTriggersAssignments() throws Throwable {
         try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 KafkaSourceEnumerator enumerator =
@@ -155,7 +156,7 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testReaderRegistrationTriggersAssignments() throws Throwable {
+    void testReaderRegistrationTriggersAssignments() throws Throwable {
         try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 KafkaSourceEnumerator enumerator =
@@ -178,7 +179,7 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testRunWithDiscoverPartitionsOnceToCheckNoMoreSplit() throws Throwable {
+    void testRunWithDiscoverPartitionsOnceToCheckNoMoreSplit() throws Throwable {
         try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 KafkaSourceEnumerator enumerator =
@@ -202,7 +203,7 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testRunWithPeriodicPartitionDiscoveryOnceToCheckNoMoreSplit() throws Throwable {
+    void testRunWithPeriodicPartitionDiscoveryOnceToCheckNoMoreSplit() throws Throwable {
         try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 KafkaSourceEnumerator enumerator =
@@ -226,7 +227,7 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testRunWithDiscoverPartitionsOnceWithZeroMsToCheckNoMoreSplit() throws Throwable {
+    void testRunWithDiscoverPartitionsOnceWithZeroMsToCheckNoMoreSplit() throws Throwable {
         try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 // Disable periodic partition discovery
@@ -249,8 +250,9 @@ public class KafkaEnumeratorTest {
         }
     }
 
-    @Test(timeout = 30000L)
-    public void testDiscoverPartitionsPeriodically() throws Throwable {
+    @Test
+    @Timeout(30L)
+    void testDiscoverPartitionsPeriodically() throws Throwable {
         try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 KafkaSourceEnumerator enumerator =
@@ -317,7 +319,7 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testAddSplitsBack() throws Throwable {
+    void testAddSplitsBack() throws Throwable {
         try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 KafkaSourceEnumerator enumerator =
@@ -342,7 +344,7 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testWorkWithPreexistingAssignments() throws Throwable {
+    void testWorkWithPreexistingAssignments() throws Throwable {
         Set<TopicPartition> preexistingAssignments;
         try (MockSplitEnumeratorContext<KafkaPartitionSplit> context1 =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
@@ -377,7 +379,7 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testKafkaClientProperties() throws Exception {
+    void testKafkaClientProperties() throws Exception {
         Properties properties = new Properties();
         String clientIdPrefix = "test-prefix";
         Integer defaultTimeoutMs = 99999;
@@ -410,7 +412,7 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testSnapshotState() throws Throwable {
+    void testSnapshotState() throws Throwable {
         try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 KafkaSourceEnumerator enumerator = createEnumerator(context, false)) {
@@ -463,7 +465,7 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testPartitionChangeChecking() throws Throwable {
+    void testPartitionChangeChecking() throws Throwable {
         try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 KafkaSourceEnumerator enumerator =
@@ -500,7 +502,7 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testEnablePartitionDiscoveryByDefault() throws Throwable {
+    void testEnablePartitionDiscoveryByDefault() throws Throwable {
         try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 KafkaSourceEnumerator enumerator = createEnumerator(context, new Properties())) {
@@ -514,7 +516,7 @@ public class KafkaEnumeratorTest {
     }
 
     @Test
-    public void testDisablePartitionDiscovery() throws Throwable {
+    void testDisablePartitionDiscovery() throws Throwable {
         Properties props = new Properties();
         props.setProperty(
                 KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(), String.valueOf(0));

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumStateSerializerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumStateSerializerTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplitSerializer;
 
 import org.apache.kafka.common.TopicPartition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -35,7 +35,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link KafkaSourceEnumStateSerializer}. */
-public class KafkaSourceEnumStateSerializerTest {
+class KafkaSourceEnumStateSerializerTest {
 
     private static final int NUM_READERS = 10;
     private static final String TOPIC_PREFIX = "topic-";
@@ -43,7 +43,7 @@ public class KafkaSourceEnumStateSerializerTest {
     private static final long STARTING_OFFSET = KafkaPartitionSplit.EARLIEST_OFFSET;
 
     @Test
-    public void testEnumStateSerde() throws IOException {
+    void testEnumStateSerde() throws IOException {
         final KafkaSourceEnumState state =
                 new KafkaSourceEnumState(
                         constructTopicPartitions(0),
@@ -63,7 +63,7 @@ public class KafkaSourceEnumStateSerializerTest {
     }
 
     @Test
-    public void testBackwardCompatibility() throws IOException {
+    void testBackwardCompatibility() throws IOException {
 
         final Set<TopicPartition> topicPartitions = constructTopicPartitions(0);
         final Map<Integer, Set<KafkaPartitionSplit>> splitAssignments =

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberTest.java
@@ -23,9 +23,9 @@ import org.apache.flink.connector.kafka.testutils.KafkaSourceTestEnv;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,28 +39,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Unit tests for {@link KafkaSubscriber}. */
-public class KafkaSubscriberTest {
+class KafkaSubscriberTest {
     private static final String TOPIC1 = "topic1";
     private static final String TOPIC2 = "pattern-topic";
     private static final TopicPartition NON_EXISTING_TOPIC = new TopicPartition("removed", 0);
     private static AdminClient adminClient;
 
-    @BeforeClass
-    public static void setup() throws Throwable {
+    @BeforeAll
+    static void setup() throws Throwable {
         KafkaSourceTestEnv.setup();
         KafkaSourceTestEnv.createTestTopic(TOPIC1);
         KafkaSourceTestEnv.createTestTopic(TOPIC2);
         adminClient = KafkaSourceTestEnv.getAdminClient();
     }
 
-    @AfterClass
-    public static void tearDown() throws Exception {
+    @AfterAll
+    static void tearDown() throws Exception {
         adminClient.close();
         KafkaSourceTestEnv.tearDown();
     }
 
     @Test
-    public void testTopicListSubscriber() {
+    void testTopicListSubscriber() {
         List<String> topics = Arrays.asList(TOPIC1, TOPIC2);
         KafkaSubscriber subscriber =
                 KafkaSubscriber.getTopicListSubscriber(Arrays.asList(TOPIC1, TOPIC2));
@@ -74,7 +74,7 @@ public class KafkaSubscriberTest {
     }
 
     @Test
-    public void testNonExistingTopic() {
+    void testNonExistingTopic() {
         final KafkaSubscriber subscriber =
                 KafkaSubscriber.getTopicListSubscriber(
                         Collections.singletonList(NON_EXISTING_TOPIC.topic()));
@@ -85,7 +85,7 @@ public class KafkaSubscriberTest {
     }
 
     @Test
-    public void testTopicPatternSubscriber() {
+    void testTopicPatternSubscriber() {
         KafkaSubscriber subscriber =
                 KafkaSubscriber.getTopicPatternSubscriber(Pattern.compile("pattern.*"));
         final Set<TopicPartition> subscribedPartitions =
@@ -99,7 +99,7 @@ public class KafkaSubscriberTest {
     }
 
     @Test
-    public void testPartitionSetSubscriber() {
+    void testPartitionSetSubscriber() {
         List<String> topics = Arrays.asList(TOPIC1, TOPIC2);
         Set<TopicPartition> partitions =
                 new HashSet<>(KafkaSourceTestEnv.getPartitionsForTopics(topics));
@@ -114,7 +114,7 @@ public class KafkaSubscriberTest {
     }
 
     @Test
-    public void testNonExistingPartition() {
+    void testNonExistingPartition() {
         TopicPartition nonExistingPartition = new TopicPartition(TOPIC1, Integer.MAX_VALUE);
         final KafkaSubscriber subscriber =
                 KafkaSubscriber.getPartitionSetSubscriber(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetricsTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/metrics/KafkaSourceReaderMetricsTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.metrics.testutils.MetricListener;
 import org.apache.flink.runtime.metrics.groups.InternalSourceReaderMetricGroup;
 
 import org.apache.kafka.common.TopicPartition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
@@ -42,7 +42,7 @@ public class KafkaSourceReaderMetricsTest {
     private static final TopicPartition BAR_1 = new TopicPartition("bar", 1);
 
     @Test
-    public void testCurrentOffsetTracking() {
+    void testCurrentOffsetTracking() {
         MetricListener metricListener = new MetricListener();
 
         final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
@@ -66,7 +66,7 @@ public class KafkaSourceReaderMetricsTest {
     }
 
     @Test
-    public void testCommitOffsetTracking() {
+    void testCommitOffsetTracking() {
         MetricListener metricListener = new MetricListener();
 
         final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
@@ -101,7 +101,7 @@ public class KafkaSourceReaderMetricsTest {
     }
 
     @Test
-    public void testNonTrackingTopicPartition() {
+    void testNonTrackingTopicPartition() {
         MetricListener metricListener = new MetricListener();
         final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
                 new KafkaSourceReaderMetrics(
@@ -113,7 +113,7 @@ public class KafkaSourceReaderMetricsTest {
     }
 
     @Test
-    public void testFailedCommit() {
+    void testFailedCommit() {
         MetricListener metricListener = new MetricListener();
         final KafkaSourceReaderMetrics kafkaSourceReaderMetrics =
                 new KafkaSourceReaderMetrics(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -100,14 +100,14 @@ public class KafkaPartitionSplitReaderTest {
     }
 
     @Test
-    public void testHandleSplitChangesAndFetch() throws Exception {
+    void testHandleSplitChangesAndFetch() throws Exception {
         KafkaPartitionSplitReader reader = createReader();
         assignSplitsAndFetchUntilFinish(reader, 0);
         assignSplitsAndFetchUntilFinish(reader, 1);
     }
 
     @Test
-    public void testWakeUp() throws Exception {
+    void testWakeUp() throws Exception {
         KafkaPartitionSplitReader reader = createReader();
         TopicPartition nonExistingTopicPartition = new TopicPartition("NotExist", 0);
         assignSplits(
@@ -136,7 +136,7 @@ public class KafkaPartitionSplitReaderTest {
     }
 
     @Test
-    public void testWakeupThenAssign() throws IOException {
+    void testWakeupThenAssign() throws IOException {
         KafkaPartitionSplitReader reader = createReader();
         // Assign splits with records
         assignSplits(reader, splitsByOwners.get(0));
@@ -154,7 +154,7 @@ public class KafkaPartitionSplitReaderTest {
     }
 
     @Test
-    public void testNumBytesInCounter() throws Exception {
+    void testNumBytesInCounter() throws Exception {
         final OperatorMetricGroup operatorMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup();
         final Counter numBytesInCounter =
@@ -236,7 +236,7 @@ public class KafkaPartitionSplitReaderTest {
     }
 
     @Test
-    public void testAssignEmptySplit() throws Exception {
+    void testAssignEmptySplit() throws Exception {
         KafkaPartitionSplitReader reader = createReader();
         final KafkaPartitionSplit normalSplit =
                 new KafkaPartitionSplit(
@@ -276,7 +276,7 @@ public class KafkaPartitionSplitReaderTest {
     }
 
     @Test
-    public void testUsingCommittedOffsetsWithNoneOffsetResetStrategy() {
+    void testUsingCommittedOffsetsWithNoneOffsetResetStrategy() {
         final Properties props = new Properties();
         props.setProperty(
                 ConsumerConfig.GROUP_ID_CONFIG, "using-committed-offset-with-none-offset-reset");
@@ -321,7 +321,7 @@ public class KafkaPartitionSplitReaderTest {
     }
 
     @Test
-    public void testConsumerClientRackSupplier() {
+    void testConsumerClientRackSupplier() {
         String rackId = "use1-az1";
         Properties properties = new Properties();
         KafkaPartitionSplitReader reader =

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
@@ -461,7 +461,7 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
     }
 
     @Test
-    public void testSupportsPausingOrResumingSplits() throws Exception {
+    void testSupportsPausingOrResumingSplits() throws Exception {
         final Set<String> finishedSplits = new HashSet<>();
 
         try (final KafkaSourceReader<Integer> reader =
@@ -507,7 +507,7 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
     }
 
     @Test
-    public void testThatReaderDoesNotCallRackIdSupplierOnInit() throws Exception {
+    void testThatReaderDoesNotCallRackIdSupplierOnInit() throws Exception {
         SerializableSupplier<String> rackIdSupplier = Mockito.mock(SerializableSupplier.class);
 
         try (KafkaSourceReader<Integer> reader =
@@ -525,7 +525,7 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
     }
 
     @Test
-    public void testThatReaderDoesCallRackIdSupplierOnSplitAssignment() throws Exception {
+    void testThatReaderDoesCallRackIdSupplierOnSplitAssignment() throws Exception {
         SerializableSupplier<String> rackIdSupplier = Mockito.mock(SerializableSupplier.class);
         Mockito.when(rackIdSupplier.get()).thenReturn("use1-az1");
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializationSchemaTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializationSchemaTest.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for KafkaRecordDeserializationSchema. */
-public class KafkaRecordDeserializationSchemaTest {
+class KafkaRecordDeserializationSchemaTest {
 
     private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
 
@@ -52,8 +52,8 @@ public class KafkaRecordDeserializationSchemaTest {
     private static Map<String, ?> configuration;
     private static boolean isKeyDeserializer;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         configurableConfiguration = new HashMap<>(1);
         configuration = new HashMap<>(1);
         isKeyDeserializer = false;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializationSchemaTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializationSchemaTest.java
@@ -32,8 +32,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -60,7 +60,7 @@ public class KafkaRecordDeserializationSchemaTest {
     }
 
     @Test
-    public void testKafkaDeserializationSchemaWrapper() throws Exception {
+    void testKafkaDeserializationSchemaWrapper() throws Exception {
         final ConsumerRecord<byte[], byte[]> consumerRecord = getConsumerRecord();
         KafkaRecordDeserializationSchema<ObjectNode> schema =
                 KafkaRecordDeserializationSchema.of(new JSONKeyValueDeserializationSchema(true));
@@ -79,7 +79,7 @@ public class KafkaRecordDeserializationSchemaTest {
     }
 
     @Test
-    public void testKafkaValueDeserializationSchemaWrapper() throws Exception {
+    void testKafkaValueDeserializationSchemaWrapper() throws Exception {
         final ConsumerRecord<byte[], byte[]> consumerRecord = getConsumerRecord();
         KafkaRecordDeserializationSchema<
                         org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node
@@ -105,7 +105,7 @@ public class KafkaRecordDeserializationSchemaTest {
     }
 
     @Test
-    public void testKafkaValueDeserializerWrapper() throws Exception {
+    void testKafkaValueDeserializerWrapper() throws Exception {
         final String topic = "Topic";
         byte[] value = new StringSerializer().serialize(topic, "world");
         final ConsumerRecord<byte[], byte[]> consumerRecord =
@@ -122,7 +122,7 @@ public class KafkaRecordDeserializationSchemaTest {
     }
 
     @Test
-    public void testKafkaValueDeserializerWrapperWithoutConfigurable() throws Exception {
+    void testKafkaValueDeserializerWrapperWithoutConfigurable() throws Exception {
         final Map<String, String> config = Collections.singletonMap("simpleKey", "simpleValue");
         KafkaRecordDeserializationSchema<String> schema =
                 KafkaRecordDeserializationSchema.valueOnly(SimpleStringSerializer.class, config);
@@ -133,7 +133,7 @@ public class KafkaRecordDeserializationSchemaTest {
     }
 
     @Test
-    public void testKafkaValueDeserializerWrapperWithConfigurable() throws Exception {
+    void testKafkaValueDeserializerWrapperWithConfigurable() throws Exception {
         final Map<String, String> config = Collections.singletonMap("configKey", "configValue");
         KafkaRecordDeserializationSchema<String> schema =
                 KafkaRecordDeserializationSchema.valueOnly(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitSerializerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitSerializerTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class KafkaPartitionSplitSerializerTest {
 
     @Test
-    public void testSerializer() throws IOException {
+    void testSerializer() throws IOException {
         String topic = "topic";
         Long offsetZero = 0L;
         Long normalOffset = 1L;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkFixedPartitionerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkFixedPartitionerTest.java
@@ -20,12 +20,12 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartitioner;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link FlinkFixedPartitioner}. */
-public class FlinkFixedPartitionerTest {
+class FlinkFixedPartitionerTest {
 
     /**
      * Test for when there are more sinks than partitions.
@@ -39,7 +39,7 @@ public class FlinkFixedPartitionerTest {
      * </pre>
      */
     @Test
-    public void testMoreFlinkThanBrokers() {
+    void testMoreFlinkThanBrokers() {
         FlinkFixedPartitioner<String> part = new FlinkFixedPartitioner<>();
 
         int[] partitions = new int[] {0};
@@ -73,7 +73,7 @@ public class FlinkFixedPartitionerTest {
      * </pre>
      */
     @Test
-    public void testFewerPartitions() {
+    void testFewerPartitions() {
         FlinkFixedPartitioner<String> part = new FlinkFixedPartitioner<>();
 
         int[] partitions = new int[] {0, 1, 2, 3, 4};
@@ -93,7 +93,7 @@ public class FlinkFixedPartitionerTest {
      * 			3	----------/
      */
     @Test
-    public void testMixedCase() {
+    void testMixedCase() {
         FlinkFixedPartitioner<String> part = new FlinkFixedPartitioner<>();
         int[] partitions = new int[] {0, 1};
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
@@ -36,12 +36,13 @@ import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicsDescriptor;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OperatorSnapshotUtil;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.SerializedValue;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -66,7 +67,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
  * <p>For regenerating the binary snapshot files run {@link #writeSnapshot()} on the corresponding
  * Flink release-* branch.
  */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class FlinkKafkaConsumerBaseMigrationTest {
 
     /**
@@ -90,7 +91,7 @@ public class FlinkKafkaConsumerBaseMigrationTest {
 
     private final FlinkVersion testMigrateVersion;
 
-    @Parameterized.Parameters(name = "Migration Savepoint: {0}")
+    @Parameters(name = "Migration Savepoint: {0}")
     public static Collection<FlinkVersion> parameters() {
         return FlinkVersion.rangeOf(FlinkVersion.v1_8, FlinkVersion.v1_16);
     }
@@ -100,9 +101,9 @@ public class FlinkKafkaConsumerBaseMigrationTest {
     }
 
     /** Manually run this to write binary snapshot data. */
-    @Ignore
+    @Disabled
     @Test
-    public void writeSnapshot() throws Exception {
+    void writeSnapshot() throws Exception {
         writeSnapshot(
                 "src/test/resources/kafka-consumer-migration-test-flink"
                         + flinkGenerateSavepointVersion
@@ -194,7 +195,7 @@ public class FlinkKafkaConsumerBaseMigrationTest {
 
     /** Test restoring from an legacy empty state, when no partitions could be found for topics. */
     @Test
-    public void testRestoreFromEmptyStateNoPartitions() throws Exception {
+    void testRestoreFromEmptyStateNoPartitions() throws Exception {
         final DummyFlinkKafkaConsumer<String> consumerFunction =
                 new DummyFlinkKafkaConsumer<>(
                         Collections.singletonList("dummy-topic"),
@@ -235,7 +236,7 @@ public class FlinkKafkaConsumerBaseMigrationTest {
      * could be found for topics.
      */
     @Test
-    public void testRestoreFromEmptyStateWithPartitions() throws Exception {
+    void testRestoreFromEmptyStateWithPartitions() throws Exception {
         final List<KafkaTopicPartition> partitions = new ArrayList<>(PARTITION_STATE.keySet());
 
         final DummyFlinkKafkaConsumer<String> consumerFunction =
@@ -295,7 +296,7 @@ public class FlinkKafkaConsumerBaseMigrationTest {
      * partitions could be found for topics.
      */
     @Test
-    public void testRestore() throws Exception {
+    void testRestore() throws Exception {
         final List<KafkaTopicPartition> partitions = new ArrayList<>(PARTITION_STATE.keySet());
 
         final DummyFlinkKafkaConsumer<String> consumerFunction =

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -69,7 +69,7 @@ import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.SupplierWithException;
 import org.apache.flink.util.function.ThrowingRunnable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
@@ -102,14 +102,14 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 /** Tests for the {@link FlinkKafkaConsumerBase}. */
-public class FlinkKafkaConsumerBaseTest extends TestLogger {
+class FlinkKafkaConsumerBaseTest {
 
     private static final int maxParallelism = Short.MAX_VALUE / 2;
 
     /** Tests that not both types of timestamp extractors / watermark generators can be used. */
     @Test
     @SuppressWarnings("unchecked")
-    public void testEitherWatermarkExtractor() {
+    void testEitherWatermarkExtractor() {
         assertThatThrownBy(
                         () ->
                                 new DummyFlinkKafkaConsumer<String>()
@@ -142,7 +142,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
 
     /** Tests that no checkpoints happen when the fetcher is not running. */
     @Test
-    public void ignoreCheckpointWhenNotRunning() throws Exception {
+    void ignoreCheckpointWhenNotRunning() throws Exception {
         @SuppressWarnings("unchecked")
         final MockFetcher<String> fetcher = new MockFetcher<>();
         final FlinkKafkaConsumerBase<String> consumer =
@@ -170,7 +170,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
      * correctly contains the restored state instead.
      */
     @Test
-    public void checkRestoredCheckpointWhenFetcherNotReady() throws Exception {
+    void checkRestoredCheckpointWhenFetcherNotReady() throws Exception {
         @SuppressWarnings("unchecked")
         final FlinkKafkaConsumerBase<String> consumer = new DummyFlinkKafkaConsumer<>();
 
@@ -203,7 +203,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
     }
 
     @Test
-    public void testConfigureOnCheckpointsCommitMode() throws Exception {
+    void testConfigureOnCheckpointsCommitMode() throws Exception {
         @SuppressWarnings("unchecked")
         // auto-commit enabled; this should be ignored in this case
         final DummyFlinkKafkaConsumer<String> consumer = new DummyFlinkKafkaConsumer<>(true);
@@ -216,7 +216,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
     }
 
     @Test
-    public void testConfigureAutoCommitMode() throws Exception {
+    void testConfigureAutoCommitMode() throws Exception {
         @SuppressWarnings("unchecked")
         final DummyFlinkKafkaConsumer<String> consumer = new DummyFlinkKafkaConsumer<>(true);
 
@@ -226,7 +226,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
     }
 
     @Test
-    public void testConfigureDisableOffsetCommitWithCheckpointing() throws Exception {
+    void testConfigureDisableOffsetCommitWithCheckpointing() throws Exception {
         @SuppressWarnings("unchecked")
         // auto-commit enabled; this should be ignored in this case
         final DummyFlinkKafkaConsumer<String> consumer = new DummyFlinkKafkaConsumer<>(true);
@@ -241,7 +241,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
     }
 
     @Test
-    public void testConfigureDisableOffsetCommitWithoutCheckpointing() throws Exception {
+    void testConfigureDisableOffsetCommitWithoutCheckpointing() throws Exception {
         @SuppressWarnings("unchecked")
         final DummyFlinkKafkaConsumer<String> consumer = new DummyFlinkKafkaConsumer<>(false);
 
@@ -255,7 +255,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
      * (filterRestoredPartitionsWithDiscovered is active)
      */
     @Test
-    public void testSetFilterRestoredParitionsNoChange() throws Exception {
+    void testSetFilterRestoredParitionsNoChange() throws Exception {
         checkFilterRestoredPartitionsWithDisovered(
                 Arrays.asList(new String[] {"kafka_topic_1", "kafka_topic_2"}),
                 Arrays.asList(new String[] {"kafka_topic_1", "kafka_topic_2"}),
@@ -268,7 +268,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
      * in restored partitions. (filterRestoredPartitionsWithDiscovered is active)
      */
     @Test
-    public void testSetFilterRestoredParitionsWithRemovedTopic() throws Exception {
+    void testSetFilterRestoredParitionsWithRemovedTopic() throws Exception {
         checkFilterRestoredPartitionsWithDisovered(
                 Arrays.asList(new String[] {"kafka_topic_1", "kafka_topic_2"}),
                 Arrays.asList(new String[] {"kafka_topic_1"}),
@@ -281,7 +281,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
      * (filterRestoredPartitionsWithDiscovered is active)
      */
     @Test
-    public void testSetFilterRestoredParitionsWithAddedTopic() throws Exception {
+    void testSetFilterRestoredParitionsWithAddedTopic() throws Exception {
         checkFilterRestoredPartitionsWithDisovered(
                 Arrays.asList(new String[] {"kafka_topic_1"}),
                 Arrays.asList(new String[] {"kafka_topic_1", "kafka_topic_2"}),
@@ -294,7 +294,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
      * (filterRestoredPartitionsWithDiscovered is disabled)
      */
     @Test
-    public void testDisableFilterRestoredParitionsNoChange() throws Exception {
+    void testDisableFilterRestoredParitionsNoChange() throws Exception {
         checkFilterRestoredPartitionsWithDisovered(
                 Arrays.asList(new String[] {"kafka_topic_1", "kafka_topic_2"}),
                 Arrays.asList(new String[] {"kafka_topic_1", "kafka_topic_2"}),
@@ -307,7 +307,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
      * still in restored partitions. (filterRestoredPartitionsWithDiscovered is disabled)
      */
     @Test
-    public void testDisableFilterRestoredParitionsWithRemovedTopic() throws Exception {
+    void testDisableFilterRestoredParitionsWithRemovedTopic() throws Exception {
         checkFilterRestoredPartitionsWithDisovered(
                 Arrays.asList(new String[] {"kafka_topic_1", "kafka_topic_2"}),
                 Arrays.asList(new String[] {"kafka_topic_1"}),
@@ -320,7 +320,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
      * (filterRestoredPartitionsWithDiscovered is disabled)
      */
     @Test
-    public void testDisableFilterRestoredParitionsWithAddedTopic() throws Exception {
+    void testDisableFilterRestoredParitionsWithAddedTopic() throws Exception {
         checkFilterRestoredPartitionsWithDisovered(
                 Arrays.asList(new String[] {"kafka_topic_1"}),
                 Arrays.asList(new String[] {"kafka_topic_1", "kafka_topic_2"}),
@@ -598,7 +598,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
     }
 
     @Test
-    public void testClosePartitionDiscovererWhenOpenThrowException() throws Exception {
+    void testClosePartitionDiscovererWhenOpenThrowException() throws Exception {
         final RuntimeException failureCause =
                 new RuntimeException(new FlinkException("Test partition discoverer exception"));
         final FailingPartitionDiscoverer failingPartitionDiscoverer =
@@ -614,7 +614,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
     }
 
     @Test
-    public void testClosePartitionDiscovererWhenCreateKafkaFetcherFails() throws Exception {
+    void testClosePartitionDiscovererWhenCreateKafkaFetcherFails() throws Exception {
         final FlinkException failureCause = new FlinkException("Create Kafka fetcher failure.");
 
         final DummyPartitionDiscoverer testPartitionDiscoverer = new DummyPartitionDiscoverer();
@@ -633,7 +633,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
     }
 
     @Test
-    public void testClosePartitionDiscovererWhenKafkaFetcherFails() throws Exception {
+    void testClosePartitionDiscovererWhenKafkaFetcherFails() throws Exception {
         final FlinkException failureCause = new FlinkException("Run Kafka fetcher failure.");
 
         // in this scenario, the partition discoverer will be concurrently accessed;
@@ -674,7 +674,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
     }
 
     @Test
-    public void testClosePartitionDiscovererWithCancellation() throws Exception {
+    void testClosePartitionDiscovererWithCancellation() throws Exception {
         final DummyPartitionDiscoverer testPartitionDiscoverer = new DummyPartitionDiscoverer();
 
         final TestingFlinkKafkaConsumer<String> consumer =
@@ -707,7 +707,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
      * that the two methods create compatible serializers.
      */
     @Test
-    public void testExplicitStateSerializerCompatibility() throws Exception {
+    void testExplicitStateSerializerCompatibility() throws Exception {
         ExecutionConfig executionConfig = new ExecutionConfig();
 
         Tuple2<KafkaTopicPartition, Long> tuple =
@@ -733,12 +733,12 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
     }
 
     @Test
-    public void testScaleUp() throws Exception {
+    void testScaleUp() throws Exception {
         testRescaling(5, 2, 8, 30);
     }
 
     @Test
-    public void testScaleDown() throws Exception {
+    void testScaleDown() throws Exception {
         testRescaling(5, 10, 2, 100);
     }
 
@@ -883,7 +883,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
     }
 
     @Test
-    public void testOpen() throws Exception {
+    void testOpen() throws Exception {
         MockDeserializationSchema<Object> deserializationSchema = new MockDeserializationSchema<>();
 
         AbstractStreamOperatorTestHarness<Object> testHarness =
@@ -898,7 +898,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
     }
 
     @Test
-    public void testOpenWithRestoreState() throws Exception {
+    void testOpenWithRestoreState() throws Exception {
         MockDeserializationSchema<String> deserializationSchema = new MockDeserializationSchema<>();
         final FlinkKafkaConsumerBase<String> consumer =
                 new DummyFlinkKafkaConsumer<>(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -65,7 +65,6 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
-import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.SupplierWithException;
 import org.apache.flink.util.function.ThrowingRunnable;
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerITCase.java
@@ -34,13 +34,13 @@ import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.junit.ClassRule;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.junit.jupiter.Container;
 
 import java.nio.file.Path;
 import java.util.Properties;
@@ -48,10 +48,10 @@ import java.util.concurrent.CountDownLatch;
 
 /** ITCase tests class for {@link FlinkKafkaConsumer}. */
 @TestInstance(Lifecycle.PER_CLASS)
-public class FlinkKafkaConsumerITCase {
+class FlinkKafkaConsumerITCase {
     private static final String TOPIC1 = "FlinkKafkaConsumerITCase_topic1";
 
-    @ClassRule
+    @Container
     public static final MiniClusterWithClientResource MINI_CLUSTER =
             new MiniClusterWithClientResource(
                     new MiniClusterResourceConfiguration.Builder()
@@ -71,7 +71,7 @@ public class FlinkKafkaConsumerITCase {
     }
 
     @Test
-    public void testStopWithSavepoint(@TempDir Path savepointsDir) throws Exception {
+    void testStopWithSavepoint(@TempDir Path savepointsDir) throws Exception {
         Configuration config =
                 new Configuration()
                         .set(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerITCase.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.jupiter.api.AfterAll;
@@ -52,8 +52,8 @@ class FlinkKafkaConsumerITCase {
     private static final String TOPIC1 = "FlinkKafkaConsumerITCase_topic1";
 
     @Container
-    public static final MiniClusterWithClientResource MINI_CLUSTER =
-            new MiniClusterWithClientResource(
+    public static final MiniClusterExtension MINI_CLUSTER =
+            new MiniClusterExtension(
                     new MiniClusterResourceConfiguration.Builder()
                             .setConfiguration(new Configuration())
                             .build());

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerITCase.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.jupiter.api.AfterAll;
@@ -52,8 +52,8 @@ class FlinkKafkaConsumerITCase {
     private static final String TOPIC1 = "FlinkKafkaConsumerITCase_topic1";
 
     @Container
-    public static final MiniClusterExtension MINI_CLUSTER =
-            new MiniClusterExtension(
+    public static final MiniClusterWithClientResource MINI_CLUSTER =
+            new MiniClusterWithClientResource(
                     new MiniClusterResourceConfiguration.Builder()
                             .setConfiguration(new Configuration())
                             .build());

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
@@ -27,8 +27,8 @@ import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBaseTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBaseTest.java
@@ -40,15 +40,18 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
@@ -58,16 +61,22 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /** Tests for the {@link FlinkKafkaProducerBase}. */
-public class FlinkKafkaProducerBaseTest {
+class FlinkKafkaProducerBaseTest {
 
     /** Tests that the constructor eagerly checks bootstrap servers are set in config. */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInstantiationFailsWhenBootstrapServersMissing() throws Exception {
         // no bootstrap servers set in props
         Properties props = new Properties();
         // should throw IllegalArgumentException
-        new DummyFlinkKafkaProducer<>(
-                props, new KeyedSerializationSchemaWrapper<>(new SimpleStringSchema()), null);
+        assertThatThrownBy(
+                () ->
+                        new DummyFlinkKafkaProducer<>(
+                                props,
+                                new KeyedSerializationSchemaWrapper<>(
+                                        new SimpleStringSchema()),
+                                null))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     /**
@@ -75,7 +84,7 @@ public class FlinkKafkaProducerBaseTest {
      * deserializers if not set.
      */
     @Test
-    public void testKeyValueDeserializersSetIfMissing() throws Exception {
+    void testKeyValueDeserializersSetIfMissing() throws Exception {
         Properties props = new Properties();
         props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:12345");
         // should set missing key value deserializers
@@ -94,7 +103,7 @@ public class FlinkKafkaProducerBaseTest {
     /** Tests that partitions list is determinate and correctly provided to custom partitioner. */
     @SuppressWarnings("unchecked")
     @Test
-    public void testPartitionerInvokedWithDeterminatePartitionList() throws Exception {
+    void testPartitionerInvokedWithDeterminatePartitionList() throws Exception {
         FlinkKafkaPartitioner<String> mockPartitioner = mock(FlinkKafkaPartitioner.class);
 
         RuntimeContext mockRuntimeContext = mock(StreamingRuntimeContext.class);
@@ -141,7 +150,7 @@ public class FlinkKafkaProducerBaseTest {
      * should be rethrown.
      */
     @Test
-    public void testAsyncErrorRethrownOnInvoke() throws Throwable {
+    void testAsyncErrorRethrownOnInvoke() throws Throwable {
         final DummyFlinkKafkaProducer<String> producer =
                 new DummyFlinkKafkaProducer<>(
                         FakeStandardProducerConfig.get(),
@@ -178,7 +187,7 @@ public class FlinkKafkaProducerBaseTest {
      * should be rethrown.
      */
     @Test
-    public void testAsyncErrorRethrownOnCheckpoint() throws Throwable {
+    void testAsyncErrorRethrownOnCheckpoint() throws Throwable {
         final DummyFlinkKafkaProducer<String> producer =
                 new DummyFlinkKafkaProducer<>(
                         FakeStandardProducerConfig.get(),
@@ -219,8 +228,9 @@ public class FlinkKafkaProducerBaseTest {
      * pending records. The test for that is covered in testAtLeastOnceProducer.
      */
     @SuppressWarnings("unchecked")
-    @Test(timeout = 5000)
-    public void testAsyncErrorRethrownOnCheckpointAfterFlush() throws Throwable {
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void testAsyncErrorRethrownOnCheckpointAfterFlush() throws Throwable {
         final DummyFlinkKafkaProducer<String> producer =
                 new DummyFlinkKafkaProducer<>(
                         FakeStandardProducerConfig.get(),
@@ -280,8 +290,9 @@ public class FlinkKafkaProducerBaseTest {
      * the test will not finish if the logic is broken.
      */
     @SuppressWarnings("unchecked")
-    @Test(timeout = 10000)
-    public void testAtLeastOnceProducer() throws Throwable {
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testAtLeastOnceProducer() throws Throwable {
         final DummyFlinkKafkaProducer<String> producer =
                 new DummyFlinkKafkaProducer<>(
                         FakeStandardProducerConfig.get(),
@@ -353,8 +364,9 @@ public class FlinkKafkaProducerBaseTest {
      * records; we set a timeout because the test will not finish if the logic is broken.
      */
     @SuppressWarnings("unchecked")
-    @Test(timeout = 5000)
-    public void testDoesNotWaitForPendingRecordsIfFlushingDisabled() throws Throwable {
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    void testDoesNotWaitForPendingRecordsIfFlushingDisabled() throws Throwable {
         final DummyFlinkKafkaProducer<String> producer =
                 new DummyFlinkKafkaProducer<>(
                         FakeStandardProducerConfig.get(),

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerITCase.java
@@ -30,9 +30,9 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
 
 import org.apache.kafka.common.errors.ProducerFencedException;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -57,7 +57,7 @@ import static org.assertj.core.api.Assertions.fail;
  * <p>Do not run this class in the same junit execution with other tests in your IDE. This may lead
  * leaking threads.
  */
-public class FlinkKafkaProducerITCase extends KafkaTestBase {
+class FlinkKafkaProducerITCase extends KafkaTestBase {
 
     protected String transactionalId;
     protected Properties extraProperties;
@@ -68,8 +68,8 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
     protected KeyedSerializationSchema<Integer> integerKeyedSerializationSchema =
             new KeyedSerializationSchemaWrapper<>(integerSerializationSchema);
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         transactionalId = UUID.randomUUID().toString();
         extraProperties = new Properties();
         extraProperties.putAll(standardProps);
@@ -86,12 +86,12 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
     }
 
     @Test
-    public void resourceCleanUpNone() throws Exception {
+    void resourceCleanUpNone() throws Exception {
         resourceCleanUp(FlinkKafkaProducer.Semantic.NONE);
     }
 
     @Test
-    public void resourceCleanUpAtLeastOnce() throws Exception {
+    void resourceCleanUpAtLeastOnce() throws Exception {
         resourceCleanUp(FlinkKafkaProducer.Semantic.AT_LEAST_ONCE);
     }
 
@@ -125,7 +125,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
      * will not clash with previous transactions using same transactional.ids.
      */
     @Test
-    public void testRestoreToCheckpointAfterExceedingProducersPool() throws Exception {
+    void testRestoreToCheckpointAfterExceedingProducersPool() throws Exception {
         String topic = "flink-kafka-producer-fail-before-notify";
 
         try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness1 =
@@ -171,8 +171,8 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
 
     /** This test hangs when running it in your IDE. */
     @Test
-    @Ignore
-    public void testFlinkKafkaProducerFailBeforeNotify() throws Exception {
+    @Disabled
+    void testFlinkKafkaProducerFailBeforeNotify() throws Exception {
         String topic = "flink-kafka-producer-fail-before-notify";
 
         final OneInputStreamOperatorTestHarness<Integer, Object> testHarness =
@@ -220,7 +220,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
      * committed records that were created after this lingering transaction.
      */
     @Test
-    public void testFailBeforeNotifyAndResumeWorkAfterwards() throws Exception {
+    void testFailBeforeNotifyAndResumeWorkAfterwards() throws Exception {
         String topic = "flink-kafka-producer-fail-before-notify";
 
         OneInputStreamOperatorTestHarness<Integer, Object> testHarness1 = createTestHarness(topic);
@@ -274,7 +274,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
     }
 
     @Test
-    public void testFailAndRecoverSameCheckpointTwice() throws Exception {
+    void testFailAndRecoverSameCheckpointTwice() throws Exception {
         String topic = "flink-kafka-producer-fail-and-recover-same-checkpoint-twice";
 
         OperatorSubtaskState snapshot1;
@@ -331,7 +331,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
      * read committed records that were created after this lingering transaction.
      */
     @Test
-    public void testScaleDownBeforeFirstCheckpoint() throws Exception {
+    void testScaleDownBeforeFirstCheckpoint() throws Exception {
         String topic = "scale-down-before-first-checkpoint";
 
         List<AutoCloseable> operatorsToClose = new ArrayList<>();
@@ -401,7 +401,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
      * so it has to generate new ones that are greater then 4.
      */
     @Test
-    public void testScaleUpAfterScalingDown() throws Exception {
+    void testScaleUpAfterScalingDown() throws Exception {
         String topic = "scale-up-after-scaling-down";
 
         final int parallelism1 = 4;
@@ -531,7 +531,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
     }
 
     @Test
-    public void testRecoverCommittedTransaction() throws Exception {
+    void testRecoverCommittedTransaction() throws Exception {
         String topic = "flink-kafka-producer-recover-committed-transaction";
 
         OneInputStreamOperatorTestHarness<Integer, Object> testHarness = createTestHarness(topic);
@@ -560,7 +560,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
     }
 
     @Test
-    public void testRunOutOfProducersInThePool() throws Exception {
+    void testRunOutOfProducersInThePool() throws Exception {
         String topic = "flink-kafka-run-out-of-producers";
 
         try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness =
@@ -583,7 +583,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
     }
 
     @Test
-    public void testMigrateFromAtLeastOnceToExactlyOnce() throws Exception {
+    void testMigrateFromAtLeastOnceToExactlyOnce() throws Exception {
         String topic = "testMigrateFromAtLeastOnceToExactlyOnce";
         testRecoverWithChangeSemantics(
                 topic,
@@ -594,7 +594,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
     }
 
     @Test
-    public void testMigrateFromAtExactlyOnceToAtLeastOnce() throws Exception {
+    void testMigrateFromAtExactlyOnceToAtLeastOnce() throws Exception {
         String topic = "testMigrateFromExactlyOnceToAtLeastOnce";
         testRecoverWithChangeSemantics(
                 topic,
@@ -605,7 +605,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
     }
 
     @Test
-    public void testDefaultTransactionalIdPrefix() throws Exception {
+    void testDefaultTransactionalIdPrefix() throws Exception {
         Properties properties = createProperties();
         String topic = "testCustomizeTransactionalIdPrefix";
         FlinkKafkaProducer<Integer> kafkaProducer =
@@ -642,7 +642,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
     }
 
     @Test
-    public void testCustomizeTransactionalIdPrefix() throws Exception {
+    void testCustomizeTransactionalIdPrefix() throws Exception {
         String transactionalIdPrefix = "my-prefix";
 
         Properties properties = createProperties();
@@ -675,7 +675,7 @@ public class FlinkKafkaProducerITCase extends KafkaTestBase {
     }
 
     @Test
-    public void testRestoreUsingDifferentTransactionalIdPrefix() throws Exception {
+    void testRestoreUsingDifferentTransactionalIdPrefix() throws Exception {
         String topic = "testCustomizeTransactionalIdPrefix";
         Properties properties = createProperties();
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerMigrationOperatorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerMigrationOperatorTest.java
@@ -19,9 +19,9 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.FlinkVersion;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.Ignore;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Disabled;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -34,8 +34,8 @@ import java.util.Collection;
  * by the {@link #getOperatorSnapshotPath(FlinkVersion)} method then copy the resource to the path
  * also specified by the {@link #getOperatorSnapshotPath(FlinkVersion)} method.
  */
-public class FlinkKafkaProducerMigrationOperatorTest extends FlinkKafkaProducerMigrationTest {
-    @Parameterized.Parameters(name = "Migration Savepoint: {0}")
+class FlinkKafkaProducerMigrationOperatorTest extends FlinkKafkaProducerMigrationTest {
+    @Parameters(name = "Migration Savepoint: {0}")
     public static Collection<FlinkVersion> parameters() {
         return Arrays.asList(
                 FlinkVersion.v1_8, FlinkVersion.v1_9, FlinkVersion.v1_10, FlinkVersion.v1_11);
@@ -52,7 +52,7 @@ public class FlinkKafkaProducerMigrationOperatorTest extends FlinkKafkaProducerM
                 + "-snapshot";
     }
 
-    @Ignore
+    @Disabled
     @Override
     public void writeSnapshot() throws Exception {
         throw new UnsupportedOperationException();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerMigrationTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerMigrationTest.java
@@ -23,10 +23,11 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collection;
 import java.util.Properties;
@@ -38,9 +39,9 @@ import java.util.Properties;
  * <p>For regenerating the binary snapshot files run {@link #writeSnapshot()} on the corresponding
  * Flink release-* branch.
  */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class FlinkKafkaProducerMigrationTest extends KafkaMigrationTestBase {
-    @Parameterized.Parameters(name = "Migration Savepoint: {0}")
+    @Parameters(name = "Migration Savepoint: {0}")
     public static Collection<FlinkVersion> parameters() {
         return FlinkVersion.rangeOf(FlinkVersion.v1_8, FlinkVersion.v1_16);
     }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartiti
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -34,11 +34,12 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link FlinkKafkaProducer}. */
-public class FlinkKafkaProducerTest {
+class FlinkKafkaProducerTest {
     @Test
-    public void testOpenSerializationSchemaProducer() throws Exception {
+    void testOpenSerializationSchemaProducer() throws Exception {
         OpenTestingSerializationSchema schema = new OpenTestingSerializationSchema();
         FlinkKafkaProducer<Integer> kafkaProducer =
                 new FlinkKafkaProducer<>("localhost:9092", "test-topic", schema);
@@ -58,7 +59,7 @@ public class FlinkKafkaProducerTest {
     }
 
     @Test
-    public void testOpenKafkaSerializationSchemaProducer() throws Exception {
+    void testOpenKafkaSerializationSchemaProducer() throws Exception {
         OpenTestingKafkaSerializationSchema schema = new OpenTestingKafkaSerializationSchema();
         Properties properties = new Properties();
         properties.put("bootstrap.servers", "localhost:9092");
@@ -84,7 +85,7 @@ public class FlinkKafkaProducerTest {
     }
 
     @Test
-    public void testOpenKafkaCustomPartitioner() throws Exception {
+    void testOpenKafkaCustomPartitioner() throws Exception {
         CustomPartitioner<Integer> partitioner = new CustomPartitioner<>();
         Properties properties = new Properties();
         properties.put("bootstrap.servers", "localhost:9092");
@@ -109,12 +110,13 @@ public class FlinkKafkaProducerTest {
         assertThat(partitioner.openCalled).isTrue();
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testProvidedNullTransactionalIdPrefix() {
         FlinkKafkaProducer<Integer> kafkaProducer =
                 new FlinkKafkaProducer<>(
                         "localhost:9092", "test-topic", new OpenTestingSerializationSchema());
-        kafkaProducer.setTransactionalIdPrefix(null);
+        assertThatThrownBy(() -> kafkaProducer.setTransactionalIdPrefix(null))
+                .isInstanceOf(NullPointerException.class);
     }
 
     private static class CustomPartitioner<T> extends FlinkKafkaPartitioner<T> {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/JSONKeyValueDeserializationSchemaTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/JSONKeyValueDeserializationSchemaTest.java
@@ -24,17 +24,17 @@ import org.apache.flink.streaming.util.serialization.JSONKeyValueDeserialization
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the{@link JSONKeyValueDeserializationSchema}. */
-public class JSONKeyValueDeserializationSchemaTest {
+class JSONKeyValueDeserializationSchemaTest {
 
     private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
 
     @Test
-    public void testDeserializeWithoutMetadata() throws Exception {
+    void testDeserializeWithoutMetadata() throws Exception {
         ObjectNode initialKey = OBJECT_MAPPER.createObjectNode();
         initialKey.put("index", 4);
         byte[] serializedKey = OBJECT_MAPPER.writeValueAsBytes(initialKey);
@@ -54,7 +54,7 @@ public class JSONKeyValueDeserializationSchemaTest {
     }
 
     @Test
-    public void testDeserializeWithoutKey() throws Exception {
+    void testDeserializeWithoutKey() throws Exception {
         byte[] serializedKey = null;
 
         ObjectNode initialValue = OBJECT_MAPPER.createObjectNode();
@@ -87,7 +87,7 @@ public class JSONKeyValueDeserializationSchemaTest {
     }
 
     @Test
-    public void testDeserializeWithoutValue() throws Exception {
+    void testDeserializeWithoutValue() throws Exception {
         ObjectNode initialKey = OBJECT_MAPPER.createObjectNode();
         initialKey.put("index", 4);
         byte[] serializedKey = OBJECT_MAPPER.writeValueAsBytes(initialKey);
@@ -105,7 +105,7 @@ public class JSONKeyValueDeserializationSchemaTest {
     }
 
     @Test
-    public void testDeserializeWithMetadata() throws Exception {
+    void testDeserializeWithMetadata() throws Exception {
         ObjectNode initialKey = OBJECT_MAPPER.createObjectNode();
         initialKey.put("index", 4);
         byte[] serializedKey = OBJECT_MAPPER.writeValueAsBytes(initialKey);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -88,7 +88,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.NotLeaderForPartitionException;
 import org.apache.kafka.common.errors.TimeoutException;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import javax.annotation.Nullable;
 import javax.management.MBeanServer;
@@ -143,8 +143,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
      * Makes sure that no job is on the JobManager any more from any previous tests that use the
      * same mini cluster. Otherwise, missing slots may happen.
      */
-    @Before
-    public void setClientAndEnsureNoJobIsLingering() throws Exception {
+    @BeforeEach
+    void setClientAndEnsureNoJobIsLingering() throws Exception {
         client = flink.getClusterClient();
         waitUntilNoJobIsRunning(client);
     }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
@@ -38,8 +38,9 @@ import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartiti
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.annotation.Nullable;
 
@@ -47,12 +48,13 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 /** IT cases for Kafka. */
-public class KafkaITCase extends KafkaConsumerTestBase {
+class KafkaITCase extends KafkaConsumerTestBase {
 
-    @BeforeClass
-    public static void prepare() throws Exception {
+    @BeforeAll
+    protected static void prepare() throws Exception {
         KafkaProducerTestBase.prepare();
         ((KafkaTestEnvironmentImpl) kafkaServer)
                 .setProducerSemantic(FlinkKafkaProducer.Semantic.AT_LEAST_ONCE);
@@ -62,130 +64,153 @@ public class KafkaITCase extends KafkaConsumerTestBase {
     //  Suite of Tests
     // ------------------------------------------------------------------------
 
-    @Test(timeout = 120000)
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
     public void testFailOnNoBroker() throws Exception {
         runFailOnNoBrokerTest();
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testConcurrentProducerConsumerTopology() throws Exception {
         runSimpleConcurrentProducerConsumerTopology();
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testKeyValueSupport() throws Exception {
         runKeyValueTest();
     }
 
     // --- canceling / failures ---
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testCancelingEmptyTopic() throws Exception {
         runCancelingOnEmptyInputTest();
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testCancelingFullTopic() throws Exception {
         runCancelingOnFullInputTest();
     }
 
     // --- source to partition mappings and exactly once ---
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testOneToOneSources() throws Exception {
         runOneToOneExactlyOnceTest();
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testOneSourceMultiplePartitions() throws Exception {
         runOneSourceMultiplePartitionsExactlyOnceTest();
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testMultipleSourcesOnePartition() throws Exception {
         runMultipleSourcesOnePartitionExactlyOnceTest();
     }
 
     // --- broker failure ---
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testBrokerFailure() throws Exception {
         runBrokerFailureTest();
     }
 
     // --- special executions ---
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testBigRecordJob() throws Exception {
         runBigRecordTestTopology();
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testMultipleTopicsWithLegacySerializer() throws Exception {
         runProduceConsumeMultipleTopics(true);
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testMultipleTopicsWithKafkaSerializer() throws Exception {
         runProduceConsumeMultipleTopics(false);
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testAllDeletes() throws Exception {
         runAllDeletesTest();
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testMetricsAndEndOfStream() throws Exception {
         runEndOfStreamTest();
     }
 
     // --- startup mode ---
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testStartFromEarliestOffsets() throws Exception {
         runStartFromEarliestOffsets();
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testStartFromLatestOffsets() throws Exception {
         runStartFromLatestOffsets();
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testStartFromGroupOffsets() throws Exception {
         runStartFromGroupOffsets();
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testStartFromSpecificOffsets() throws Exception {
         runStartFromSpecificOffsets();
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testStartFromTimestamp() throws Exception {
         runStartFromTimestamp();
     }
 
     // --- offset committing ---
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testCommitOffsetsToKafka() throws Exception {
         runCommitOffsetsToKafka();
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testAutoOffsetRetrievalAndCommitToKafka() throws Exception {
         runAutoOffsetRetrievalAndCommitToKafka();
     }
 
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testCollectingSchema() throws Exception {
         runCollectingSchemaTest();
     }
 
     /** Kafka 20 specific test, ensuring Timestamps are properly written to and read from Kafka. */
-    @Test(timeout = 60000)
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testTimestamps() throws Exception {
 
         final String topic = "tstopic-" + UUID.randomUUID();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaMigrationTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaMigrationTestBase.java
@@ -27,10 +27,10 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OperatorSnapshotUtil;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,20 +79,20 @@ public abstract class KafkaMigrationTestBase extends KafkaTestBase {
      * Override {@link KafkaTestBase}. Kafka Migration Tests are starting up Kafka/ZooKeeper cluster
      * manually
      */
-    @BeforeClass
-    public static void prepare() throws Exception {}
+    @BeforeAll
+    protected static void prepare() throws Exception {}
 
     /**
      * Override {@link KafkaTestBase}. Kafka Migration Tests are starting up Kafka/ZooKeeper cluster
      * manually
      */
-    @AfterClass
-    public static void shutDownServices() throws Exception {}
+    @AfterAll
+    protected static void shutDownServices() throws Exception {}
 
     /** Manually run this to write binary snapshot data. */
-    @Ignore
+    @Disabled
     @Test
-    public void writeSnapshot() throws Exception {
+    void writeSnapshot() throws Exception {
         try {
             checkState(flinkGenerateSavepointVersion.isPresent());
             startClusters();
@@ -129,7 +129,7 @@ public abstract class KafkaMigrationTestBase extends KafkaTestBase {
 
     @SuppressWarnings("warning")
     @Test
-    public void testRestoreProducer() throws Exception {
+    void testRestoreProducer() throws Exception {
         try {
             startClusters();
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerAtLeastOnceITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerAtLeastOnceITCase.java
@@ -18,14 +18,14 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 /** IT cases for the {@link FlinkKafkaProducer}. */
 @SuppressWarnings("serial")
-public class KafkaProducerAtLeastOnceITCase extends KafkaProducerTestBase {
+class KafkaProducerAtLeastOnceITCase extends KafkaProducerTestBase {
 
-    @BeforeClass
-    public static void prepare() throws Exception {
+    @BeforeAll
+    protected static void prepare() throws Exception {
         KafkaProducerTestBase.prepare();
         ((KafkaTestEnvironmentImpl) kafkaServer)
                 .setProducerSemantic(FlinkKafkaProducer.Semantic.AT_LEAST_ONCE);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerExactlyOnceITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerExactlyOnceITCase.java
@@ -18,21 +18,21 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /** IT cases for the {@link FlinkKafkaProducer}. */
 @SuppressWarnings("serial")
-public class KafkaProducerExactlyOnceITCase extends KafkaProducerTestBase {
-    @BeforeClass
-    public static void prepare() throws Exception {
+class KafkaProducerExactlyOnceITCase extends KafkaProducerTestBase {
+    @BeforeAll
+    protected static void prepare() throws Exception {
         KafkaProducerTestBase.prepare();
         ((KafkaTestEnvironmentImpl) kafkaServer)
                 .setProducerSemantic(FlinkKafkaProducer.Semantic.EXACTLY_ONCE);
     }
 
     @Test
-    public void testMultipleSinkOperators() throws Exception {
+    void testMultipleSinkOperators() throws Exception {
         testExactlyOnce(false, 2);
     }
 }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
@@ -40,7 +40,7 @@ import org.apache.flink.test.util.SuccessException;
 import org.apache.flink.test.util.TestUtils;
 import org.apache.flink.util.Preconditions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -87,7 +87,7 @@ public abstract class KafkaProducerTestBase extends KafkaTestBaseWithFlink {
      * partitions are present.
      */
     @Test
-    public void testCustomPartitioning() {
+    void testCustomPartitioning() {
         try {
             LOG.info("Starting KafkaProducerITCase.testCustomPartitioning()");
 
@@ -204,13 +204,13 @@ public abstract class KafkaProducerTestBase extends KafkaTestBaseWithFlink {
 
     /** Tests the exactly-once semantic for the simple writes into Kafka. */
     @Test
-    public void testExactlyOnceRegularSink() throws Exception {
+    void testExactlyOnceRegularSink() throws Exception {
         testExactlyOnce(true, 1);
     }
 
     /** Tests the exactly-once semantic for the simple writes into Kafka. */
     @Test
-    public void testExactlyOnceCustomOperator() throws Exception {
+    void testExactlyOnceCustomOperator() throws Exception {
         testExactlyOnce(false, 1);
     }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
@@ -36,9 +36,9 @@ import org.apache.flink.util.InstantiationUtil;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.testcontainers.junit.jupiter.Container;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
 
 import java.io.Serializable;
 import java.util.Properties;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
@@ -34,14 +34,15 @@ import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.util.InstantiationUtil;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.junit.jupiter.Container;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import java.nio.file.Path;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -65,7 +66,7 @@ public class KafkaShortRetentionTestBase implements Serializable {
     private static KafkaTestEnvironment kafkaServer;
     private static Properties standardProps;
 
-    @ClassRule
+    @Container
     public static MiniClusterWithClientResource flink =
             new MiniClusterWithClientResource(
                     new MiniClusterResourceConfiguration.Builder()
@@ -74,7 +75,7 @@ public class KafkaShortRetentionTestBase implements Serializable {
                             .setNumberSlotsPerTaskManager(TM_SLOTS)
                             .build());
 
-    @ClassRule public static TemporaryFolder tempFolder = new TemporaryFolder();
+    @TempDir public Path tempFolder;
 
     protected static Properties secureProps = new Properties();
 
@@ -84,8 +85,8 @@ public class KafkaShortRetentionTestBase implements Serializable {
         return flinkConfig;
     }
 
-    @BeforeClass
-    public static void prepare() throws Exception {
+    @BeforeAll
+    static void prepare() throws Exception {
         LOG.info("-------------------------------------------------------------------------");
         LOG.info("    Starting KafkaShortRetentionTestBase ");
         LOG.info("-------------------------------------------------------------------------");
@@ -113,8 +114,8 @@ public class KafkaShortRetentionTestBase implements Serializable {
         standardProps = kafkaServer.getStandardProperties();
     }
 
-    @AfterClass
-    public static void shutDownServices() throws Exception {
+    @AfterAll
+    static void shutDownServices() throws Exception {
         kafkaServer.shutdown();
 
         secureProps.clear();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
@@ -30,7 +30,7 @@ import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.util.InstantiationUtil;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -65,8 +65,8 @@ class KafkaShortRetentionTestBase implements Serializable {
     private static Properties standardProps;
 
     @Container
-    public static MiniClusterWithClientResource flink =
-            new MiniClusterWithClientResource(
+    public static MiniClusterExtension flink =
+            new MiniClusterExtension (
                     new MiniClusterResourceConfiguration.Builder()
                             .setConfiguration(getConfiguration())
                             .setNumberTaskManagers(NUM_TMS)

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
@@ -30,7 +30,7 @@ import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
-import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.util.InstantiationUtil;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -65,8 +65,8 @@ class KafkaShortRetentionTestBase implements Serializable {
     private static Properties standardProps;
 
     @Container
-    public static MiniClusterExtension flink =
-            new MiniClusterExtension (
+    public static MiniClusterWithClientResource flink =
+            new MiniClusterWithClientResource(
                     new MiniClusterResourceConfiguration.Builder()
                             .setConfiguration(getConfiguration())
                             .setNumberTaskManagers(NUM_TMS)

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
@@ -36,13 +36,11 @@ import org.apache.flink.util.InstantiationUtil;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.junit.jupiter.Container;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
-import java.nio.file.Path;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -53,7 +51,7 @@ import static org.apache.flink.test.util.TestUtils.tryExecute;
  * can make sure our consumer is properly handling cases where we run into out of offset errors
  */
 @SuppressWarnings("serial")
-public class KafkaShortRetentionTestBase implements Serializable {
+class KafkaShortRetentionTestBase implements Serializable {
 
     protected static final Logger LOG = LoggerFactory.getLogger(KafkaShortRetentionTestBase.class);
 
@@ -74,8 +72,6 @@ public class KafkaShortRetentionTestBase implements Serializable {
                             .setNumberTaskManagers(NUM_TMS)
                             .setNumberSlotsPerTaskManager(TM_SLOTS)
                             .build());
-
-    @TempDir public Path tempFolder;
 
     protected static Properties secureProps = new Properties();
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -95,9 +95,6 @@ public abstract class KafkaTestBase {
 
     public static List<KafkaClusterTestEnvMetadata> kafkaClusters = new ArrayList<>();
 
-    @TempDir
-    public static File temporaryFolder;
-
     public static Properties secureProps = new Properties();
 
     // ------------------------------------------------------------------------

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -29,7 +29,6 @@ import org.apache.flink.streaming.util.TestStreamEnvironment;
 import org.apache.flink.test.util.SuccessException;
 import org.apache.flink.testutils.junit.RetryOnFailure;
 import org.apache.flink.util.InstantiationUtil;
-import org.apache.flink.util.TestLogger;
 
 import com.google.common.base.MoreObjects;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -39,9 +38,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.io.TempDir;
-
-import java.io.File;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBaseWithFlink.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBaseWithFlink.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.connectors.kafka;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 
-import org.junit.ClassRule;
+import org.testcontainers.junit.jupiter.Container;
 
 /** The base for the Kafka tests with Flink's MiniCluster. */
 @SuppressWarnings("serial")
@@ -30,7 +30,7 @@ public abstract class KafkaTestBaseWithFlink extends KafkaTestBase {
 
     protected static final int TM_SLOTS = 8;
 
-    @ClassRule
+    @Container
     public static MiniClusterWithClientResource flink =
             new MiniClusterWithClientResource(
                     new MiniClusterResourceConfiguration.Builder()

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBaseWithFlink.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBaseWithFlink.java
@@ -18,7 +18,7 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 
 import org.testcontainers.junit.jupiter.Container;
 
@@ -31,8 +31,8 @@ public abstract class KafkaTestBaseWithFlink extends KafkaTestBase {
     protected static final int TM_SLOTS = 8;
 
     @Container
-    public static MiniClusterWithClientResource flink =
-            new MiniClusterWithClientResource(
+    public static MiniClusterExtension flink =
+            new MiniClusterExtension(
                     new MiniClusterResourceConfiguration.Builder()
                             .setConfiguration(getFlinkConfiguration())
                             .setNumberTaskManagers(NUM_TMS)

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBaseWithFlink.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBaseWithFlink.java
@@ -18,7 +18,7 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
-import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
 
 import org.testcontainers.junit.jupiter.Container;
 
@@ -31,8 +31,8 @@ public abstract class KafkaTestBaseWithFlink extends KafkaTestBase {
     protected static final int TM_SLOTS = 8;
 
     @Container
-    public static MiniClusterExtension flink =
-            new MiniClusterExtension(
+    public static MiniClusterWithClientResource flink =
+            new MiniClusterWithClientResource(
                     new MiniClusterResourceConfiguration.Builder()
                             .setConfiguration(getFlinkConfiguration())
                             .setNumberTaskManagers(NUM_TMS)

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTest.java
@@ -28,7 +28,7 @@ import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.util.SerializedValue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
@@ -43,10 +43,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link AbstractFetcher}. */
 @SuppressWarnings("serial")
-public class AbstractFetcherTest {
+class AbstractFetcherTest {
 
     @Test
-    public void testIgnorePartitionStateSentinelInSnapshot() throws Exception {
+    void testIgnorePartitionStateSentinelInSnapshot() throws Exception {
         final String testTopic = "test topic name";
         Map<KafkaTopicPartition, Long> originalPartitions = new HashMap<>();
         originalPartitions.put(
@@ -93,7 +93,7 @@ public class AbstractFetcherTest {
     // ------------------------------------------------------------------------
 
     @Test
-    public void testSkipCorruptedRecord() throws Exception {
+    void testSkipCorruptedRecord() throws Exception {
         final String testTopic = "test topic name";
         Map<KafkaTopicPartition, Long> originalPartitions = new HashMap<>();
         originalPartitions.put(
@@ -127,7 +127,7 @@ public class AbstractFetcherTest {
     }
 
     @Test
-    public void testConcurrentPartitionsDiscoveryAndLoopFetching() throws Exception {
+    void testConcurrentPartitionsDiscoveryAndLoopFetching() throws Exception {
         // test data
         final KafkaTopicPartition testPartition = new KafkaTopicPartition("test", 42);
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherWatermarksTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherWatermarksTest.java
@@ -31,12 +31,15 @@ import org.apache.flink.streaming.runtime.operators.util.AssignerWithPeriodicWat
 import org.apache.flink.streaming.runtime.operators.util.AssignerWithPunctuatedWatermarksAdapter;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.SerializedValue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.experimental.runners.Enclosed;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -54,14 +57,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the watermarking behaviour of {@link AbstractFetcher}. */
 @SuppressWarnings("serial")
-@RunWith(Enclosed.class)
-public class AbstractFetcherWatermarksTest {
+class AbstractFetcherWatermarksTest {
 
     /** Tests with watermark generators that have a periodic nature. */
-    @RunWith(Parameterized.class)
+    @ExtendWith(ParameterizedTestExtension.class)
     public static class PeriodicWatermarksSuite {
 
-        @Parameterized.Parameters
+        @Parameters
         public static Collection<WatermarkStrategy<Long>> getParams() {
             return Arrays.asList(
                     new AssignerWithPeriodicWatermarksAdapter.Strategy<>(
@@ -70,10 +72,10 @@ public class AbstractFetcherWatermarksTest {
                             .withTimestampAssigner((event, previousTimestamp) -> event));
         }
 
-        @Parameterized.Parameter public WatermarkStrategy<Long> testWmStrategy;
+        @Parameter public WatermarkStrategy<Long> testWmStrategy;
 
         @Test
-        public void testPeriodicWatermarks() throws Exception {
+        void testPeriodicWatermarks() throws Exception {
             final String testTopic = "test topic name";
             Map<KafkaTopicPartition, Long> originalPartitions = new HashMap<>();
             originalPartitions.put(
@@ -161,7 +163,7 @@ public class AbstractFetcherWatermarksTest {
         }
 
         @Test
-        public void testSkipCorruptedRecordWithPeriodicWatermarks() throws Exception {
+        void testSkipCorruptedRecordWithPeriodicWatermarks() throws Exception {
             final String testTopic = "test topic name";
             Map<KafkaTopicPartition, Long> originalPartitions = new HashMap<>();
             originalPartitions.put(
@@ -212,7 +214,7 @@ public class AbstractFetcherWatermarksTest {
         }
 
         @Test
-        public void testPeriodicWatermarksWithNoSubscribedPartitionsShouldYieldNoWatermarks()
+        void testPeriodicWatermarksWithNoSubscribedPartitionsShouldYieldNoWatermarks()
                 throws Exception {
             final String testTopic = "test topic name";
             Map<KafkaTopicPartition, Long> originalPartitions = new HashMap<>();
@@ -248,7 +250,7 @@ public class AbstractFetcherWatermarksTest {
     public static class PunctuatedWatermarksSuite {
 
         @Test
-        public void testSkipCorruptedRecordWithPunctuatedWatermarks() throws Exception {
+        void testSkipCorruptedRecordWithPunctuatedWatermarks() throws Exception {
             final String testTopic = "test topic name";
             Map<KafkaTopicPartition, Long> originalPartitions = new HashMap<>();
             originalPartitions.put(
@@ -296,7 +298,7 @@ public class AbstractFetcherWatermarksTest {
         }
 
         @Test
-        public void testPunctuatedWatermarks() throws Exception {
+        void testPunctuatedWatermarks() throws Exception {
             final String testTopic = "test topic name";
             Map<KafkaTopicPartition, Long> originalPartitions = new HashMap<>();
             originalPartitions.put(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherWatermarksTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherWatermarksTest.java
@@ -37,9 +37,7 @@ import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.SerializedValue;
 
 import org.junit.jupiter.api.Test;
-import org.junit.experimental.runners.Enclosed;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractPartitionDiscovererTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractPartitionDiscovererTest.java
@@ -20,7 +20,10 @@ package org.apache.flink.streaming.connectors.kafka.internals;
 
 import org.apache.flink.streaming.connectors.kafka.testutils.TestPartitionDiscoverer;
 
-import org.junit.Test;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -40,7 +43,7 @@ import static org.assertj.core.api.Assertions.fail;
  * Tests that the partition assignment in the partition discoverer is deterministic and stable, with
  * both fixed and growing partitions.
  */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class AbstractPartitionDiscovererTest {
 
     private static final String TEST_TOPIC = "test-topic";
@@ -52,7 +55,7 @@ public class AbstractPartitionDiscovererTest {
         this.topicsDescriptor = topicsDescriptor;
     }
 
-    @Parameterized.Parameters(name = "KafkaTopicsDescriptor = {0}")
+    @Parameters(name = "KafkaTopicsDescriptor = {0}")
     @SuppressWarnings("unchecked")
     public static Collection<KafkaTopicsDescriptor[]> timeCharacteristic() {
         return Arrays.asList(
@@ -65,7 +68,7 @@ public class AbstractPartitionDiscovererTest {
     }
 
     @Test
-    public void testPartitionsEqualConsumersFixedPartitions() throws Exception {
+    void testPartitionsEqualConsumersFixedPartitions() throws Exception {
         List<KafkaTopicPartition> mockGetAllPartitionsForTopicsReturn =
                 Arrays.asList(
                         new KafkaTopicPartition(TEST_TOPIC, 0),
@@ -117,7 +120,7 @@ public class AbstractPartitionDiscovererTest {
     }
 
     @Test
-    public void testMultiplePartitionsPerConsumersFixedPartitions() {
+    void testMultiplePartitionsPerConsumersFixedPartitions() {
         try {
             final int[] partitionIDs = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
@@ -186,7 +189,7 @@ public class AbstractPartitionDiscovererTest {
     }
 
     @Test
-    public void testPartitionsFewerThanConsumersFixedPartitions() {
+    void testPartitionsFewerThanConsumersFixedPartitions() {
         try {
             List<KafkaTopicPartition> mockGetAllPartitionsForTopicsReturn =
                     Arrays.asList(
@@ -248,7 +251,7 @@ public class AbstractPartitionDiscovererTest {
     }
 
     @Test
-    public void testGrowingPartitions() {
+    void testGrowingPartitions() {
         try {
             final int[] newPartitionIDs = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
             List<KafkaTopicPartition> allPartitions = new ArrayList<>(11);
@@ -417,7 +420,7 @@ public class AbstractPartitionDiscovererTest {
     }
 
     @Test
-    public void testDeterministicAssignmentWithDifferentFetchedPartitionOrdering()
+    void testDeterministicAssignmentWithDifferentFetchedPartitionOrdering()
             throws Exception {
         int numSubtasks = 4;
 
@@ -478,7 +481,7 @@ public class AbstractPartitionDiscovererTest {
     }
 
     @Test
-    public void testNonContiguousPartitionIdDiscovery() throws Exception {
+    void testNonContiguousPartitionIdDiscovery() throws Exception {
         List<KafkaTopicPartition> mockGetAllPartitionsForTopicsReturn1 =
                 Arrays.asList(
                         new KafkaTopicPartition("test-topic", 1),

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractPartitionDiscovererTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractPartitionDiscovererTest.java
@@ -19,9 +19,9 @@
 package org.apache.flink.streaming.connectors.kafka.internals;
 
 import org.apache.flink.streaming.connectors.kafka.testutils.TestPartitionDiscoverer;
-
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractPartitionDiscovererTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractPartitionDiscovererTest.java
@@ -24,8 +24,6 @@ import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTe
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/ClosableBlockingQueueTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/ClosableBlockingQueueTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.connectors.kafka.internals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,14 +30,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 /** Tests for the {@link ClosableBlockingQueue}. */
-public class ClosableBlockingQueueTest {
+class ClosableBlockingQueueTest {
 
     // ------------------------------------------------------------------------
     //  single-threaded unit tests
     // ------------------------------------------------------------------------
 
     @Test
-    public void testCreateQueueHashCodeEquals() {
+    void testCreateQueueHashCodeEquals() {
         try {
             ClosableBlockingQueue<String> queue1 = new ClosableBlockingQueue<>();
             ClosableBlockingQueue<String> queue2 = new ClosableBlockingQueue<>(22);
@@ -91,7 +91,7 @@ public class ClosableBlockingQueueTest {
     }
 
     @Test
-    public void testCloseEmptyQueue() {
+    void testCloseEmptyQueue() {
         try {
             ClosableBlockingQueue<String> queue = new ClosableBlockingQueue<>();
             assertThat(queue.isOpen()).isTrue();
@@ -114,7 +114,7 @@ public class ClosableBlockingQueueTest {
     }
 
     @Test
-    public void testCloseNonEmptyQueue() {
+    void testCloseNonEmptyQueue() {
         try {
             ClosableBlockingQueue<Integer> queue = new ClosableBlockingQueue<>(asList(1, 2, 3));
             assertThat(queue.isOpen()).isTrue();
@@ -148,7 +148,7 @@ public class ClosableBlockingQueueTest {
     }
 
     @Test
-    public void testPeekAndPoll() {
+    void testPeekAndPoll() {
         try {
             ClosableBlockingQueue<String> queue = new ClosableBlockingQueue<>();
 
@@ -208,7 +208,7 @@ public class ClosableBlockingQueueTest {
     }
 
     @Test
-    public void testPollBatch() {
+    void testPollBatch() {
         try {
             ClosableBlockingQueue<String> queue = new ClosableBlockingQueue<>();
 
@@ -240,7 +240,7 @@ public class ClosableBlockingQueueTest {
     }
 
     @Test
-    public void testGetElementBlocking() {
+    void testGetElementBlocking() {
         try {
             ClosableBlockingQueue<String> queue = new ClosableBlockingQueue<>();
 
@@ -297,7 +297,7 @@ public class ClosableBlockingQueueTest {
     }
 
     @Test
-    public void testGetBatchBlocking() {
+    void testGetBatchBlocking() {
         try {
             ClosableBlockingQueue<String> queue = new ClosableBlockingQueue<>();
 
@@ -357,7 +357,7 @@ public class ClosableBlockingQueueTest {
     // ------------------------------------------------------------------------
 
     @Test
-    public void notifyOnClose() {
+    void notifyOnClose() {
         try {
             final long oneYear = 365L * 24 * 60 * 60 * 1000;
 
@@ -412,7 +412,7 @@ public class ClosableBlockingQueueTest {
 
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
     @Test
-    public void testMultiThreadedAddGet() {
+    void testMultiThreadedAddGet() {
         try {
             final ClosableBlockingQueue<Integer> queue = new ClosableBlockingQueue<>();
             final AtomicReference<Throwable> pushErrorRef = new AtomicReference<>();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartitionTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartitionTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.connectors.kafka.internals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -27,10 +27,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 /** Tests for the {@link KafkaTopicPartition}. */
-public class KafkaTopicPartitionTest {
+class KafkaTopicPartitionTest {
 
     @Test
-    public void validateUid() {
+    void validateUid() {
         Field uidField;
         try {
             uidField = KafkaTopicPartition.class.getDeclaredField("serialVersionUID");

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptorTest.java
@@ -19,9 +19,9 @@ package org.apache.flink.streaming.connectors.kafka.internals;
 
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicsDescriptorTest.java
@@ -17,8 +17,10 @@
 
 package org.apache.flink.streaming.connectors.kafka.internals;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
@@ -29,10 +31,10 @@ import java.util.regex.Pattern;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link KafkaTopicsDescriptor}. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class KafkaTopicsDescriptorTest {
 
-    @Parameterized.Parameters
+    @Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
@@ -57,7 +59,7 @@ public class KafkaTopicsDescriptorTest {
     }
 
     @Test
-    public void testIsMatchingTopic() {
+    void testIsMatchingTopic() {
         KafkaTopicsDescriptor topicsDescriptor =
                 new KafkaTopicsDescriptor(fixedTopics, topicPattern);
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleExactlyOnceITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleExactlyOnceITCase.java
@@ -27,11 +27,11 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.kafka.testutils.FailingIdentityMapper;
 import org.apache.flink.streaming.connectors.kafka.testutils.ValidatingExactlyOnceSink;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.streaming.api.TimeCharacteristic.EventTime;
 import static org.apache.flink.streaming.api.TimeCharacteristic.IngestionTime;
@@ -39,9 +39,8 @@ import static org.apache.flink.streaming.api.TimeCharacteristic.ProcessingTime;
 import static org.apache.flink.test.util.TestUtils.tryExecute;
 
 /** Failure Recovery IT Test for KafkaShuffle. */
-public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
-
-    @Rule public final Timeout timeout = Timeout.millis(600000L);
+@Timeout(value = 60000L, unit = TimeUnit.MILLISECONDS)
+class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
 
     /**
      * Failure Recovery after processing 2/3 data with time characteristic: ProcessingTime.
@@ -49,7 +48,7 @@ public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
      */
     @Test
-    public void testFailureRecoveryProcessingTime() throws Exception {
+    void testFailureRecoveryProcessingTime() throws Exception {
         testKafkaShuffleFailureRecovery(1000, ProcessingTime);
     }
 
@@ -59,7 +58,7 @@ public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
      */
     @Test
-    public void testFailureRecoveryIngestionTime() throws Exception {
+    void testFailureRecoveryIngestionTime() throws Exception {
         testKafkaShuffleFailureRecovery(1000, IngestionTime);
     }
 
@@ -69,7 +68,7 @@ public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
      */
     @Test
-    public void testFailureRecoveryEventTime() throws Exception {
+    void testFailureRecoveryEventTime() throws Exception {
         testKafkaShuffleFailureRecovery(1000, EventTime);
     }
 
@@ -79,7 +78,7 @@ public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
      */
     @Test
-    public void testAssignedToPartitionFailureRecoveryProcessingTime() throws Exception {
+    void testAssignedToPartitionFailureRecoveryProcessingTime() throws Exception {
         testAssignedToPartitionFailureRecovery(500, ProcessingTime);
     }
 
@@ -89,7 +88,7 @@ public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
      */
     @Test
-    public void testAssignedToPartitionFailureRecoveryIngestionTime() throws Exception {
+    void testAssignedToPartitionFailureRecoveryIngestionTime() throws Exception {
         testAssignedToPartitionFailureRecovery(500, IngestionTime);
     }
 
@@ -99,7 +98,7 @@ public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
      */
     @Test
-    public void testAssignedToPartitionFailureRecoveryEventTime() throws Exception {
+    void testAssignedToPartitionFailureRecoveryEventTime() throws Exception {
         testAssignedToPartitionFailureRecovery(500, EventTime);
     }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleITCase.java
@@ -35,9 +35,8 @@ import org.apache.flink.streaming.connectors.kafka.internals.KafkaShuffleFetcher
 import org.apache.flink.util.PropertiesUtil;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -46,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.streaming.api.TimeCharacteristic.EventTime;
 import static org.apache.flink.streaming.api.TimeCharacteristic.IngestionTime;
@@ -57,9 +57,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 /** Simple End to End Test for Kafka. */
-public class KafkaShuffleITCase extends KafkaShuffleTestBase {
-
-    @Rule public final Timeout timeout = Timeout.millis(600000L);
+@Timeout(value = 60000L, unit = TimeUnit.MILLISECONDS)
+class KafkaShuffleITCase extends KafkaShuffleTestBase {
 
     /**
      * To test no data is lost or duplicated end-2-end with the default time characteristic:
@@ -68,7 +67,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
      */
     @Test
-    public void testSimpleProcessingTime() throws Exception {
+    void testSimpleProcessingTime() throws Exception {
         testKafkaShuffle(200000, ProcessingTime);
     }
 
@@ -78,7 +77,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
      */
     @Test
-    public void testSimpleIngestionTime() throws Exception {
+    void testSimpleIngestionTime() throws Exception {
         testKafkaShuffle(200000, IngestionTime);
     }
 
@@ -88,7 +87,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
      */
     @Test
-    public void testSimpleEventTime() throws Exception {
+    void testSimpleEventTime() throws Exception {
         testKafkaShuffle(100000, EventTime);
     }
 
@@ -98,7 +97,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
      */
     @Test
-    public void testAssignedToPartitionProcessingTime() throws Exception {
+    void testAssignedToPartitionProcessingTime() throws Exception {
         testAssignedToPartition(300000, ProcessingTime);
     }
 
@@ -108,7 +107,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
      */
     @Test
-    public void testAssignedToPartitionIngestionTime() throws Exception {
+    void testAssignedToPartitionIngestionTime() throws Exception {
         testAssignedToPartition(300000, IngestionTime);
     }
 
@@ -118,7 +117,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
      */
     @Test
-    public void testAssignedToPartitionEventTime() throws Exception {
+    void testAssignedToPartitionEventTime() throws Exception {
         testAssignedToPartition(100000, EventTime);
     }
 
@@ -128,7 +127,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 2; Kafka Partition # = 3; Consumer Parallelism = 3.
      */
     @Test
-    public void testWatermarkIncremental() throws Exception {
+    void testWatermarkIncremental() throws Exception {
         testWatermarkIncremental(100000);
     }
 
@@ -138,7 +137,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
      */
     @Test
-    public void testSerDeProcessingTime() throws Exception {
+    void testSerDeProcessingTime() throws Exception {
         testRecordSerDe(ProcessingTime);
     }
 
@@ -149,7 +148,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
      */
     @Test
-    public void testSerDeIngestionTime() throws Exception {
+    void testSerDeIngestionTime() throws Exception {
         testRecordSerDe(IngestionTime);
     }
 
@@ -160,7 +159,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
      */
     @Test
-    public void testSerDeEventTime() throws Exception {
+    void testSerDeEventTime() throws Exception {
         testRecordSerDe(EventTime);
     }
 
@@ -171,7 +170,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      * <p>Producer Parallelism = 1; Kafka Partition # = 1; Consumer Parallelism = 1.
      */
     @Test
-    public void testWatermarkBroadcasting() throws Exception {
+    void testWatermarkBroadcasting() throws Exception {
         final int numberOfPartitions = 3;
         final int producerParallelism = 2;
         final int numElementsPerProducer = 1000;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleTestBase.java
@@ -40,18 +40,18 @@ import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition
 import org.apache.flink.test.util.SuccessException;
 import org.apache.flink.util.Collector;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.util.Random;
 
 import static org.apache.flink.streaming.api.TimeCharacteristic.EventTime;
 
 /** Base Test Class for KafkaShuffle. */
-public class KafkaShuffleTestBase extends KafkaConsumerTestBase {
+class KafkaShuffleTestBase extends KafkaConsumerTestBase {
     static final long INIT_TIMESTAMP = System.currentTimeMillis();
 
-    @BeforeClass
-    public static void prepare() throws Exception {
+    @BeforeAll
+    protected static void prepare() throws Exception {
         KafkaProducerTestBase.prepare();
         ((KafkaTestEnvironmentImpl) kafkaServer)
                 .setProducerSemantic(FlinkKafkaProducer.Semantic.EXACTLY_ONCE);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaChangelogTableITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaChangelogTableITCase.java
@@ -32,8 +32,8 @@ import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.config.OptimizerConfigOptions;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.ZoneId;
@@ -45,17 +45,17 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaTableTestUt
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaTableTestUtils.waitingExpectedResults;
 
 /** IT cases for Kafka with changelog format for Table API & SQL. */
-public class KafkaChangelogTableITCase extends KafkaTableTestBase {
+class KafkaChangelogTableITCase extends KafkaTableTestBase {
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         // we have to use single parallelism,
         // because we will count the messages in sink to terminate the job
         env.setParallelism(1);
     }
 
     @Test
-    public void testKafkaDebeziumChangelogSource() throws Exception {
+    void testKafkaDebeziumChangelogSource() throws Exception {
         final String topic = "changelog_topic";
         createTestTopic(topic, 1, 1);
 
@@ -182,7 +182,7 @@ public class KafkaChangelogTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testKafkaCanalChangelogSource() throws Exception {
+    void testKafkaCanalChangelogSource() throws Exception {
         final String topic = "changelog_canal";
         createTestTopic(topic, 1, 1);
 
@@ -323,7 +323,7 @@ public class KafkaChangelogTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testKafkaMaxwellChangelogSource() throws Exception {
+    void testKafkaMaxwellChangelogSource() throws Exception {
         final String topic = "changelog_maxwell";
         createTestTopic(topic, 1, 1);
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptionsUtilTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptionsUtilTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.DataType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,10 +38,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link KafkaConnectorOptionsUtil}. */
-public class KafkaConnectorOptionsUtilTest {
+class KafkaConnectorOptionsUtilTest {
 
     @Test
-    public void testFormatProjection() {
+    void testFormatProjection() {
         final DataType dataType =
                 DataTypes.ROW(
                         FIELD("id", INT()),
@@ -60,7 +60,7 @@ public class KafkaConnectorOptionsUtilTest {
     }
 
     @Test
-    public void testMissingKeyFormatProjection() {
+    void testMissingKeyFormatProjection() {
         final DataType dataType = ROW(FIELD("id", INT()));
         final Map<String, String> options = createTestOptions();
 
@@ -74,7 +74,7 @@ public class KafkaConnectorOptionsUtilTest {
     }
 
     @Test
-    public void testInvalidKeyFormatFieldProjection() {
+    void testInvalidKeyFormatFieldProjection() {
         final DataType dataType = ROW(FIELD("id", INT()), FIELD("name", STRING()));
         final Map<String, String> options = createTestOptions();
         options.put("key.fields", "non_existing");
@@ -92,7 +92,7 @@ public class KafkaConnectorOptionsUtilTest {
     }
 
     @Test
-    public void testInvalidKeyFormatPrefixProjection() {
+    void testInvalidKeyFormatPrefixProjection() {
         final DataType dataType =
                 ROW(FIELD("k_part_1", INT()), FIELD("part_2", STRING()), FIELD("name", STRING()));
         final Map<String, String> options = createTestOptions();
@@ -109,7 +109,7 @@ public class KafkaConnectorOptionsUtilTest {
     }
 
     @Test
-    public void testInvalidValueFormatProjection() {
+    void testInvalidValueFormatProjection() {
         final DataType dataType = ROW(FIELD("k_id", INT()), FIELD("id", STRING()));
         final Map<String, String> options = createTestOptions();
         options.put("key.fields", "k_id");

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -77,7 +77,7 @@ import org.apache.flink.util.TestLoggerExtension;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.TopicPartition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
@@ -187,7 +187,7 @@ public class KafkaDynamicTableFactoryTest {
     private static final DataType SCHEMA_DATA_TYPE = SCHEMA.toPhysicalRowDataType();
 
     @Test
-    public void testTableSource() {
+    void testTableSource() {
         final DynamicTableSource actualSource = createTableSource(SCHEMA, getBasicSourceOptions());
         final KafkaDynamicSource actualKafkaSource = (KafkaDynamicSource) actualSource;
 
@@ -221,7 +221,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTableSourceWithPattern() {
+    void testTableSourceWithPattern() {
         final Map<String, String> modifiedOptions =
                 getModifiedOptions(
                         getBasicSourceOptions(),
@@ -265,7 +265,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTableSourceWithKeyValue() {
+    void testTableSourceWithKeyValue() {
         final DynamicTableSource actualSource = createTableSource(SCHEMA, getKeyValueOptions());
         final KafkaDynamicSource actualKafkaSource = (KafkaDynamicSource) actualSource;
         // initialize stateful testing formats
@@ -301,7 +301,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTableSourceWithKeyValueAndMetadata() {
+    void testTableSourceWithKeyValueAndMetadata() {
         final Map<String, String> options = getKeyValueOptions();
         options.put("value.test-format.readable-metadata", "metadata_1:INT, metadata_2:STRING");
 
@@ -354,7 +354,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTableSourceCommitOnCheckpointDisabled() {
+    void testTableSourceCommitOnCheckpointDisabled() {
         final Map<String, String> modifiedOptions =
                 getModifiedOptions(
                         getBasicSourceOptions(), options -> options.remove("properties.group.id"));
@@ -387,7 +387,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTableSourceSetOffsetResetWithException() {
+    void testTableSourceSetOffsetResetWithException() {
         String errorStrategy = "errorStrategy";
         assertThatThrownBy(() -> testTableSourceSetOffsetReset(errorStrategy))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -430,7 +430,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testBoundedSpecificOffsetsValidate() {
+    void testBoundedSpecificOffsetsValidate() {
         final Map<String, String> modifiedOptions =
                 getModifiedOptions(
                         getBasicSourceOptions(),
@@ -446,7 +446,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testBoundedSpecificOffsets() {
+    void testBoundedSpecificOffsets() {
         testBoundedOffsets(
                 "specific-offsets",
                 options -> {
@@ -468,7 +468,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testBoundedLatestOffset() {
+    void testBoundedLatestOffset() {
         testBoundedOffsets(
                 "latest-offset",
                 options -> {},
@@ -492,7 +492,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testBoundedGroupOffsets() {
+    void testBoundedGroupOffsets() {
         testBoundedOffsets(
                 "group-offsets",
                 options -> {},
@@ -512,7 +512,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testBoundedTimestamp() {
+    void testBoundedTimestamp() {
         testBoundedOffsets(
                 "timestamp",
                 options -> {
@@ -579,7 +579,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTableSink() {
+    void testTableSink() {
         final Map<String, String> modifiedOptions =
                 getModifiedOptions(
                         getBasicSinkOptions(),
@@ -619,7 +619,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTableSinkSemanticTranslation() {
+    void testTableSinkSemanticTranslation() {
         final List<String> semantics = Arrays.asList("exactly-once", "at-least-once", "none");
         final EncodingFormat<SerializationSchema<RowData>> valueEncodingFormat =
                 new EncodingFormatMock(",");
@@ -651,7 +651,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTableSinkWithKeyValue() {
+    void testTableSinkWithKeyValue() {
         final Map<String, String> modifiedOptions =
                 getModifiedOptions(
                         getKeyValueOptions(),
@@ -694,7 +694,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTableSinkWithParallelism() {
+    void testTableSinkWithParallelism() {
         final Map<String, String> modifiedOptions =
                 getModifiedOptions(
                         getBasicSinkOptions(), options -> options.put("sink.parallelism", "100"));
@@ -728,7 +728,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testTableSinkAutoCompleteSchemaRegistrySubject() {
+    void testTableSinkAutoCompleteSchemaRegistrySubject() {
         // only format
         verifyEncoderSubject(
                 options -> {
@@ -876,7 +876,7 @@ public class KafkaDynamicTableFactoryTest {
     // --------------------------------------------------------------------------------------------
 
     @Test
-    public void testSourceTableWithTopicAndTopicPattern() {
+    void testSourceTableWithTopicAndTopicPattern() {
         assertThatThrownBy(
                         () -> {
                             final Map<String, String> modifiedOptions =
@@ -897,7 +897,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testMissingStartupTimestamp() {
+    void testMissingStartupTimestamp() {
         assertThatThrownBy(
                         () -> {
                             final Map<String, String> modifiedOptions =
@@ -917,7 +917,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testMissingSpecificOffsets() {
+    void testMissingSpecificOffsets() {
         assertThatThrownBy(
                         () -> {
                             final Map<String, String> modifiedOptions =
@@ -938,7 +938,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testInvalidSinkPartitioner() {
+    void testInvalidSinkPartitioner() {
         assertThatThrownBy(
                         () -> {
                             final Map<String, String> modifiedOptions =
@@ -956,7 +956,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testInvalidRoundRobinPartitionerWithKeyFields() {
+    void testInvalidRoundRobinPartitionerWithKeyFields() {
         assertThatThrownBy(
                         () -> {
                             final Map<String, String> modifiedOptions =
@@ -976,7 +976,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testExactlyOnceGuaranteeWithoutTransactionalIdPrefix() {
+    void testExactlyOnceGuaranteeWithoutTransactionalIdPrefix() {
         assertThatThrownBy(
                         () -> {
                             final Map<String, String> modifiedOptions =
@@ -1002,7 +1002,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testSinkWithTopicListOrTopicPattern() {
+    void testSinkWithTopicListOrTopicPattern() {
         Map<String, String> modifiedOptions =
                 getModifiedOptions(
                         getBasicSinkOptions(),
@@ -1039,7 +1039,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testPrimaryKeyValidation() {
+    void testPrimaryKeyValidation() {
         final ResolvedSchema pkSchema =
                 new ResolvedSchema(
                         SCHEMA.getColumns(),
@@ -1098,7 +1098,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testDiscoverPartitionByDefault() {
+    void testDiscoverPartitionByDefault() {
         Map<String, String> tableSourceOptions =
                 getModifiedOptions(
                         getBasicSourceOptions(),
@@ -1136,7 +1136,7 @@ public class KafkaDynamicTableFactoryTest {
     }
 
     @Test
-    public void testDisableDiscoverPartition() {
+    void testDisableDiscoverPartition() {
         Map<String, String> tableSourceOptions =
                 getModifiedOptions(
                         getBasicSourceOptions(),

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
@@ -35,16 +35,18 @@ import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.utils.EncodingUtils;
 import org.apache.flink.test.util.SuccessException;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.types.Row;
 
 import org.apache.kafka.clients.consumer.NoOffsetForPartitionException;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -76,21 +78,21 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.HamcrestCondition.matching;
 
 /** Basic IT cases for the Kafka table source and sink. */
-@RunWith(Parameterized.class)
-public class KafkaTableITCase extends KafkaTableTestBase {
+@ExtendWith(ParameterizedTestExtension.class)
+class KafkaTableITCase extends KafkaTableTestBase {
 
     private static final String JSON_FORMAT = "json";
     private static final String AVRO_FORMAT = "avro";
     private static final String CSV_FORMAT = "csv";
 
-    @Parameterized.Parameter public String format;
+    @Parameter public String format;
 
-    @Parameterized.Parameters(name = "format = {0}")
+    @Parameters(name = "format = {0}")
     public static Collection<String> parameters() {
         return Arrays.asList(JSON_FORMAT, AVRO_FORMAT, CSV_FORMAT);
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         // we have to use single parallelism,
         // because we will count the messages in sink to terminate the job
@@ -98,7 +100,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testKafkaSourceSink() throws Exception {
+    void testKafkaSourceSink() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
         final String topic = "tstopic_" + format + "_" + UUID.randomUUID();
@@ -189,7 +191,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testKafkaSourceSinkWithBoundedSpecificOffsets() throws Exception {
+    void testKafkaSourceSinkWithBoundedSpecificOffsets() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
         final String topic = "bounded_" + format + "_" + UUID.randomUUID();
@@ -243,7 +245,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testKafkaSourceSinkWithBoundedTimestamp() throws Exception {
+    void testKafkaSourceSinkWithBoundedTimestamp() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
         final String topic = "bounded_" + format + "_" + UUID.randomUUID();
@@ -300,7 +302,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testKafkaTableWithMultipleTopics() throws Exception {
+    void testKafkaTableWithMultipleTopics() throws Exception {
         // ---------- create source and sink tables -------------------
         String tableTemp =
                 "create table %s (\n"
@@ -393,7 +395,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testKafkaSourceSinkWithMetadata() throws Exception {
+    void testKafkaSourceSinkWithMetadata() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
         final String topic = "metadata_topic_" + format + "_" + UUID.randomUUID();
@@ -485,7 +487,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testKafkaSourceSinkWithKeyAndPartialValue() throws Exception {
+    void testKafkaSourceSinkWithKeyAndPartialValue() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
         final String topic = "key_partial_value_topic_" + format + "_" + UUID.randomUUID();
@@ -566,7 +568,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testKafkaSourceSinkWithKeyAndFullValue() throws Exception {
+    void testKafkaSourceSinkWithKeyAndFullValue() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
         final String topic = "key_full_value_topic_" + format + "_" + UUID.randomUUID();
@@ -644,7 +646,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testKafkaTemporalJoinChangelog() throws Exception {
+    void testKafkaTemporalJoinChangelog() throws Exception {
         // Set the session time zone to UTC, because the next `METADATA FROM
         // 'value.source.timestamp'` DDL
         // will use the session time zone when convert the changelog time from milliseconds to
@@ -787,7 +789,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testPerPartitionWatermarkKafka() throws Exception {
+    void testPerPartitionWatermarkKafka() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
         final String topic = "per_partition_watermark_topic_" + format + "_" + UUID.randomUUID();
@@ -877,7 +879,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testPerPartitionWatermarkWithIdleSource() throws Exception {
+    void testPerPartitionWatermarkWithIdleSource() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
         final String topic = "idle_partition_watermark_topic_" + format + "_" + UUID.randomUUID();
@@ -952,7 +954,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testLatestOffsetStrategyResume() throws Exception {
+    void testLatestOffsetStrategyResume() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
         final String topic = "latest_offset_resume_topic_" + format + "_" + UUID.randomUUID();
@@ -1084,17 +1086,17 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testStartFromGroupOffsetsLatest() throws Exception {
+    void testStartFromGroupOffsetsLatest() throws Exception {
         testStartFromGroupOffsets("latest");
     }
 
     @Test
-    public void testStartFromGroupOffsetsEarliest() throws Exception {
+    void testStartFromGroupOffsetsEarliest() throws Exception {
         testStartFromGroupOffsets("earliest");
     }
 
     @Test
-    public void testStartFromGroupOffsetsNone() {
+    void testStartFromGroupOffsetsNone() {
         Assertions.assertThatThrownBy(() -> testStartFromGroupOffsetsWithNoneResetStrategy())
                 .satisfies(FlinkAssertions.anyCauseMatches(NoOffsetForPartitionException.class));
     }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
@@ -35,9 +35,9 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.testcontainers.junit.jupiter.Container;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
@@ -63,7 +63,7 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
     private static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
     private static final int zkTimeoutMills = 30000;
 
-    @ClassRule
+    @Container
     public static final KafkaContainer KAFKA_CONTAINER =
             new KafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA)) {
                 @Override
@@ -87,8 +87,8 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
     // Timer for scheduling logging task if the test hangs
     private final Timer loggingTimer = new Timer("Debug Logging Timer");
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         env = StreamExecutionEnvironment.getExecutionEnvironment();
         tEnv = StreamTableEnvironment.create(env);
         env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
@@ -107,8 +107,8 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
                 });
     }
 
-    @After
-    public void after() {
+    @AfterEach
+    void after() {
         // Cancel timer for debug logging
         cancelTimeoutLogger();
     }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
@@ -37,11 +37,11 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.testcontainers.junit.jupiter.Container;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.utility.DockerImageName;
 
 import java.time.Duration;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/ReducingUpsertWriterTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/ReducingUpsertWriterTest.java
@@ -37,8 +37,6 @@ import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTe
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.time.Instant;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/ReducingUpsertWriterTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/ReducingUpsertWriterTest.java
@@ -33,7 +33,10 @@ import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 
-import org.junit.Test;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -55,9 +58,9 @@ import static org.apache.flink.types.RowKind.UPDATE_AFTER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ReducingUpsertWriter}. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class ReducingUpsertWriterTest {
-    @Parameterized.Parameters(name = "object reuse = {0}")
+    @Parameters(name = "object reuse = {0}")
     public static Object[] enableObjectReuse() {
         return new Boolean[] {true, false};
     }
@@ -150,7 +153,7 @@ public class ReducingUpsertWriterTest {
     }
 
     @Test
-    public void testWriteData() throws Exception {
+    void testWriteData() throws Exception {
         final MockedSinkWriter writer = new MockedSinkWriter();
         final ReducingUpsertWriter<?, ?> bufferedWriter = createBufferedWriter(writer);
 
@@ -217,7 +220,7 @@ public class ReducingUpsertWriterTest {
     }
 
     @Test
-    public void testFlushDataWhenCheckpointing() throws Exception {
+    void testFlushDataWhenCheckpointing() throws Exception {
         final MockedSinkWriter writer = new MockedSinkWriter();
         final ReducingUpsertWriter<?, ?> bufferedWriter = createBufferedWriter(writer);
         // write all data, there should be 3 records are still buffered
@@ -265,7 +268,7 @@ public class ReducingUpsertWriterTest {
     }
 
     @Test
-    public void testWriteDataWithNullTimestamp() throws Exception {
+    void testWriteDataWithNullTimestamp() throws Exception {
         final MockedSinkWriter writer = new MockedSinkWriter();
         final ReducingUpsertWriter<?, ?> bufferedWriter = createBufferedWriter(writer);
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/ReducingUpsertWriterTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/ReducingUpsertWriterTest.java
@@ -32,9 +32,9 @@ import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
-
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactoryTest.java
@@ -66,13 +66,11 @@ import org.apache.flink.table.types.AtomicDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
-import org.apache.flink.util.TestLogger;
 
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.TopicPartition;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -91,7 +89,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link UpsertKafkaDynamicTableFactory}. */
-public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
+class UpsertKafkaDynamicTableFactoryTest {
 
     private static final String SOURCE_TOPIC = "sourceTopic_1";
 
@@ -148,10 +146,8 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
             new TestFormatFactory.DecodingFormatMock(
                     ",", true, ChangelogMode.insertOnly(), Collections.emptyMap());
 
-    @Rule public ExpectedException thrown = ExpectedException.none();
-
     @Test
-    public void testTableSource() {
+    void testTableSource() {
         final DataType producedDataType = SOURCE_SCHEMA.toPhysicalRowDataType();
         // Construct table source using options and table source factory
         final DynamicTableSource actualSource =
@@ -176,7 +172,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testTableSink() {
+    void testTableSink() {
         // Construct table sink using options and table sink factory.
         final Map<String, String> modifiedOptions =
                 getModifiedOptions(
@@ -217,7 +213,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
 
     @SuppressWarnings("rawtypes")
     @Test
-    public void testBufferedTableSink() {
+    void testBufferedTableSink() {
         // Construct table sink using options and table sink factory.
         final DynamicTableSink actualSink =
                 createTableSink(
@@ -274,7 +270,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testTableSinkWithParallelism() {
+    void testTableSinkWithParallelism() {
         final Map<String, String> modifiedOptions =
                 getModifiedOptions(
                         getFullSinkOptions(),
@@ -310,7 +306,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testTableSinkAutoCompleteSchemaRegistrySubject() {
+    void testTableSinkAutoCompleteSchemaRegistrySubject() {
         // value.format + key.format
         verifyEncoderSubject(
                 options -> {
@@ -420,7 +416,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     // --------------------------------------------------------------------------------------------
 
     @Test
-    public void testBoundedSpecificOffsetsValidate() {
+    void testBoundedSpecificOffsetsValidate() {
         final Map<String, String> options = getFullSourceOptions();
         options.put(
                 KafkaConnectorOptions.SCAN_BOUNDED_MODE.key(),
@@ -434,7 +430,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testBoundedSpecificOffsets() {
+    void testBoundedSpecificOffsets() {
         testBoundedOffsets(
                 ScanBoundedMode.SPECIFIC_OFFSETS,
                 options -> {
@@ -456,7 +452,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testBoundedLatestOffset() {
+    void testBoundedLatestOffset() {
         testBoundedOffsets(
                 ScanBoundedMode.LATEST_OFFSET,
                 options -> {},
@@ -480,7 +476,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testBoundedGroupOffsets() {
+    void testBoundedGroupOffsets() {
         testBoundedOffsets(
                 ScanBoundedMode.GROUP_OFFSETS,
                 options -> {
@@ -502,7 +498,7 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testBoundedTimestamp() {
+    void testBoundedTimestamp() {
         testBoundedOffsets(
                 ScanBoundedMode.TIMESTAMP,
                 options -> {
@@ -552,10 +548,9 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     // --------------------------------------------------------------------------------------------
 
     @Test
-    public void testCreateSourceTableWithoutPK() {
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
+    void testCreateSourceTableWithoutPK() {
+        Assertions.assertThrows(ValidationException.class,
+                () -> containsCause(
                         new ValidationException(
                                 "'upsert-kafka' tables require to define a PRIMARY KEY constraint. "
                                         + "The PRIMARY KEY specifies which columns should be read from or write to the Kafka message key. "
@@ -570,10 +565,9 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testCreateSinkTableWithoutPK() {
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
+    void testCreateSinkTableWithoutPK() {
+        Assertions.assertThrows(ValidationException.class,
+                () -> containsCause(
                         new ValidationException(
                                 "'upsert-kafka' tables require to define a PRIMARY KEY constraint. "
                                         + "The PRIMARY KEY specifies which columns should be read from or write to the Kafka message key. "
@@ -587,10 +581,9 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testSerWithCDCFormatAsValue() {
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
+    void testSerWithCDCFormatAsValue() {
+        Assertions.assertThrows(ValidationException.class,
+                () -> containsCause(
                         new ValidationException(
                                 String.format(
                                         "'upsert-kafka' connector doesn't support '%s' as value format, "
@@ -612,10 +605,9 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testDeserWithCDCFormatAsValue() {
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
+    void testDeserWithCDCFormatAsValue() {
+        Assertions.assertThrows(ValidationException.class,
+                () -> containsCause(
                         new ValidationException(
                                 String.format(
                                         "'upsert-kafka' connector doesn't support '%s' as value format, "
@@ -637,10 +629,9 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testInvalidSinkBufferFlush() {
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
+    void testInvalidSinkBufferFlush() {
+        Assertions.assertThrows(ValidationException.class,
+                () -> containsCause(
                         new ValidationException(
                                 "'sink.buffer-flush.max-rows' and 'sink.buffer-flush.interval' "
                                         + "must be set to be greater than zero together to enable"
@@ -656,10 +647,9 @@ public class UpsertKafkaDynamicTableFactoryTest extends TestLogger {
     }
 
     @Test
-    public void testExactlyOnceGuaranteeWithoutTransactionalIdPrefix() {
-        thrown.expect(ValidationException.class);
-        thrown.expect(
-                containsCause(
+    void testExactlyOnceGuaranteeWithoutTransactionalIdPrefix() {
+        Assertions.assertThrows(ValidationException.class,
+                () -> containsCause(
                         new ValidationException(
                                 "sink.transactional-id-prefix must be specified when using DeliveryGuarantee.EXACTLY_ONCE.")));
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
@@ -24,12 +24,13 @@ import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.table.utils.LegacyRowResource;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.types.Row;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -56,27 +57,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.HamcrestCondition.matching;
 
 /** Upsert-kafka IT cases. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class UpsertKafkaTableITCase extends KafkaTableTestBase {
 
     private static final String JSON_FORMAT = "json";
     private static final String CSV_FORMAT = "csv";
     private static final String AVRO_FORMAT = "avro";
 
-    @Parameterized.Parameter public String format;
+    @Parameter public String format;
 
-    @Parameterized.Parameters(name = "format = {0}")
+    @Parameters(name = "format = {0}")
     public static Object[] parameters() {
         return new Object[] {JSON_FORMAT, CSV_FORMAT, AVRO_FORMAT};
     }
-
-    @Rule public final LegacyRowResource usesLegacyRows = LegacyRowResource.INSTANCE;
 
     private static final String USERS_TOPIC = "users";
     private static final String WORD_COUNT_TOPIC = "word_count";
 
     @Test
-    public void testAggregate() throws Exception {
+    void testAggregate() throws Exception {
         String topic = WORD_COUNT_TOPIC + "_" + format;
         createTestTopic(topic, 4, 1);
         // -------------   test   ---------------
@@ -87,7 +86,7 @@ public class UpsertKafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testTemporalJoin() throws Exception {
+    void testTemporalJoin() throws Exception {
         String topic = USERS_TOPIC + "_" + format;
         createTestTopic(topic, 2, 1);
         // -------------   test   ---------------
@@ -110,7 +109,7 @@ public class UpsertKafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testBufferedUpsertSink() throws Exception {
+    void testBufferedUpsertSink() throws Exception {
         final String topic = "buffered_upsert_topic_" + format;
         createTestTopic(topic, 1, 1);
         String bootstraps = getBootstrapServers();
@@ -199,7 +198,7 @@ public class UpsertKafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testBufferedUpsertSinkWithoutAssigningWatermark() throws Exception {
+    void testBufferedUpsertSinkWithoutAssigningWatermark() throws Exception {
         final String topic = "buffered_upsert_topic_without_assigning_watermark_" + format;
         createTestTopic(topic, 1, 1);
         String bootstraps = getBootstrapServers();
@@ -264,7 +263,7 @@ public class UpsertKafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testSourceSinkWithKeyAndPartialValue() throws Exception {
+    void testSourceSinkWithKeyAndPartialValue() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
         final String topic = "key_partial_value_topic_" + format;
@@ -362,7 +361,7 @@ public class UpsertKafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testKafkaSourceSinkWithKeyAndFullValue() throws Exception {
+    void testKafkaSourceSinkWithKeyAndFullValue() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
         final String topic = "key_full_value_topic_" + format;
@@ -457,7 +456,7 @@ public class UpsertKafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testUpsertKafkaSourceSinkWithBoundedSpecificOffsets() throws Exception {
+    void testUpsertKafkaSourceSinkWithBoundedSpecificOffsets() throws Exception {
         final String topic = "bounded_upsert_" + format + "_" + UUID.randomUUID();
         createTestTopic(topic, 1, 1);
 
@@ -510,7 +509,7 @@ public class UpsertKafkaTableITCase extends KafkaTableTestBase {
     }
 
     @Test
-    public void testUpsertKafkaSourceSinkWithBoundedTimestamp() throws Exception {
+    void testUpsertKafkaSourceSinkWithBoundedTimestamp() throws Exception {
         final String topic = "bounded_upsert_" + format + "_" + UUID.randomUUID();
         createTestTopic(topic, 1, 1);
 
@@ -596,7 +595,7 @@ public class UpsertKafkaTableITCase extends KafkaTableTestBase {
      * results.
      */
     @Test
-    public void testUpsertKafkaSourceSinkWithZeroLengthBoundedness() throws Exception {
+    void testUpsertKafkaSourceSinkWithZeroLengthBoundedness() throws Exception {
         final String topic = "bounded_upsert_" + format + "_" + UUID.randomUUID();
         createTestTopic(topic, 1, 1);
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaTableITCase.java
@@ -23,7 +23,6 @@ import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
-import org.apache.flink.table.utils.LegacyRowResource;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;


### PR DESCRIPTION
### What is the purpose of the change

- [JUnit5 Migration] Module: [flink-connector-kafka](https://github.com/apache/flink-connector-kafka), [FLINK-25538](https://issues.apache.org/jira/browse/FLINK-25538).

### Brief change log

- Updated Junit4 test packages to Junit5 test packages. 
- This pull request is continuation of the previous pull request #66.

### Verifying this change

- This change is a trivial rework / code cleanup without any test coverage.
- Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)

### Documentation

- Does this pull request introduce a new feature? no)
- If yes, how is the feature documented? (not applicable)