### PR TITLE
[FLINK-36422][docs] Fix PyFlink jar download link

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/kafka.md
@@ -45,7 +45,7 @@ Apache Flink 集成了通用的 Kafka 连接器，它会尽力与 Kafka client �
 Flink 目前的流连接器还不是二进制发行版的一部分。
 [在此处]({{< ref "docs/dev/configuration/overview" >}})可以了解到如何链接它们，从而在集群中运行。
 
-{{< py_download_link "kafka" >}}
+{{< py_connector_download_link "kafka" >}}
 
 ## Kafka Source
 {{< hint info >}}

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -41,7 +41,7 @@ For details on Kafka compatibility, please refer to the official [Kafka document
 Flink's streaming connectors are not part of the binary distribution.
 See how to link with them for cluster execution [here]({{< ref "docs/dev/configuration/overview" >}}).
 
-{{< py_download_link "kafka" >}}
+{{< py_connector_download_link "kafka" >}}
 
 ## Kafka Source
 {{< hint info >}}


### PR DESCRIPTION
## What is the purpose of the change
Fix PyFlink jar download link.

## Brief change log
* Use `py_connector_download_link` shortcode to generate link with correct connector artifact version, instead of Flink version.

## Verifying this change
* Generated documentation locally

## Does this pull request potentially affect one of the following parts:
* Dependencies (does it add or upgrade a dependency): no
* The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
* The serializers: no
* The runtime per-record code paths (performance sensitive): no
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
* The S3 file system connector: no

