### PR TITLE
[FLINK-36595][docs] Explicitly set connector compatibility as string to prevent version comparison mismatch

### DIFF
--- a/docs/data/kafka.yml
+++ b/docs/data/kafka.yml
@@ -17,7 +17,7 @@
 ################################################################################
 
 version: 3.3.0
-flink_compatibility: [1.19, 1.20]
+flink_compatibility: ["1.19", "1.20"]
 variants:
   - maven: flink-connector-kafka
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka/$full_version/flink-sql-connector-kafka-$full_version.jar


### PR DESCRIPTION
Fix connector release flink compatibility configuration for documentation build to render released artifact version correctly.

#### Before fix:
![image](https://github.com/user-attachments/assets/cc7617d7-8a91-4fa7-89f9-cc7f06e7c711)

#### After fix:
![image](https://github.com/user-attachments/assets/2e1b1633-96cf-4eb1-ae01-a1138442bc4f)
