### PR TITLE
[FLINK-37613] Fix resource leak during abortion

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaCommitter.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaCommitter.java
@@ -139,6 +139,7 @@ class KafkaCommitter implements Committer<KafkaCommittable>, Closeable {
                         "Transaction ({}) encountered error and data has been potentially lost.",
                         request,
                         e);
+                closeCommitterProducer(producer);
                 // cause failover
                 request.signalFailedWithUnknownReason(e);
             }
@@ -150,6 +151,10 @@ class KafkaCommitter implements Committer<KafkaCommittable>, Closeable {
             return;
         }
         backchannel.send(TransactionFinished.erroneously(producer.getTransactionalId()));
+        closeCommitterProducer(producer);
+    }
+
+    private void closeCommitterProducer(FlinkKafkaInternalProducer<?, ?> producer) {
         if (producer == this.committingProducer) {
             this.committingProducer.close();
             this.committingProducer = null;


### PR DESCRIPTION
Transaction abortion can take a while. Apparently, task cleanup may not trigger correctly if this abortion is interrupted (for some unrelated reason). This leaks producers. The fix is to close() manually during initialization of the EOS writer until we fixed the Flink bug FLINK-37612.