### PR TITLE
[FLINK-37396] Fix setup.py: multiple top-level packages discovered in a flat-layout

### DIFF
--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -133,6 +133,7 @@ if in_flink_source:
 
 # Runs the python setup
 setup(
+    py_modules=[],
     name=PACKAGE_NAME,
     version=connector_version,
     include_package_data=True,


### PR DESCRIPTION
Inspired by [Multiple top-level packages discovered in a flat-layout](https://stackoverflow.com/questions/72294299/multiple-top-level-packages-discovered-in-a-flat-layout) , add `py_modules=[]` to fix python CI test [FLINK-37396](https://issues.apache.org/jira/browse/FLINK-37396).