### PR TITLE
[FLINK-25920] bump flink version to 1.20.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ under the License.
     </modules>
 
     <properties>
-        <flink.version>1.20.0</flink.version>
+        <flink.version>1.20.1</flink.version>
         <kafka.version>3.4.0</kafka.version>
         <confluent.version>7.4.4</confluent.version>
 


### PR DESCRIPTION
Currently, test often error with "Currently it is not supported to update the CommittableSummary for a checkpoint coming from the same subtask. Please check the status of FLINK-25920"

https://issues.apache.org/jira/browse/FLINK-25920 hava fixed it, thus bump flink version to 1.20.1 to reduce test error.