### PR TITLE
[FLINK-36906] Optimize the logic for determining if a split is finished

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -122,7 +122,7 @@ public class KafkaPartitionSplitReader
         KafkaPartitionSplitRecords recordsBySplits =
                 new KafkaPartitionSplitRecords(consumerRecords, kafkaSourceReaderMetrics);
         List<TopicPartition> finishedPartitions = new ArrayList<>();
-        for (TopicPartition tp : consumer.assignment()) {
+        for (TopicPartition tp : consumerRecords.partitions()) {
             long stoppingOffset = getStoppingOffset(tp);
             long consumerPosition = consumer.position(tp);
             // Stop fetching when the consumer's position reaches the stoppingOffset.


### PR DESCRIPTION
When determining if a split is finished, process only the partitions with data from the current fetch instead of all partitions. This reduces unnecessary partition checks and improves performance and resource utilization.