### PR TITLE
[FLINK-36278] Reduce log size

### DIFF
--- a/flink-connector-kafka-e2e-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
+++ b/flink-connector-kafka-e2e-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
@@ -45,8 +45,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Container;
@@ -62,7 +60,6 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.connector.kafka.testutils.DockerImageVersions.KAFKA;
 import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createKafkaContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -71,20 +68,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Testcontainers
 class SmokeKafkaITCase {
 
-    private static final Logger LOG = LoggerFactory.getLogger(SmokeKafkaITCase.class);
     private static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
     private static final Network NETWORK = Network.newNetwork();
     private static final String EXAMPLE_JAR_MATCHER = "flink-streaming-kafka-test.*";
 
     @Container
     public static final KafkaContainer KAFKA_CONTAINER =
-            createKafkaContainer(KAFKA, LOG)
+            createKafkaContainer(SmokeKafkaITCase.class)
                     .withEmbeddedZookeeper()
                     .withNetwork(NETWORK)
                     .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);
 
     public static final TestcontainersSettings TESTCONTAINERS_SETTINGS =
-            TestcontainersSettings.builder().logger(LOG).dependsOn(KAFKA_CONTAINER).build();
+            TestcontainersSettings.builder()
+                    .logger(KafkaUtil.getLogger("flink", SmokeKafkaITCase.class))
+                    .dependsOn(KAFKA_CONTAINER)
+                    .build();
 
     @RegisterExtension
     public static final FlinkContainers FLINK =

--- a/flink-connector-kafka-e2e-tests/flink-end-to-end-tests-common-kafka/src/test/resources/log4j2-test.properties
+++ b/flink-connector-kafka-e2e-tests/flink-end-to-end-tests-common-kafka/src/test/resources/log4j2-test.properties
@@ -32,3 +32,27 @@ appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
 #logger.yarn.name = org.testcontainers.shaded.com.github.dockerjava.core
 #logger.yarn.level = WARN
 #logger.yarn.appenderRef.console.ref = TestLogger
+
+# Logger configuration for containers, by default this is off
+# If you want to investigate test failures, overwrite the level as above
+logger.container.name = container
+logger.container.level = OFF
+logger.container.additivity = false  # This prevents messages from being logged by the root logger
+logger.container.appenderRef.containerappender.ref = ContainerLogger
+
+logger.kafkacontainer.name = container.kafka
+logger.kafkacontainer.level = OFF
+
+logger.flinkcontainer.name = container.flink
+logger.flinkcontainer.level = OFF
+
+logger.flinkenv.name = org.apache.flink.connector.testframe.container.FlinkContainerTestEnvironment
+logger.flinkenv.level = OFF
+logger.flinkenv.additivity = false  # This prevents messages from being logged by the root logger
+logger.flinkenv.appenderRef.containerappender.ref = ContainerLogger
+
+appender.containerappender.name = ContainerLogger
+appender.containerappender.type = CONSOLE
+appender.containerappender.target = SYSTEM_ERR
+appender.containerappender.layout.type = PatternLayout
+appender.containerappender.layout.pattern = [%c{1}] %m%n

--- a/flink-connector-kafka/pom.xml
+++ b/flink-connector-kafka/pom.xml
@@ -133,32 +133,6 @@ under the License.
             <type>test-jar</type>
         </dependency>
 
-
-        <dependency>
-            <!-- include kafka server for tests  -->
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_${scala.binary.version}</artifactId>
-            <version>${kafka.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.dropwizard.metrics</groupId>
-                    <artifactId>metrics-core</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>test</scope>
-        </dependency>
-
-		<dependency>
-			<groupId>org.apache.zookeeper</groupId>
-			<artifactId>zookeeper</artifactId>
-			<version>${zookeeper.version}</version>
-			<scope>test</scope>
-		</dependency>
-
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
@@ -138,7 +138,7 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
         }
 
         if (restartingReaders.get()) {
-            logger.info("Poll next invoked while restarting readers");
+            logger.debug("Poll next invoked while restarting readers");
             return logAndReturnInputStatus(InputStatus.NOTHING_AVAILABLE);
         }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducerITCase.java
