### PR TITLE
Reduce some redundant operations in the initialization of KafkaSourceEnumState

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumState.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumState.java
@@ -32,7 +32,7 @@ public class KafkaSourceEnumState {
     /** Partitions with status: ASSIGNED or UNASSIGNED_INITIAL. */
     private final Set<TopicPartitionAndAssignmentStatus> partitions;
     /**
-     * this flag will be marked as true if inital partitions are discovered after enumerator starts.
+     * this flag will be marked as true if initial partitions are discovered after enumerator starts.
      */
     private final boolean initialDiscoveryFinished;
 

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumStateSerializer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumStateSerializer.java
@@ -118,7 +118,6 @@ public class KafkaSourceEnumStateSerializer
                 DataInputStream in = new DataInputStream(bais)) {
 
             final int numPartitions = in.readInt();
-            Set<TopicPartition> topicPartitions = new HashSet<>(numPartitions);
             Set<TopicPartitionAndAssignmentStatus> partitions = new HashSet<>(numPartitions);
             for (int i = 0; i < numPartitions; i++) {
                 final String topic = in.readUTF();

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -112,7 +112,7 @@ public class KafkaSourceEnumerator
                 properties,
                 context,
                 boundedness,
-                new KafkaSourceEnumState(Collections.emptySet(), Collections.emptySet(), false));
+                new KafkaSourceEnumState(Collections.emptySet(), false));
     }
 
     public KafkaSourceEnumerator(


### PR DESCRIPTION
## What is the purpose of the change

In certain methods, such as the `DynamicKafkaSourceEnumerator#onHandleSubscribedStreamsFetch()` method, partitions are divided into `assignedPartitions` and `unassignedInitialPartitions` before being passed as parameters to the KafkaSourceEnumState constructor. However, within the constructor, these `assignedPartitions` and `unassignedInitialPartitions` are recombined into partitions, leading to unnecessary operations and reduced performance. By optimizing the code to pass partitions directly as a parameter when initializing KafkaSourceEnumState, we can eliminate redundant operations and enhance performance.


## Brief change log

## Verifying this change
- This change is a trivial rework / code cleanup without any test coverage.
- Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @public(Evolving): (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)
## Documentation
- Does this pull request introduce a new feature? no)
- If yes, how is the feature documented? (not applicable)