### PR TITLE
[FLINK-XXXXX][Connectors/Kafka]bump kafka client version to 3.5.2 to use KIP-881 (client.rack)

### DIFF
--- a/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.kafka:kafka-clients:3.4.0
+- org.apache.kafka:kafka-clients:3.5.2

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@ under the License.
 
     <properties>
         <flink.version>1.17.0</flink.version>
-        <kafka.version>3.4.0</kafka.version>
+        <kafka.version>3.5.2</kafka.version>
         <zookeeper.version>3.7.2</zookeeper.version>
         <confluent.version>7.4.4</confluent.version>
 


### PR DESCRIPTION
To use the Rack-aware Partition Assignment for Kafka Consumers ([KIP-881](https://cwiki.apache.org/confluence/display/KAFKA/KIP-881%3A+Rack-aware+Partition+Assignment+for+Kafka+Consumers)) introduced in [confluent blog](https://www.confluent.io/blog/introducing-apache-kafka-3-5/), 
upgrade the kafka client version used by flink-connector-kafka to version 3.5.2.