@@ -34,8 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -47,7 +45,6 @@ import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.connector.kafka.testutils.DockerImageVersions.KAFKA;
 import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createKafkaContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -56,12 +53,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ExtendWith(TestLoggerExtension.class)
 class FlinkKafkaInternalProducerITCase {
 
-    private static final Logger LOG =
-            LoggerFactory.getLogger(FlinkKafkaInternalProducerITCase.class);
-
     @Container
     private static final KafkaContainer KAFKA_CONTAINER =
-            createKafkaContainer(KAFKA, LOG).withEmbeddedZookeeper();
+            createKafkaContainer(FlinkKafkaInternalProducerITCase.class).withEmbeddedZookeeper();
 
     @Test
     void testInitTransactionId() {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
@@ -101,7 +101,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
-import static org.apache.flink.connector.kafka.testutils.DockerImageVersions.KAFKA;
 import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createKafkaContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -124,7 +123,7 @@ public class KafkaSinkITCase extends TestLogger {
 
     @ClassRule
     public static final KafkaContainer KAFKA_CONTAINER =
-            createKafkaContainer(KAFKA, LOG)
+            createKafkaContainer(KafkaSinkITCase.class)
                     .withEmbeddedZookeeper()
                     .withNetwork(NETWORK)
                     .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaTransactionLogITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaTransactionLogITCase.java
@@ -44,7 +44,6 @@ import static org.apache.flink.connector.kafka.sink.KafkaTransactionLog.Transact
 import static org.apache.flink.connector.kafka.sink.KafkaTransactionLog.TransactionState.Ongoing;
 import static org.apache.flink.connector.kafka.sink.KafkaTransactionLog.TransactionState.PrepareAbort;
 import static org.apache.flink.connector.kafka.sink.KafkaTransactionLog.TransactionState.PrepareCommit;
-import static org.apache.flink.connector.kafka.testutils.DockerImageVersions.KAFKA;
 import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createKafkaContainer;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,7 +56,7 @@ public class KafkaTransactionLogITCase extends TestLogger {
 
     @ClassRule
     public static final KafkaContainer KAFKA_CONTAINER =
-            createKafkaContainer(KAFKA, LOG).withEmbeddedZookeeper();
+            createKafkaContainer(KafkaTransactionLogITCase.class).withEmbeddedZookeeper();
 
     private final List<Producer<byte[], Integer>> openProducers = new ArrayList<>();
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterTestBase.java
@@ -55,7 +55,6 @@ import java.util.Properties;
 import java.util.concurrent.ScheduledFuture;
 import java.util.function.Consumer;
 
-import static org.apache.flink.connector.kafka.testutils.DockerImageVersions.KAFKA;
 import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createKafkaContainer;
 
 /** Test base for KafkaWriter. */
@@ -73,7 +72,7 @@ public abstract class KafkaWriterTestBase {
     protected TriggerTimeService timeService;
 
     protected static final KafkaContainer KAFKA_CONTAINER =
-            createKafkaContainer(KAFKA, LOG)
+            createKafkaContainer(KafkaWriterTestBase.class)
                     .withEmbeddedZookeeper()
                     .withNetwork(NETWORK)
                     .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/DynamicKafkaSourceExternalContext.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/DynamicKafkaSourceExternalContext.java
@@ -240,7 +240,7 @@ public class DynamicKafkaSourceExternalContext implements DataStreamSourceExtern
                         }
                     }
 
-                    logger.info("Writing producer records: {}", producerRecords);
+                    logger.debug("Writing producer records: {}", producerRecords);
 
                     DynamicKafkaSourceTestHelper.produceToKafka(
                             clusterPropertiesMap.get(cluster),

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerMigrationTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerMigrationTest.java
@@ -54,7 +54,6 @@ public class FlinkKafkaProducerMigrationTest extends KafkaMigrationTestBase {
         Properties properties = new Properties();
         properties.putAll(standardProps);
         properties.putAll(secureProps);
-        properties.put(ProducerConfig.CLIENT_ID_CONFIG, "producer-client-id");
         properties.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "producer-transaction-id");
         properties.put(FlinkKafkaProducer.KEY_DISABLE_METRICS, "true");
         return properties;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -2097,7 +2097,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
                                 count++;
 
-                                LOG.info("Received message {}, total {} messages", value, count);
+                                LOG.debug("Received message {}, total {} messages", value, count);
 
                                 // verify if we've seen everything
                                 if (count == finalCount) {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -53,10 +53,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
-import scala.concurrent.duration.FiniteDuration;
 
 import static org.assertj.core.api.Assertions.fail;
 
@@ -89,8 +86,6 @@ public abstract class KafkaTestBase extends TestLogger {
     public static String brokerConnectionStrings;
 
     public static Properties standardProps;
-
-    public static FiniteDuration timeout = new FiniteDuration(10, TimeUnit.SECONDS);
 
     public static KafkaTestEnvironment kafkaServer;
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -165,7 +165,7 @@ public abstract class KafkaTestBase extends TestLogger {
             throws Exception {
         kafkaServer = constructKafkaTestEnvironment();
 
-        LOG.info("Starting KafkaTestBase.prepare() for Kafka " + kafkaServer.getVersion());
+        LOG.info("Starting KafkaTestBase.prepare() for Kafka {}", kafkaServer.getVersion());
 
         kafkaServer.prepare(environmentConfig);
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -434,7 +434,7 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
             int brokerID, @Nullable GenericContainer<?> zookeeper) {
         String brokerName = String.format("Kafka-%d", brokerID);
         KafkaContainer broker =
-                KafkaUtil.createKafkaContainer(DockerImageVersions.KAFKA, LOG, brokerName)
+                KafkaUtil.createKafkaContainer(brokerName)
                         .withNetworkAliases(brokerName)
                         .withEnv("KAFKA_BROKER_ID", String.valueOf(brokerID))
                         .withEnv("KAFKA_MESSAGE_MAX_BYTES", String.valueOf(50 * 1024 * 1024))

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/metrics/KafkaMetricMutableWrapperTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/metrics/KafkaMetricMutableWrapperTest.java
@@ -28,8 +28,6 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Container;
@@ -42,20 +40,18 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static org.apache.flink.connector.kafka.testutils.DockerImageVersions.KAFKA;
 import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createKafkaContainer;
 
 @Testcontainers
 @ExtendWith(TestLoggerExtension.class)
 class KafkaMetricMutableWrapperTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaMetricMutableWrapperTest.class);
     private static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
     private static final Network NETWORK = Network.newNetwork();
 
     @Container
     public static final KafkaContainer KAFKA_CONTAINER =
-            createKafkaContainer(KAFKA, LOG)
+            createKafkaContainer(KafkaMetricMutableWrapperTest.class)
                     .withEmbeddedZookeeper()
                     .withNetwork(NETWORK)
                     .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
@@ -19,7 +19,7 @@
 package org.apache.flink.streaming.connectors.kafka.table;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.connector.kafka.testutils.DockerImageVersions;
+import org.apache.flink.connector.kafka.testutils.KafkaUtil;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.test.util.AbstractTestBase;
@@ -41,8 +41,6 @@ import org.junit.ClassRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.utility.DockerImageName;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -65,15 +63,8 @@ public abstract class KafkaTableTestBase extends AbstractTestBase {
 
     @ClassRule
     public static final KafkaContainer KAFKA_CONTAINER =
-            new KafkaContainer(DockerImageName.parse(DockerImageVersions.KAFKA)) {
-                @Override
-                protected void doStart() {
-                    super.doStart();
-                    if (LOG.isInfoEnabled()) {
-                        this.followOutput(new Slf4jLogConsumer(LOG));
-                    }
-                }
-            }.withEmbeddedZookeeper()
+            KafkaUtil.createKafkaContainer(KafkaTableTestBase.class)
+                    .withEmbeddedZookeeper()
                     .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS)
                     .withEnv(
                             "KAFKA_TRANSACTION_MAX_TIMEOUT_MS",

--- a/flink-connector-kafka/src/test/resources/log4j2-test.properties
+++ b/flink-connector-kafka/src/test/resources/log4j2-test.properties
@@ -27,6 +27,12 @@ appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
 appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
 
+# Overwrite the level for all Flink related loggers
+logger.flink.name = org.apache.flink
+logger.flink.level = OFF # WARN for starting debugging
+logger.flinkconnector.name = org.apache.flink.connector
+logger.flinkconnector.level = OFF # INFO/DEBUG for starting debugging
+
 # Kafka producer and consumer level
 logger.kafka.name = org.apache.kafka
 logger.kafka.level = OFF

--- a/flink-connector-kafka/src/test/resources/log4j2-test.properties
+++ b/flink-connector-kafka/src/test/resources/log4j2-test.properties
@@ -27,15 +27,9 @@ appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
 appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
 
-logger.kafka.name = kafka
+# Kafka producer and consumer level
+logger.kafka.name = org.apache.kafka
 logger.kafka.level = OFF
-logger.kafka2.name = state.change
-logger.kafka2.level = OFF
-
-logger.zookeeper.name = org.apache.zookeeper
-logger.zookeeper.level = OFF
-logger.I0Itec.name = org.I0Itec
-logger.I0Itec.level = OFF
 
 # Logger configuration for containers, by default this is off
 # If you want to investigate test failures, overwrite the level as above

--- a/flink-connector-kafka/src/test/resources/log4j2-test.properties
+++ b/flink-connector-kafka/src/test/resources/log4j2-test.properties
@@ -37,5 +37,20 @@ logger.zookeeper.level = OFF
 logger.I0Itec.name = org.I0Itec
 logger.I0Itec.level = OFF
 
-logger.splitreader.name = org.apache.flink.connector.kafka.source.reader.KafkaPartitionSplitReader
-logger.splitreader.level = DEBUG
+# Logger configuration for containers, by default this is off
+# If you want to investigate test failures, overwrite the level as above
+logger.container.name = container
+logger.container.level = OFF
+logger.container.additivity = false  # This prevents messages from being logged by the root logger
+logger.container.appenderRef.containerappender.ref = ContainerLogger
+
+logger.flinkenv.name = org.apache.flink.connector.testframe.container.FlinkContainerTestEnvironment
+logger.flinkenv.level = OFF
+logger.flinkenv.additivity = false  # This prevents messages from being logged by the root logger
+logger.flinkenv.appenderRef.containerappender.ref = ContainerLogger
+
+appender.containerappender.name = ContainerLogger
+appender.containerappender.type = CONSOLE
+appender.containerappender.target = SYSTEM_ERR
+appender.containerappender.layout.type = PatternLayout
+appender.containerappender.layout.pattern = [%c{1}] %m%n

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@ under the License.
     <properties>
         <flink.version>1.17.0</flink.version>
         <kafka.version>3.4.0</kafka.version>
-        <zookeeper.version>3.7.2</zookeeper.version>
         <confluent.version>7.4.4</confluent.version>
 
         <jackson-bom.version>2.15.2</jackson-bom.version>
@@ -230,22 +229,6 @@ under the License.
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${kafka.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.zookeeper</groupId>
-                <artifactId>zookeeper</artifactId>
-                <version>${zookeeper.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-log4j12</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>

--- a/tools/ci/log4j.properties
+++ b/tools/ci/log4j.properties
@@ -38,6 +38,10 @@ appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss,SSS} [%20t] %-5p %-60c %x - %m%n
 appender.file.createOnDemand = true
 
+# Kafka producer and consumer level
+logger.kafka.name = org.apache.kafka
+logger.kafka.level = OFF
+
 # suppress the irrelevant (wrong) warnings from the netty channel handler
 logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
 logger.netty.level = ERROR

--- a/tools/ci/log4j.properties
+++ b/tools/ci/log4j.properties
@@ -41,3 +41,27 @@ appender.file.createOnDemand = true
 # suppress the irrelevant (wrong) warnings from the netty channel handler
 logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
 logger.netty.level = ERROR
+
+# Logger configuration for containers, by default this is off
+# If you want to investigate test failures, overwrite the level as above
+logger.container.name = container
+logger.container.level = OFF
+logger.container.additivity = false  # This prevents messages from being logged by the root logger
+logger.container.appenderRef.containerappender.ref = ContainerLogger
+
+logger.kafkacontainer.name = container.kafka
+logger.kafkacontainer.level = WARN
+
+logger.flinkcontainer.name = container.flink
+logger.flinkcontainer.level = WARN
+
+logger.flinkenv.name = org.apache.flink.connector.testframe.container.FlinkContainerTestEnvironment
+logger.flinkenv.level = WARN
+logger.flinkenv.additivity = false  # This prevents messages from being logged by the root logger
+logger.flinkenv.appenderRef.containerappender.ref = ContainerLogger
+
+appender.containerappender.name = ContainerLogger
+appender.containerappender.type = CONSOLE
+appender.containerappender.target = SYSTEM_ERR
+appender.containerappender.layout.type = PatternLayout
+appender.containerappender.layout.pattern = [%c{1}] %m%n

--- a/tools/ci/log4j.properties
+++ b/tools/ci/log4j.properties
@@ -38,6 +38,12 @@ appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss,SSS} [%20t] %-5p %-60c %x - %m%n
 appender.file.createOnDemand = true
 
+# Reduce most flink logs except for connector specific loggers
+logger.flink.name = org.apache.flink
+logger.flink.level = WARN
+logger.flinkconnector.name = org.apache.flink.connector
+logger.flinkconnector.level = INFO
+
 # Kafka producer and consumer level
 logger.kafka.name = org.apache.kafka
 logger.kafka.level = OFF


### PR DESCRIPTION
Currently, container logs appear under an o.a.f logger and thus are visible on CI. This results in compressed log size >40MB for a run and often leads to download errors.

This PR reroutes container logs to a special container logger. It also uses a custom format to significantly reduce the size of each log line. The logs for containers are disabled by default.

Here is the original log of an ITCase (308 KB)
[old.log](https://github.com/user-attachments/files/17010325/old.log)

```
2794 [docker-java-stream--2048098242] INFO  org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironmentImpl [] - [Kafka-0] STDOUT: [2024-09-16 08:26:53,236] INFO Server environment:java.library.path=/usr/java/packages/lib:/lib:/usr/lib:/usr/lib64:/lib64 (org.apache.zookeeper.server.ZooKeeperServer)
2794 [docker-java-stream--2048098242] INFO  org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironmentImpl [] - [Kafka-0] STDOUT: [2024-09-16 08:26:53,236] INFO Server environment:java.io.tmpdir=/tmp (org.apache.zookeeper.server.ZooKeeperServer)
2794 [docker-java-stream--2048098242] INFO  org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironmentImpl [] - [Kafka-0] STDOUT: [2024-09-16 08:26:53,236] INFO Server environment:java.compiler=<NA> (org.apache.zookeeper.server.ZooKeeperServer)
```

New formatter, same level (199 KB)
[with container.log](https://github.com/user-attachments/files/17010326/with.container.log)

```
[Kafka-0] [2024-09-16 08:18:25,496] INFO Server environment:java.library.path=/usr/java/packages/lib:/lib:/usr/lib:/usr/lib64:/lib64 (org.apache.zookeeper.server.ZooKeeperServer)
[Kafka-0] [2024-09-16 08:18:25,496] INFO Server environment:java.io.tmpdir=/tmp (org.apache.zookeeper.server.ZooKeeperServer)
[Kafka-0] [2024-09-16 08:18:25,496] INFO Server environment:java.compiler=<NA> (org.apache.zookeeper.server.ZooKeeperServer)

```

Disabled container log (113 KB)
[no container.log](https://github.com/user-attachments/files/17010324/no.container.log)
