### PR TITLE
[FLINK-36210] Optimize the logic for fetching topic metadata in the TopicPatternSubscriber mode

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
@@ -44,7 +44,7 @@ class KafkaSubscriberUtils {
         try {
             Set<String> allTopicNames = adminClient.listTopics().names().get();
             Set<String> patternTopicNames = allTopicNames.stream()
-                    .filter(topicName -> topicPattern.matcher(topicName).matches())
+                    .filter(name -> topicPattern.matcher(name).matches())
                     .collect(Collectors.toSet());
             return getTopicMetadata(adminClient, patternTopicNames);
         } catch (Exception e) {

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
@@ -43,10 +43,10 @@ class KafkaSubscriberUtils {
     static Map<String, TopicDescription> getTopicMetadata(AdminClient adminClient, Pattern topicPattern) {
         try {
             Set<String> allTopicNames = adminClient.listTopics().names().get();
-            Set<String> patternTopicNames = allTopicNames.stream()
+            Set<String> matchedTopicNames = allTopicNames.stream()
                     .filter(name -> topicPattern.matcher(name).matches())
                     .collect(Collectors.toSet());
-            return getTopicMetadata(adminClient, patternTopicNames);
+            return getTopicMetadata(adminClient, matchedTopicNames);
         } catch (Exception e) {
             throw new RuntimeException(
                     String.format("Failed to get metadata for %s topics.", topicPattern.pattern()), e);

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
@@ -23,6 +23,8 @@ import org.apache.kafka.clients.admin.TopicDescription;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /** The base implementations of {@link KafkaSubscriber}. */
 class KafkaSubscriberUtils {
@@ -35,6 +37,19 @@ class KafkaSubscriberUtils {
             return getTopicMetadata(adminClient, allTopicNames);
         } catch (Exception e) {
             throw new RuntimeException("Failed to get metadata for all topics.", e);
+        }
+    }
+
+    static Map<String, TopicDescription> getTopicMetadata(AdminClient adminClient, Pattern topicPattern) {
+        try {
+            Set<String> allTopicNames = adminClient.listTopics().names().get();
+            Set<String> patternTopicNames = allTopicNames.stream()
+                    .filter(topicName -> topicPattern.matcher(topicName).matches())
+                    .collect(Collectors.toSet());
+            return getTopicMetadata(adminClient, patternTopicNames);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    String.format("Failed to get metadata for %s topics.", topicPattern.pattern()), e);
         }
     }
 

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
@@ -45,11 +45,11 @@ class TopicPatternSubscriber implements KafkaSubscriber {
     @Override
     public Set<TopicPartition> getSubscribedTopicPartitions(AdminClient adminClient) {
         LOG.debug("Fetching descriptions for {} topics on Kafka cluster", topicPattern.pattern());
-        final Map<String, TopicDescription> patternTopicMetadata = getTopicMetadata(adminClient, topicPattern);
+        final Map<String, TopicDescription> matchedTopicMetadata = getTopicMetadata(adminClient, topicPattern);
 
         Set<TopicPartition> subscribedTopicPartitions = new HashSet<>();
 
-        patternTopicMetadata.forEach(
+        matchedTopicMetadata.forEach(
                 (topicName, topicDescription) -> {
                     for (TopicPartitionInfo partition : topicDescription.partitions()) {
                         subscribedTopicPartitions.add(

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.getAllTopicMetadata;
+import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.getTopicMetadata;
 
 /** A subscriber to a topic pattern. */
 class TopicPatternSubscriber implements KafkaSubscriber {
@@ -44,20 +44,19 @@ class TopicPatternSubscriber implements KafkaSubscriber {
 
     @Override
     public Set<TopicPartition> getSubscribedTopicPartitions(AdminClient adminClient) {
-        LOG.debug("Fetching descriptions for all topics on Kafka cluster");
-        final Map<String, TopicDescription> allTopicMetadata = getAllTopicMetadata(adminClient);
+        LOG.debug("Fetching descriptions for {} topics on Kafka cluster", topicPattern.pattern());
+        final Map<String, TopicDescription> patternTopicMetadata = getTopicMetadata(adminClient, topicPattern);
 
         Set<TopicPartition> subscribedTopicPartitions = new HashSet<>();
 
-        allTopicMetadata.forEach(
+        patternTopicMetadata.forEach(
                 (topicName, topicDescription) -> {
-                    if (topicPattern.matcher(topicName).matches()) {
-                        for (TopicPartitionInfo partition : topicDescription.partitions()) {
-                            subscribedTopicPartitions.add(
-                                    new TopicPartition(
-                                            topicDescription.name(), partition.partition()));
-                        }
+                    for (TopicPartitionInfo partition : topicDescription.partitions()) {
+                        subscribedTopicPartitions.add(
+                                new TopicPartition(
+                                        topicDescription.name(), partition.partition()));
                     }
+
                 });
 
         return subscribedTopicPartitions;


### PR DESCRIPTION
## What is the purpose of the change

In `TopicPatternSubscriber` mode, our current logic for fetch topic metadata for all topics and then filtering it. We can optimize this by first filtering the topic names and then fetch metadata only for the filtered topics.

## Brief change log

## Verifying this change
- This change is a trivial rework / code cleanup without any test coverage.
- Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @public(Evolving): (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)
## Documentation
- Does this pull request introduce a new feature? no)
- If yes, how is the feature documented? (not applicable)