### PR TITLE
[FLINK-37573] Remove Java 8 in CI

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         flink: [ 1.20.0 ]
-        jdk: [ '8, 11, 17, 21' ]
+        jdk: [ '11, 17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
@@ -41,3 +41,4 @@ jobs:
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
+      jdk_version: 11

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -46,5 +46,5 @@ jobs:
     with:
       flink_version: ${{ matrix.flink_branches.flink }}
       connector_branch: ${{ matrix.flink_branches.branch }}
-      jdk_version: ${{ matrix.flink_branches.jdk || '8, 11, 17, 21' }}
+      jdk_version: ${{ matrix.flink_branches.jdk || '11, 17, 21' }}
       run_dependency_convergence: false


### PR DESCRIPTION
For Flink 2.0/flink-connector-kafka 4.0, we planned to remove Java 8 support. Since the python builds are broken for 8 now, let's move ahead with the removal.