### PR TITLE
[FLINK-35870] Change DEFAULT_KAFKA_TRANSACTION_TIMEOUT in KafkaSinkBuilder

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilder.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilder.java
@@ -61,7 +61,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 public class KafkaSinkBuilder<IN> {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaSinkBuilder.class);
-    private static final Duration DEFAULT_KAFKA_TRANSACTION_TIMEOUT = Duration.ofHours(1);
+    private static final Duration DEFAULT_KAFKA_TRANSACTION_TIMEOUT = Duration.ofMinutes(15);
     private static final String[] warnKeys =
             new String[] {
                 ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilderTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.TestLogger;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Properties;
 import java.util.function.Consumer;
@@ -85,6 +86,27 @@ public class KafkaSinkBuilderTest extends TestLogger {
         validateProducerConfig(
                 getNoServerBuilder().setKafkaProducerConfig(testConf1),
                 p -> assertThat(p).containsKeys(DEFAULT_KEYS));
+    }
+
+    @Test
+    public void testTransactionTimeoutSetting() {
+        validateProducerConfig(
+                getBasicBuilder(),
+                p -> {
+                    assertThat(p.get(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG))
+                            .isEqualTo((int) Duration.ofMinutes(15).toMillis());
+                });
+
+        Properties testConf = new Properties();
+        testConf.put(
+                ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, (int) Duration.ofHours(1).toMillis());
+
+        validateProducerConfig(
+                getBasicBuilder().setKafkaProducerConfig(testConf),
+                p -> {
+                    assertThat(p.get(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG))
+                            .isEqualTo((int) Duration.ofHours(1).toMillis());
+                });
     }
 
     private void validateProducerConfig(


### PR DESCRIPTION
change `DEFAULT_KAFKA_TRANSACTION_TIMEOUT` in `KafkaSinkBuilder` class.

The default value is 15 minutes, as shown in the official Kakfa documentation.

So I changed it from 1 hour to 15 minutes and added the test.
<img width="717" alt="스크린샷 2024-07-28 오후 1 56 35" src="https://github.com/user-attachments/assets/9b3a4322-48d9-439d-9917-e7cc9d639317">
