### PR TITLE
[FLINK-35749] Kafka sink component will lose data when kafka cluster is unavailable for a while

### DIFF
--- a/flink-connector-kafka/archunit-violations/86dfd459-67a9-4b26-9b5c-0b0bbf22681a
+++ b/flink-connector-kafka/archunit-violations/86dfd459-67a9-4b26-9b5c-0b0bbf22681a
@@ -100,6 +100,12 @@ org.apache.flink.connector.kafka.sink.KafkaWriterITCase does not satisfy: only o
 * reside in a package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class InternalMiniClusterExtension\
 * reside outside of package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class MiniClusterExtension\
  or contain any fields that are public, static, and of type MiniClusterWithClientResource and final and annotated with @ClassRule or contain any fields that is of type MiniClusterWithClientResource and public and final and not static and annotated with @Rule
+org.apache.flink.connector.kafka.sink.KafkaWriterFaultToleranceITCase does not satisfy: only one of the following predicates match:\
+* reside in a package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type InternalMiniClusterExtension and annotated with @RegisterExtension\
+* reside outside of package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type MiniClusterExtension and annotated with @RegisterExtension or are , and of type MiniClusterTestEnvironment and annotated with @TestEnv\
+* reside in a package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class InternalMiniClusterExtension\
+* reside outside of package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class MiniClusterExtension\
+ or contain any fields that are public, static, and of type MiniClusterWithClientResource and final and annotated with @ClassRule or contain any fields that is of type MiniClusterWithClientResource and public and final and not static and annotated with @Rule
 org.apache.flink.connector.kafka.source.KafkaSourceITCase does not satisfy: only one of the following predicates match:\
 * reside in a package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type InternalMiniClusterExtension and annotated with @RegisterExtension\
 * reside outside of package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type MiniClusterExtension and annotated with @RegisterExtension or are , and of type MiniClusterTestEnvironment and annotated with @TestEnv\

--- a/flink-connector-kafka/archunit-violations/86dfd459-67a9-4b26-9b5c-0b0bbf22681a
+++ b/flink-connector-kafka/archunit-violations/86dfd459-67a9-4b26-9b5c-0b0bbf22681a
@@ -22,6 +22,12 @@ org.apache.flink.connector.kafka.sink.KafkaWriterITCase does not satisfy: only o
 * reside in a package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class InternalMiniClusterExtension\
 * reside outside of package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class MiniClusterExtension\
  or contain any fields that are public, static, and of type MiniClusterWithClientResource and final and annotated with @ClassRule or contain any fields that is of type MiniClusterWithClientResource and public and final and not static and annotated with @Rule
+org.apache.flink.connector.kafka.sink.KafkaWriterFaultToleranceITCase does not satisfy: only one of the following predicates match:\
+* reside in a package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type InternalMiniClusterExtension and annotated with @RegisterExtension\
+* reside outside of package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type MiniClusterExtension and annotated with @RegisterExtension\
+* reside in a package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class InternalMiniClusterExtension\
+* reside outside of package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class MiniClusterExtension\
+ or contain any fields that are public, static, and of type MiniClusterWithClientResource and final and annotated with @ClassRule or contain any fields that is of type MiniClusterWithClientResource and public and final and not static and annotated with @Rule
 org.apache.flink.connector.kafka.source.KafkaSourceITCase does not satisfy: only one of the following predicates match:\
 * reside in a package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type InternalMiniClusterExtension and annotated with @RegisterExtension\
 * reside outside of package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type MiniClusterExtension and annotated with @RegisterExtension\

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
@@ -449,7 +449,9 @@ class KafkaWriter<IN>
                 }
 
                 // Checking for exceptions from previous writes
