### PR TITLE
[FLINK-28842] add client.id.prefix for kafka sink

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/DefaultKafkaSinkContext.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/DefaultKafkaSinkContext.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.apache.flink.connector.kafka.sink.KafkaSink.withClientId;
+
 /**
  * Context providing information to assist constructing a {@link
  * org.apache.kafka.clients.producer.ProducerRecord}.
@@ -37,6 +39,7 @@ public class DefaultKafkaSinkContext implements KafkaRecordSerializationSchema.K
     private final int subtaskId;
     private final int numberOfParallelInstances;
     private final Properties kafkaProducerConfig;
+    private static final String clientIdSuffix = "-metadata-fetcher";
 
     private final Map<String, int[]> cachedPartitions = new HashMap<>();
 
@@ -63,7 +66,8 @@ public class DefaultKafkaSinkContext implements KafkaRecordSerializationSchema.K
     }
 
     private int[] fetchPartitionsForTopic(String topic) {
-        try (final Producer<?, ?> producer = new KafkaProducer<>(kafkaProducerConfig)) {
+        try (final Producer<?, ?> producer =
+                new KafkaProducer<>(withClientId(kafkaProducerConfig, clientIdSuffix))) {
             // the fetched list is immutable, so we're creating a mutable copy in order to sort
             // it
             final List<PartitionInfo> partitionsList =

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducer.java
@@ -38,13 +38,13 @@ import java.time.Duration;
 import java.util.Properties;
 import java.util.concurrent.Future;
 
+import static org.apache.flink.connector.kafka.sink.KafkaSink.withClientId;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A {@link KafkaProducer} that exposes private fields to allow resume producing from a given state.
  */
 class FlinkKafkaInternalProducer<K, V> extends KafkaProducer<K, V> {
-
     private static final Logger LOG = LoggerFactory.getLogger(FlinkKafkaInternalProducer.class);
     private static final String TRANSACTION_MANAGER_FIELD_NAME = "transactionManager";
     private static final String TRANSACTION_MANAGER_STATE_ENUM =
@@ -55,9 +55,10 @@ class FlinkKafkaInternalProducer<K, V> extends KafkaProducer<K, V> {
     private volatile boolean inTransaction;
     private volatile boolean hasRecordsInTransaction;
     private volatile boolean closed;
+    private static final String clientIdSuffix = "";
 
     public FlinkKafkaInternalProducer(Properties properties, @Nullable String transactionalId) {
-        super(withTransactionalId(properties, transactionalId));
+        super(withClientId(withTransactionalId(properties, transactionalId), clientIdSuffix));
         this.transactionalId = transactionalId;
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-28842

fix javax.management.InstanceAlreadyExistsException for kafka sink