### PR TITLE
[hotfix] Remove unused method

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
@@ -31,15 +31,6 @@ class KafkaSubscriberUtils {
 
     private KafkaSubscriberUtils() {}
 
-    static Map<String, TopicDescription> getAllTopicMetadata(AdminClient adminClient) {
-        try {
-            Set<String> allTopicNames = adminClient.listTopics().names().get();
-            return getTopicMetadata(adminClient, allTopicNames);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to get metadata for all topics.", e);
-        }
-    }
-
     static Map<String, TopicDescription> getTopicMetadata(
             AdminClient adminClient, Pattern topicPattern) {
         try {


### PR DESCRIPTION
KafkaSubscriberUtils#getAllTopicMetadata is no longer used after https://github.com/apache/flink-connector-kafka/pull/117 , but it's not removed.