### PR TITLE
[FLINK-34466][LINEAGE] Support dataset type facet for Avro

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/lineage/DefaultTypeDatasetFacet.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/lineage/DefaultTypeDatasetFacet.java
@@ -1,9 +1,11 @@
 package org.apache.flink.connector.kafka.lineage;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /** Default implementation of {@link KafkaDatasetFacet}. */
 @PublicEvolving
@@ -13,12 +15,24 @@ public class DefaultTypeDatasetFacet implements TypeDatasetFacet {
 
     private final TypeInformation typeInformation;
 
+    private final Optional<SerializationSchema> serializationSchema;
+
     public DefaultTypeDatasetFacet(TypeInformation typeInformation) {
         this.typeInformation = typeInformation;
+        this.serializationSchema = Optional.empty();
+    }
+
+    public DefaultTypeDatasetFacet(SerializationSchema serializationSchema) {
+        this.serializationSchema = Optional.of(serializationSchema);
+        this.typeInformation = null;
     }
 
     public TypeInformation getTypeInformation() {
         return typeInformation;
+    }
+
+    public Optional<SerializationSchema> getSerializationSchema() {
+        return serializationSchema;
     }
 
     public boolean equals(Object o) {
@@ -29,12 +43,13 @@ public class DefaultTypeDatasetFacet implements TypeDatasetFacet {
             return false;
         }
         DefaultTypeDatasetFacet that = (DefaultTypeDatasetFacet) o;
-        return Objects.equals(typeInformation, that.typeInformation);
+        return Objects.equals(typeInformation, that.typeInformation)
+                && Objects.equals(serializationSchema, that.serializationSchema);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(typeInformation);
+        return Objects.hash(typeInformation, serializationSchema);
     }
 
     @Override

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/lineage/TypeDatasetFacet.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/lineage/TypeDatasetFacet.java
@@ -1,11 +1,26 @@
 package org.apache.flink.connector.kafka.lineage;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+
+import java.util.Optional;
 
 /** Facet definition to contain type information of source and sink. */
 @PublicEvolving
 public interface TypeDatasetFacet extends LineageDatasetFacet {
     TypeInformation getTypeInformation();
+
+    /**
+     * Sometimes a sink implementing {@link TypeDatasetFacetProvider} is not able to extract type.
+     * This is happening for AvroSerializationSchema due to type erasure problem. In this case, it
+     * makes sense to expose SerializationSchema to the lineage consumer so that it can use it to
+     * extract type information.
+     *
+     * @return
+     */
+    default Optional<SerializationSchema> getSerializationSchema() {
+        return Optional.empty();
+    }
 }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSink.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSink.java
@@ -213,6 +213,10 @@ public class KafkaSink<IN>
         Optional<TypeDatasetFacet> typeDatasetFacet = Optional.empty();
         if (recordSerializer instanceof TypeDatasetFacetProvider) {
             typeDatasetFacet = ((TypeDatasetFacetProvider) recordSerializer).getTypeDatasetFacet();
+        } else {
+            LOG.info(
+                    "recordSerializer does not implement TypeDatasetFacetProvider: {}",
+                    recordSerializer);
         }
 
         if (typeDatasetFacet.isPresent()) {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
@@ -400,6 +400,24 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
                 .isEqualTo(BasicTypeInfo.STRING_TYPE_INFO);
     }
 
+    @Test
+    public void testTypeDatasetFacetWithErasureProblem() {
+        SerializationSchema serializationSchema = element -> new byte[0];
+
+        KafkaRecordSerializationSchema<String> schema =
+                KafkaRecordSerializationSchema.builder()
+                        .setTopic("some-topic")
+                        .setValueSerializationSchema(serializationSchema)
+                        .setKeySerializationSchema(new SimpleStringSchema())
+                        .build();
+
+        assertThat(((TypeDatasetFacetProvider) schema).getTypeDatasetFacet())
+                .isPresent()
+                .get()
+                .extracting(TypeDatasetFacet::getSerializationSchema)
+                .isEqualTo(Optional.of(serializationSchema));
+    }
+
     private static void assertOnlyOneSerializerAllowed(
             List<
                             Function<


### PR DESCRIPTION
With an implementation of lineage interfaces, Kafka source and sink provide `TypeDatasetFacet` which contains type information of data processed. This was working with extracting type information from `SerializationSchema`:
```
TypeExtractor.getParameterType(SerializationSchema.class, valueSerialization.getClass(), 0)
```

However, this ain't working for `ConfluentRegistryAvroSerializationSchema` due to type erasure. 

As a workaround, `TypeDatasetFacet` can be extended to contain `SerializationSchema` when direct extraction of `TypeInformation` is not possible. This allows handling this case on the lineage listener side, while keeping flink-connector-kafka unaware of Avro type extraction logic. 