### PR TITLE
[FLINK-37380] Change TransactionalIdPrefix to a required option if Exactly once 

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilder.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilder.java
@@ -70,7 +70,7 @@ public class KafkaSinkBuilder<IN> {
     private static final int MAXIMUM_PREFIX_BYTES = 64000;
 
     private DeliveryGuarantee deliveryGuarantee = DeliveryGuarantee.NONE;
-    private String transactionalIdPrefix = "kafka-sink";
+    private String transactionalIdPrefix;
 
     private final Properties kafkaProducerConfig;
     private KafkaRecordSerializationSchema<IN> recordSerializer;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaChangelogTableITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaChangelogTableITCase.java
@@ -474,6 +474,7 @@ public class KafkaChangelogTableITCase extends KafkaTableTestBase {
                                         .setPartitioner(partitioner)
                                         .build())
                         .setDeliveryGuarantee(DeliveryGuarantee.EXACTLY_ONCE)
+                        .setTransactionalIdPrefix("kafka-sink")
                         .build());
         env.execute("Write sequence");
     }

--- a/flink-python/pyflink/datastream/connectors/tests/test_kafka.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_kafka.py
@@ -472,6 +472,7 @@ class KafkaSinkTests(PyFlinkStreamingTestCase):
         sink = KafkaSink.builder() \
             .set_bootstrap_servers('localhost:9092') \
             .set_delivery_guarantee(DeliveryGuarantee.EXACTLY_ONCE) \
+            .set_transactional_id_prefix("kafka-sink") \
             .set_record_serializer(self._build_serialization_schema()) \
             .build()
         guarantee = get_field_value(sink.get_java_function(), 'deliveryGuarantee')


### PR DESCRIPTION
As described in https://issues.apache.org/jira/browse/FLINK-37380 , though org.apache.flink.connector.kafka.sink.KafkaSinkBuilder#sanityCheck said `EXACTLY_ONCE delivery guarantee requires a transactionIdPrefix to be set to provide unique transaction names across multiple KafkaSinks writing to the same Kafka cluster` ,  it 's no use because the transactionalIdPrefix with a default value "kafka-sink" will never be null.

This PR just remove the default value, and make the sanityCheck valid.