### PR TITLE
[FLINK-36630][Connectors/Kafka] Wrap consumer.position in retryOnWakeup

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -279,6 +279,10 @@ public class KafkaPartitionSplitReader
         }
     }
 
+    long getConsumerPosition(TopicPartition tp, String msg) {
+        return retryOnWakeup(() -> consumer.position(tp), msg);
+    }
+
     private void parseStartingOffsets(
             KafkaPartitionSplit split,
             List<TopicPartition> partitionsStartingFromEarliest,
@@ -442,11 +446,6 @@ public class KafkaPartitionSplitReader
 
     private long getStoppingOffset(TopicPartition tp) {
         return stoppingOffsets.getOrDefault(tp, Long.MAX_VALUE);
-    }
-
-    @VisibleForTesting
-    protected long getConsumerPosition(TopicPartition tp, String msg) {
-        return retryOnWakeup(() -> consumer.position(tp), msg);
     }
 
     private void maybeRegisterKafkaConsumerMetrics(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -136,33 +136,6 @@ public class KafkaPartitionSplitReaderTest {
     }
 
     @Test
-    public void testWakeUpOnConsumerPosition() throws Exception {
-        Properties props = new Properties();
-        props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        KafkaPartitionSplitReader reader =
-                createReader(props, UnregisteredMetricsGroup.createSourceReaderMetricGroup());
-        AtomicReference<Throwable> error = new AtomicReference<>();
-        TopicPartition tp = new TopicPartition(TOPIC3, 0);
-
-        reader.consumer().assign(Collections.singletonList(tp));
-
-        Thread t =
-                new Thread(
-                        () -> {
-                            try {
-                                reader.getConsumerPosition(tp, "testing get starting offsets");
-                            } catch (Throwable e) {
-                                error.set(e);
-                            }
-                        },
-                        "testWakeUp-thread");
-        t.start();
-        reader.wakeUp();
-        t.join();
-        assertThat(error.get()).isNull();
-    }
-
-    @Test
     public void testWakeupThenAssign() throws IOException {
         KafkaPartitionSplitReader reader = createReader();
         // Assign splits with records

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -38,7 +38,6 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -140,16 +139,13 @@ public class KafkaPartitionSplitReaderTest {
     public void testWakeUpOnConsumerPosition() throws Exception {
         Properties props = new Properties();
         props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-
         KafkaPartitionSplitReader reader =
                 createReader(props, UnregisteredMetricsGroup.createSourceReaderMetricGroup());
-
         AtomicReference<Throwable> error = new AtomicReference<>();
-
         TopicPartition tp = new TopicPartition(TOPIC3, 0);
 
-        KafkaConsumer<byte[], byte[]> consumer = reader.consumer();
-        consumer.assign(Collections.singletonList(tp));
+        reader.consumer().assign(Collections.singletonList(tp));
+
         Thread t =
                 new Thread(
                         () -> {


### PR DESCRIPTION
FLINK-34470 introduced a new consumer.position call that was not wrapped by retryOnWakeUp, differently than the rest of calls ont he class.

It was generating random WakeupExceptions on our production code for Flink19.

Trivial code change. But I extracted this to a method so i could add a simple test for all the calls
