### PR TITLE
[FLINK-36909] Reduce Stream Creation in StreamPatternSubscriber

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/metadata/KafkaMetadataService.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/metadata/KafkaMetadataService.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /** Metadata service that returns Kafka details. */
 @Experimental
@@ -34,6 +35,14 @@ public interface KafkaMetadataService extends AutoCloseable, Serializable {
      * @return set of all streams
      */
     Set<KafkaStream> getAllStreams();
+
+    /**
+     * Get current metadata for pattern streams.
+     *
+     * @param streamPattern
+     * @return
+     */
+    Set<KafkaStream> getPatternStreams(Pattern streamPattern);
 
     /**
      * Get current metadata for queried streams.

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/subscriber/StreamPatternSubscriber.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/subscriber/StreamPatternSubscriber.java
@@ -22,8 +22,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.connector.kafka.dynamic.metadata.KafkaMetadataService;
 import org.apache.flink.connector.kafka.dynamic.metadata.KafkaStream;
 
-import com.google.common.collect.ImmutableSet;
-
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -39,15 +37,6 @@ public class StreamPatternSubscriber implements KafkaStreamSubscriber {
 
     @Override
     public Set<KafkaStream> getSubscribedStreams(KafkaMetadataService kafkaMetadataService) {
-        Set<KafkaStream> allStreams = kafkaMetadataService.getAllStreams();
-        ImmutableSet.Builder<KafkaStream> builder = ImmutableSet.builder();
-        for (KafkaStream kafkaStream : allStreams) {
-            String streamId = kafkaStream.getStreamId();
-            if (streamPattern.matcher(streamId).find()) {
-                builder.add(kafkaStream);
-            }
-        }
-
-        return builder.build();
+        return kafkaMetadataService.getPatternStreams(streamPattern);
     }
 }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
@@ -265,10 +265,7 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
                     .computeIfAbsent(split.getKafkaClusterId(), (ignore) -> new HashSet<>())
                     .add(split.getKafkaPartitionSplit().getTopic());
             // check if cluster topic exists in the metadata update
-            if (newClustersAndTopics.containsKey(split.getKafkaClusterId())
-                    && newClustersAndTopics
-                            .get(split.getKafkaClusterId())
-                            .contains(split.getKafkaPartitionSplit().getTopic())) {
+            if (isSplitForActiveClusters(split, newClustersAndTopics)) {
                 filteredNewClusterSplitStateMap
                         .computeIfAbsent(split.getKafkaClusterId(), (ignore) -> new ArrayList<>())
                         .add(split);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/MockKafkaMetadataService.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/MockKafkaMetadataService.java
@@ -22,10 +22,12 @@ import org.apache.flink.connector.kafka.dynamic.metadata.KafkaMetadataService;
 import org.apache.flink.connector.kafka.dynamic.metadata.KafkaStream;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /** A mock in-memory implementation of {@link KafkaMetadataService}. */
@@ -67,6 +69,19 @@ public class MockKafkaMetadataService implements KafkaMetadataService {
     public Set<KafkaStream> getAllStreams() {
         checkAndThrowException();
         return kafkaStreams;
+    }
+
+    @Override
+    public Set<KafkaStream> getPatternStreams(Pattern streamPattern) {
+        checkAndThrowException();
+        ImmutableSet.Builder<KafkaStream> builder = ImmutableSet.builder();
+        for (KafkaStream kafkaStream : kafkaStreams) {
+            String streamId = kafkaStream.getStreamId();
+            if (streamPattern.matcher(streamId).find()) {
+                builder.add(kafkaStream);
+            }
+        }
+        return builder.build();
     }
 
     @Override

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/YamlFileMetadataService.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/YamlFileMetadataService.java
@@ -25,6 +25,7 @@ import org.apache.flink.connector.kafka.dynamic.metadata.KafkaStream;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -121,6 +123,19 @@ public class YamlFileMetadataService implements KafkaMetadataService {
     public Set<KafkaStream> getAllStreams() {
         refreshIfNeeded();
         return streamMetadata;
+    }
+
+    @Override
+    public Set<KafkaStream> getPatternStreams(Pattern streamPattern) {
+        refreshIfNeeded();
+        ImmutableSet.Builder<KafkaStream> builder = ImmutableSet.builder();
+        for (KafkaStream kafkaStream : streamMetadata) {
+            String streamId = kafkaStream.getStreamId();
+            if (streamPattern.matcher(streamId).find()) {
+                builder.add(kafkaStream);
+            }
+        }
+        return builder.build();
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
In StreamPatternSubscriber mode, our current approach is to first fetch metadata for all streams, then create all streams, and subsequently apply filters. We can optimize this process by initially filtering stream identifiers, then fetching metadata and creating streams only for the filtered ones, thereby enhancing performance and reducing resource consumption.