### PR TITLE
[FLINK-37611] Deflake ExactlyOnceKafkaWriterITCase

### DIFF
--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
@@ -67,7 +67,11 @@ public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
             try {
                 writer.getCurrentProducer().flush();
                 assertThatCode(() -> writer.write(1, SINK_WRITER_CONTEXT))
-                        .hasRootCauseExactlyInstanceOf(NetworkException.class);
+                        .rootCause()
+                        .matches(
+                                e ->
+                                        e instanceof NetworkException
+                                                || e instanceof TimeoutException);
             } finally {
                 KAFKA_CONTAINER.start();
             }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterTestBase.java
@@ -56,6 +56,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
@@ -127,6 +128,14 @@ public abstract class KafkaWriterTestBase {
             Consumer<KafkaSinkBuilder<?>> sinkBuilderAdjuster, SinkInitContext sinkInitContext)
             throws IOException {
         return (T) createSink(sinkBuilderAdjuster).createWriter(sinkInitContext);
+    }
+
+    @SuppressWarnings("unchecked")
+    <T extends KafkaWriter<?>> T restoreWriter(
+            Consumer<KafkaSinkBuilder<?>> sinkBuilderAdjuster,
+            Collection<KafkaWriterState> recoveredState,
+            SinkInitContext initContext) {
+        return (T) createSink(sinkBuilderAdjuster).restoreWriter(initContext, recoveredState);
     }
 
     KafkaSink<Integer> createSink(Consumer<KafkaSinkBuilder<?>> sinkBuilderAdjuster) {
@@ -223,7 +232,8 @@ public abstract class KafkaWriterTestBase {
                 // in general, serializers should be allowed to skip invalid elements
                 return null;
             }
-            return new ProducerRecord<>(topic, ByteBuffer.allocate(4).putInt(element).array());
+            byte[] bytes = ByteBuffer.allocate(4).putInt(element).array();
+            return new ProducerRecord<>(topic, bytes, bytes);
         }
     }
 

--- a/flink-connector-kafka/src/test/resources/log4j2-test.properties
+++ b/flink-connector-kafka/src/test/resources/log4j2-test.properties
@@ -29,9 +29,11 @@ appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n
 
 # Overwrite the level for all Flink related loggers
 logger.flink.name = org.apache.flink
-logger.flink.level = OFF # WARN for starting debugging
+# WARN for starting debugging
+logger.flink.level = OFF
 logger.flinkconnector.name = org.apache.flink.connector
-logger.flinkconnector.level = OFF # INFO/DEBUG for starting debugging
+# INFO/DEBUG for starting debugging
+logger.flinkconnector.level = OFF
 
 # Kafka producer and consumer level
 logger.kafka.name = org.apache.kafka


### PR DESCRIPTION
Deflake ExactlyOnceKafkaWriterITCase#shouldAbortLingeringTransactions

The test was actually not working correctly since writer's get their unique prefix (pool rework PR). The test mostly succeeded since the partitions in which records were written was non-deterministic and more often than not the 3 records didn't meet in the 10 partitions which resulted in an incorrect pass.

Now the value is also passed as a key, which makes partitions assignment deterministic and for this test we just write the exact same value 3 times.