-                mailboxExecutor.submit(
+                // Notice: throwing exception in mailboxExecutor thread is not safe enough for
+                // triggering global fail over, which has been fixed in [FLINK-31305].
+                mailboxExecutor.execute(
                         () -> {
                             // Checking for exceptions from previous writes
                             checkAsyncException();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
@@ -37,9 +37,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 @ExtendWith(TestLoggerExtension.class)
 public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
     private static final String INIT_KAFKA_RETRIES = "0";
-    private static final String INIT_KAFKA_REQUEST_TIMEOUT_MS = "2000";
-    private static final String INIT_KAFKA_MAX_BLOCK_MS = "3000";
-    private static final String INIT_KAFKA_DELIVERY_TIMEOUT_MS = "4000";
+    private static final String INIT_KAFKA_REQUEST_TIMEOUT_MS = "1000";
+    private static final String INIT_KAFKA_MAX_BLOCK_MS = "2000";
+    private static final String INIT_KAFKA_DELIVERY_TIMEOUT_MS = "3000";
 
     @BeforeAll
     public static void beforeAll() {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 /** Tests for the standalone KafkaWriter in case of fault tolerance. */
 @ExtendWith(TestLoggerExtension.class)
 public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
-    private static final String INIT_KAFKA_RETRIES = "1";
+    private static final String INIT_KAFKA_RETRIES = "0";
     private static final String INIT_KAFKA_REQUEST_TIMEOUT_MS = "2000";
     private static final String INIT_KAFKA_MAX_BLOCK_MS = "3000";
     private static final String INIT_KAFKA_DELIVERY_TIMEOUT_MS = "4000";

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.sink;
+
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.apache.kafka.common.errors.TimeoutException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Properties;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+
+/** Tests for the standalone KafkaWriter in case of fault tolerance. */
+@ExtendWith(TestLoggerExtension.class)
+public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
+    private static final String INIT_KAFKA_RETRIES = "1";
+    private static final String INIT_KAFKA_REQUEST_TIMEOUT_MS = "2000";
+    private static final String INIT_KAFKA_MAX_BLOCK_MS = "3000";
+    private static final String INIT_KAFKA_DELIVERY_TIMEOUT_MS = "4000";
+
+    @BeforeAll
+    public static void beforeAll() {
+        KAFKA_CONTAINER.start();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        KAFKA_CONTAINER.stop();
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo testInfo) {
+        super.setUp(testInfo);
+    }
+
+    @Test
+    void testWriteExceptionWhenKafkaUnavailable() throws Exception {
+        Properties properties = getPropertiesForSendingFaultTolerance();
+
+        final SinkWriterMetricGroup metricGroup = createSinkWriterMetricGroup();
+
+        final KafkaWriter<Integer> writer =
+                createWriterWithConfiguration(
+                        properties, DeliveryGuarantee.EXACTLY_ONCE, metricGroup);
+
+        writer.write(1, SINK_WRITER_CONTEXT);
+
+        KAFKA_CONTAINER.stop();
+
+        try {
+            writer.getCurrentProducer().flush();
+            assertThatCode(() -> writer.write(1, SINK_WRITER_CONTEXT))
+                    .hasRootCauseExactlyInstanceOf(TimeoutException.class);
+        } finally {
+            KAFKA_CONTAINER.start();
+        }
+    }
+
+    @Test
+    void testFlushExceptionWhenKafkaUnavailable() throws Exception {
+        Properties properties = getPropertiesForSendingFaultTolerance();
+
+        final SinkWriterMetricGroup metricGroup = createSinkWriterMetricGroup();
+
+        final KafkaWriter<Integer> writer =
+                createWriterWithConfiguration(
+                        properties, DeliveryGuarantee.EXACTLY_ONCE, metricGroup);
+        writer.write(1, SINK_WRITER_CONTEXT);
+
+        KAFKA_CONTAINER.stop();
+        try {
+            assertThatCode(() -> writer.flush(false))
+                    .hasRootCauseExactlyInstanceOf(TimeoutException.class);
+        } finally {
+            KAFKA_CONTAINER.start();
+        }
+    }
+
+    @Test
+    void testCloseExceptionWhenKafkaUnavailable() throws Exception {
+        Properties properties = getPropertiesForSendingFaultTolerance();
+
+        final SinkWriterMetricGroup metricGroup = createSinkWriterMetricGroup();
+
+        final KafkaWriter<Integer> writer =
+                createWriterWithConfiguration(
+                        properties, DeliveryGuarantee.EXACTLY_ONCE, metricGroup);
+
+        writer.write(1, SINK_WRITER_CONTEXT);
+
+        KAFKA_CONTAINER.stop();
+
+        try {
+            writer.getCurrentProducer().flush();
+            // closing producer resource throws exception first
+            assertThatCode(() -> writer.close())
+                    .hasNoCause()
+                    .hasMessage(
+                            String.format(
+                                    "Timeout expired after %sms while awaiting " + "InitProducerId",
+                                    INIT_KAFKA_MAX_BLOCK_MS));
+        } finally {
+            KAFKA_CONTAINER.start();
+        }
+    }
+
+    @Test
+    void testMailboxExceptionWhenKafkaUnavailable() throws Exception {
+        Properties properties = getPropertiesForSendingFaultTolerance();
+        SinkInitContext sinkInitContext =
+                new SinkInitContext(createSinkWriterMetricGroup(), timeService, null);
+
+        final KafkaWriter<Integer> writer =
+                createWriterWithConfiguration(
+                        properties, DeliveryGuarantee.EXACTLY_ONCE, sinkInitContext);
+
+        KAFKA_CONTAINER.stop();
+
+        writer.write(1, SINK_WRITER_CONTEXT);
+
+        try {
+            writer.getCurrentProducer().flush();
+
+            assertThatCode(
+                            () -> {
+                                while (sinkInitContext.getMailboxExecutor().tryYield()) {
+                                    // execute all mails
+                                }
+                            })
+                    .hasRootCauseExactlyInstanceOf(TimeoutException.class);
+        } finally {
+            KAFKA_CONTAINER.start();
+        }
+    }
+
+    private Properties getPropertiesForSendingFaultTolerance() {
+        Properties properties = getKafkaClientConfiguration();
+
+        // reduce the default vault for test case
+        properties.setProperty("retries", INIT_KAFKA_RETRIES);
+        properties.setProperty("request.timeout.ms", INIT_KAFKA_REQUEST_TIMEOUT_MS);
+        properties.setProperty("max.block.ms", INIT_KAFKA_MAX_BLOCK_MS);
+        properties.setProperty("delivery.timeout.ms", INIT_KAFKA_DELIVERY_TIMEOUT_MS);
+
+        return properties;
+    }
+}

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.connector.kafka.sink;
 
-import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.operators.ProcessingTimeService;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.connector.sink2.SinkWriter;
@@ -31,7 +30,6 @@ import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.metrics.testutils.MetricListener;
-import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.ProxyMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
@@ -583,11 +581,6 @@ public class KafkaWriterITCase {
         @Override
         public UserCodeClassLoader getUserCodeClassLoader() {
             throw new UnsupportedOperationException("Not implemented.");
-        }
-
-        @Override
-        public MailboxExecutor getMailboxExecutor() {
-            return new SyncMailboxExecutor();
         }
 
         @Override

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
@@ -260,9 +260,14 @@ public class KafkaWriterITCase {
         // to ensure that the exceptional send request has completed
         writer.getCurrentProducer().flush();
 
-        while (sinkInitContext.getMailboxExecutor().tryYield()) {
-            // execute all mails
-        }
+        assertThatCode(
+                        () -> {
+                            while (sinkInitContext.getMailboxExecutor().tryYield()) {
+                                // execute all mails
+                            }
+                        })
+                .hasRootCauseExactlyInstanceOf(ProducerFencedException.class);
+
         assertThat(numRecordsOutErrors.getCount()).isEqualTo(1L);
 
         assertThatCode(() -> writer.write(1, SINK_WRITER_CONTEXT))

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.connector.kafka.sink;
 
+import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.operators.ProcessingTimeService;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.connector.sink2.SinkWriter;
@@ -30,6 +31,7 @@ import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.metrics.testutils.MetricListener;
+import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.ProxyMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
@@ -576,6 +578,11 @@ public class KafkaWriterITCase {
         @Override
         public UserCodeClassLoader getUserCodeClassLoader() {
             throw new UnsupportedOperationException("Not implemented.");
+        }
+
+        @Override
+        public MailboxExecutor getMailboxExecutor() {
+            return new SyncMailboxExecutor();
         }
 
         @Override

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterTestBase.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.sink;
+
+import org.apache.flink.api.common.operators.ProcessingTimeService;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.connector.base.sink.writer.TestSinkInitContext;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.apache.flink.metrics.testutils.MetricListener;
+import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.ProxyMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.util.UserCodeClassLoader;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.PriorityQueue;
+import java.util.Properties;
+import java.util.concurrent.ScheduledFuture;
+import java.util.function.Consumer;
+
+import static org.apache.flink.connector.kafka.testutils.DockerImageVersions.KAFKA;
+import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createKafkaContainer;
+
+/** Test base for KafkaWriter. */
+public abstract class KafkaWriterTestBase {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(KafkaWriterTestBase.class);
+    protected static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
+    protected static final Network NETWORK = Network.newNetwork();
+    protected static final String KAFKA_METRIC_WITH_GROUP_NAME =
+            "KafkaProducer.incoming-byte-total";
+    protected static final SinkWriter.Context SINK_WRITER_CONTEXT = new DummySinkWriterContext();
+    protected static String topic;
+
+    protected MetricListener metricListener;
+    protected TriggerTimeService timeService;
+
+    protected static final KafkaContainer KAFKA_CONTAINER =
+            createKafkaContainer(KAFKA, LOG)
+                    .withEmbeddedZookeeper()
+                    .withNetwork(NETWORK)
+                    .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);
+
+    @BeforeEach
+    public void setUp(TestInfo testInfo) {
+        metricListener = new MetricListener();
+        timeService = new TriggerTimeService();
+        topic = testInfo.getDisplayName().replaceAll("\\W", "");
+    }
+
+    protected KafkaWriter<Integer> createWriterWithConfiguration(
+            Properties config, DeliveryGuarantee guarantee) throws IOException {
+        return createWriterWithConfiguration(config, guarantee, createSinkWriterMetricGroup());
+    }
+
+    protected KafkaWriter<Integer> createWriterWithConfiguration(
+            Properties config,
+            DeliveryGuarantee guarantee,
+            SinkWriterMetricGroup sinkWriterMetricGroup)
+            throws IOException {
+        return createWriterWithConfiguration(config, guarantee, sinkWriterMetricGroup, null);
+    }
+
+    protected KafkaWriter<Integer> createWriterWithConfiguration(
+            Properties config,
+            DeliveryGuarantee guarantee,
+            SinkWriterMetricGroup sinkWriterMetricGroup,
+            @Nullable Consumer<RecordMetadata> metadataConsumer)
+            throws IOException {
+        KafkaSink<Integer> kafkaSink =
+                KafkaSink.<Integer>builder()
+                        .setKafkaProducerConfig(config)
+                        .setDeliveryGuarantee(guarantee)
+                        .setTransactionalIdPrefix("test-prefix")
+                        .setRecordSerializer(new DummyRecordSerializer())
+                        .build();
+        return (KafkaWriter<Integer>)
+                kafkaSink.createWriter(
+                        new SinkInitContext(sinkWriterMetricGroup, timeService, metadataConsumer));
+    }
+
+    protected KafkaWriter<Integer> createWriterWithConfiguration(
+            Properties config, DeliveryGuarantee guarantee, SinkInitContext sinkInitContext)
+            throws IOException {
+        KafkaSink<Integer> kafkaSink =
+                KafkaSink.<Integer>builder()
+                        .setKafkaProducerConfig(config)
+                        .setDeliveryGuarantee(guarantee)
+                        .setTransactionalIdPrefix("test-prefix")
+                        .setRecordSerializer(new DummyRecordSerializer())
+                        .build();
+        return (KafkaWriter<Integer>) kafkaSink.createWriter(sinkInitContext);
+    }
+
+    protected SinkWriterMetricGroup createSinkWriterMetricGroup() {
+        DummyOperatorMetricGroup operatorMetricGroup =
+                new DummyOperatorMetricGroup(metricListener.getMetricGroup());
+        return InternalSinkWriterMetricGroup.wrap(operatorMetricGroup);
+    }
+
+    protected static Properties getKafkaClientConfiguration() {
+        final Properties standardProps = new Properties();
+        standardProps.put("bootstrap.servers", KAFKA_CONTAINER.getBootstrapServers());
+        standardProps.put("group.id", "kafkaWriter-tests");
+        standardProps.put("enable.auto.commit", false);
+        standardProps.put("key.serializer", ByteArraySerializer.class.getName());
+        standardProps.put("value.serializer", ByteArraySerializer.class.getName());
+        standardProps.put("auto.offset.reset", "earliest");
+        return standardProps;
+    }
+
+    /** mock sink context for initializing KafkaWriter. */
+    protected static class SinkInitContext extends TestSinkInitContext {
+
+        protected final SinkWriterMetricGroup metricGroup;
+        protected final ProcessingTimeService timeService;
+        @Nullable protected final Consumer<RecordMetadata> metadataConsumer;
+
+        SinkInitContext(
+                SinkWriterMetricGroup metricGroup,
+                ProcessingTimeService timeService,
+                @Nullable Consumer<RecordMetadata> metadataConsumer) {
+            this.metricGroup = metricGroup;
+            this.timeService = timeService;
+            this.metadataConsumer = metadataConsumer;
+        }
+
+        @Override
+        public UserCodeClassLoader getUserCodeClassLoader() {
+            throw new UnsupportedOperationException("Not implemented.");
+        }
+
+        @Override
+        public ProcessingTimeService getProcessingTimeService() {
+            return timeService;
+        }
+
+        @Override
+        public int getSubtaskId() {
+            return 0;
+        }
+
+        @Override
+        public int getNumberOfParallelSubtasks() {
+            return 1;
+        }
+
+        @Override
+        public int getAttemptNumber() {
+            return 0;
+        }
+
+        @Override
+        public SinkWriterMetricGroup metricGroup() {
+            return metricGroup;
+        }
+
+        @Override
+        public OptionalLong getRestoredCheckpointId() {
+            return OptionalLong.empty();
+        }
+
+        @Override
+        public SerializationSchema.InitializationContext
+                asSerializationSchemaInitializationContext() {
+            return null;
+        }
+
+        @Override
+        public <MetaT> Optional<Consumer<MetaT>> metadataConsumer() {
+            return Optional.ofNullable((Consumer<MetaT>) metadataConsumer);
+        }
+    }
+
+    /** mock recordSerializer for KafkaSink. */
+    protected static class DummyRecordSerializer
+            implements KafkaRecordSerializationSchema<Integer> {
+        @Override
+        public ProducerRecord<byte[], byte[]> serialize(
+                Integer element, KafkaSinkContext context, Long timestamp) {
+            if (element == null) {
+                // in general, serializers should be allowed to skip invalid elements
+                return null;
+            }
+            return new ProducerRecord<>(topic, ByteBuffer.allocate(4).putInt(element).array());
+        }
+    }
+
+    /**
+     * mock context for KafkaWriter#write(java.lang.Object,
+     * org.apache.flink.api.connector.sink2.SinkWriter.Context).
+     */
+    protected static class DummySinkWriterContext implements SinkWriter.Context {
+        @Override
+        public long currentWatermark() {
+            return 0;
+        }
+
+        @Override
+        public Long timestamp() {
+            return null;
+        }
+    }
+
+    /** mock metrics group for initializing KafkaWriter. */
+    protected static class DummyOperatorMetricGroup extends ProxyMetricGroup<MetricGroup>
+            implements OperatorMetricGroup {
+
+        private final OperatorIOMetricGroup operatorIOMetricGroup;
+
+        public DummyOperatorMetricGroup(MetricGroup parentMetricGroup) {
+            super(parentMetricGroup);
+            this.operatorIOMetricGroup =
+                    UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup()
+                            .getIOMetricGroup();
+        }
+
+        @Override
+        public OperatorIOMetricGroup getIOMetricGroup() {
+            return operatorIOMetricGroup;
+        }
+    }
+
+    /** mock time service for KafkaWriter. */
+    protected static class TriggerTimeService implements ProcessingTimeService {
+
+        private final PriorityQueue<Tuple2<Long, ProcessingTimeCallback>> registeredCallbacks =
+                new PriorityQueue<>(Comparator.comparingLong(o -> o.f0));
+
+        @Override
+        public long getCurrentProcessingTime() {
+            return 0;
+        }
+
+        @Override
+        public ScheduledFuture<?> registerTimer(
+                long time, ProcessingTimeCallback processingTimerCallback) {
+            registeredCallbacks.add(new Tuple2<>(time, processingTimerCallback));
+            return null;
+        }
+
+        public void trigger() throws Exception {
+            final Tuple2<Long, ProcessingTimeCallback> registered = registeredCallbacks.poll();
+            if (registered == null) {
+                LOG.warn("Triggered time service but no callback was registered.");
+                return;
+            }
+            registered.f1.onProcessingTime(registered.f0);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix the bug for losing data during kafka cluster is unavailable for a while.
The related issue: https://issues.apache.org/jira/browse/FLINK-35749 tells how to reproduce this bug.

## Brief change log

The key problem is in WriterCallback#onCompletion of KafkaWriter:
  ```java
                  mailboxExecutor.submit(
                        () -> {
                            // Checking for exceptions from previous writes
                            checkAsyncException();
                        },
                        "Update error metric");
  ```
'mailboxExecutor.submit' without getting future back will not throw exception, which causes the 'asyncProducerException' is assign to null but the job seems like nothing happened. The fix is using 'mailboxExecutor.execute' instead of 'mailboxExecutor.submit'.


## Verifying this change

Added new test case KafkaWriterFaultToleranceITCase to cover this bug.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable