### PR TITLE
[FLINK-32609] Support Projection Pushdown

### DIFF
--- a/docs/content.zh/docs/connectors/table/kafka.md
+++ b/docs/content.zh/docs/connectors/table/kafka.md
@@ -287,6 +287,22 @@ CREATE TABLE KafkaTable (
       </td>
     </tr>
     <tr>
+      <td><h5>key.format.projection-pushdown.enabled</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>启用后，查询投影（projection）会被下推到消息键（Key）格式中。下推的程度取决于该格式对投影下推的支持级别（不支持、顶层或嵌套）。
+      </td>
+    </tr>
+    <tr>
+      <td><h5>value.format.projection-pushdown.enabled</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>启用后，查询投影（projection）会被下推到消息体（Value）格式中。下推的程度取决于该格式对投影下推的支持级别（不支持、顶层或嵌套）。
+      </td>
+    </tr>
+    <tr>
       <td><h5>scan.startup.mode</h5></td>
       <td>可选</td>
       <td style="word-wrap: break-word;">group-offsets</td>

--- a/docs/content/docs/connectors/table/kafka.md
+++ b/docs/content/docs/connectors/table/kafka.md
@@ -315,6 +315,26 @@ Connector Options
       </td>
     </tr>
     <tr>
+      <td><h5>key.format.projection-pushdown.enabled</h5></td>
+      <td>optional</td>
+      <td>no</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>When enabled, query projections are pushed down into the key format. How much is pushed down
+        depends on the format's level of projection-pushdown support (none, top-level, or nested).
+      </td>
+    </tr>
+    <tr>
+      <td><h5>value.format.projection-pushdown.enabled</h5></td>
+      <td>optional</td>
+      <td>no</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>When enabled, query projections are pushed down into the value format. How much is pushed down
+        depends on the format's level of projection-pushdown support (none, top-level, or nested).
+      </td>
+    </tr>
+    <tr>
       <td><h5>scan.startup.mode</h5></td>
       <td>optional</td>
       <td>yes</td>

--- a/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/Decoder.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/Decoder.java
@@ -1,0 +1,471 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource.Context;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Decoding messages consists of two potential steps:
+ *
+ * <ol>
+ *   <li>Deserialization i.e deserializing the {@code byte[]} into a {@link RowData}. This process
+ *       is handled by a {@link DeserializationSchema}.
+ *   <li>Projection i.e. projecting any required fields from the deserialized {@link RowData}
+ *       (returned by the {@link DeserializationSchema} in the first step) to their positions in the
+ *       final produced {@link RowData}. This process is handled by a {@link Projector}.
+ * </ol>
+ *
+ * <p>In order to decode messages correctly, the {@link DeserializationSchema} and the {@link
+ * Projector} need to work together. For example, the {@link Projector} needs to know the positions
+ * of the required fields in the {@link RowData} returned by the {@link DeserializationSchema} in
+ * order to be able to correctly set fields in the final produced {@link RowData}.
+ *
+ * <p>That's why we have this {@link Decoder} class. This class ensures that the returned {@link
+ * DeserializationSchema} and {@link Projector} will work together to decode messages correctly.
+ */
+@Internal
+public class Decoder {
+
+    /**
+     * Can be null. Null is used inside {@link DynamicKafkaDeserializationSchema} to avoid
+     * deserializing keys if not required.
+     */
+    private final @Nullable DeserializationSchema<RowData> deserializationSchema;
+
+    /** Mapping of the physical position in the key to the target position in the RowData. */
+    private final Projector projector;
+
+    private Decoder(
+            final DeserializationSchema<RowData> deserializationSchema, final Projector projector) {
+        this.deserializationSchema = deserializationSchema;
+        this.projector = projector;
+    }
+
+    /**
+     * @param decodingFormat Optional format for decoding bytes.
+     * @param physicalTableDataType The data type representing the table schema.
+     * @param physicalDataTypeProjection Indices indicate the position of the field in the dataType
+     *     (key/value). Values indicate the position of the field in the tableSchema.
+     * @param prefix Optional field prefix
+     * @param projectedPhysicalFields Indices indicate the position of the field in the produced
+     *     Row. Values indicate the position of the field in the table schema.
+     * @param pushProjectionsIntoDecodingFormat if this is true and the format is a {@link
+     *     ProjectableDecodingFormat}, any {@param projectedPhysicalFields} will be pushed down into
+     *     the {@link ProjectableDecodingFormat}. Otherwise, projections will be applied after
+     *     deserialization.
+     * @return a {@link Decoder} instance.
+     */
+    public static Decoder create(
+            final Context context,
+            final @Nullable DecodingFormat<DeserializationSchema<RowData>> decodingFormat,
+            final DataType physicalTableDataType,
+            final int[] physicalDataTypeProjection,
+            final @Nullable String prefix,
+            final int[][] projectedPhysicalFields,
+            final List<String> metadataKeys,
+            final boolean pushProjectionsIntoDecodingFormat) {
+        if (decodingFormat == null) {
+            return Decoder.noDeserializationOrProjection();
+        } else if (!pushProjectionsIntoDecodingFormat
+                || !(decodingFormat instanceof ProjectableDecodingFormat)) {
+            return Decoder.projectAfterDeserializing(
+                    context,
+                    decodingFormat,
+                    physicalTableDataType,
+                    physicalDataTypeProjection,
+                    prefix,
+                    projectedPhysicalFields,
+                    metadataKeys);
+        } else {
+            final ProjectableDecodingFormat<DeserializationSchema<RowData>>
+                    projectableDecodingFormat =
+                            (ProjectableDecodingFormat<DeserializationSchema<RowData>>)
+                                    decodingFormat;
+            if (projectableDecodingFormat.supportsNestedProjection()) {
+                return Decoder.projectInsideDeserializer(
+                        context,
+                        projectableDecodingFormat,
+                        physicalTableDataType,
+                        physicalDataTypeProjection,
+                        prefix,
+                        projectedPhysicalFields,
+                        metadataKeys);
+            } else {
+                return Decoder.projectTopLevelInsideDeserializerThenNestedAfter(
+                        context,
+                        projectableDecodingFormat,
+                        physicalTableDataType,
+                        physicalDataTypeProjection,
+                        prefix,
+                        projectedPhysicalFields,
+                        metadataKeys);
+            }
+        }
+    }
+
+    /**
+     * @return a {@link DeserializationSchema} or null.
+     */
+    @Nullable
+    public DeserializationSchema<RowData> getDeserializationSchema() {
+        return deserializationSchema;
+    }
+
+    /**
+     * @return a {@link Projector}.
+     */
+    public Projector getProjector() {
+        return projector;
+    }
+
+    /**
+     * Creates an identity projection array where each field in the row type maps to itself.
+     *
+     * @param rowType the row type representing the table schema
+     * @return an int[][] with one entry per field in the row type, where entry i is {i}
+     */
+    public static int[][] identityProjection(final RowType rowType) {
+        final int tableSchemaSize = rowType.getFieldCount();
+        final int[][] projectedFields = new int[tableSchemaSize][];
+        for (int i = 0; i < tableSchemaSize; i++) {
+            projectedFields[i] = new int[] {i};
+        }
+        return projectedFields;
+    }
+
+    private static Decoder noDeserializationOrProjection() {
+        return new Decoder(null, new ProjectorImpl(Collections.emptyMap(), 0, 0));
+    }
+
+    private static DataType toPhysicalDataType(
+            final DataType physicalTableDataType,
+            final int[] physicalDataTypeProjection,
+            final @Nullable String prefix) {
+        final DataType temp =
+                Projection.of(physicalDataTypeProjection).project(physicalTableDataType);
+        return Optional.ofNullable(prefix)
+                .map(s -> TableDataTypeUtils.stripRowPrefix(temp, s))
+                .orElse(temp);
+    }
+
+    private static Map<Integer, Integer> tableToDeserializedTopLevelPos(
+            final int[] dataTypeProjection) {
+        final HashMap<Integer, Integer> tableToDeserializedPos = new HashMap<>();
+        for (int i = 0; i < dataTypeProjection.length; i++) {
+            tableToDeserializedPos.put(dataTypeProjection[i], i);
+        }
+        return tableToDeserializedPos;
+    }
+
+    private static int[] copyArray(final int[] arr) {
+        return Arrays.copyOf(arr, arr.length);
+    }
+
+    private static void addMetadataProjections(
+            final DecodingFormat<?> decodingFormat,
+            final int deserializedSize,
+            final int physicalSize,
+            final List<String> requestedMetadataKeys,
+            final Map<List<Integer>, Integer> deserializedToProducedPos) {
+
+        if (!requestedMetadataKeys.isEmpty()) {
+            decodingFormat.applyReadableMetadata(requestedMetadataKeys);
+
+            // project only requested metadata keys
+            for (int i = 0; i < requestedMetadataKeys.size(); i++) {
+                // metadata is always added to the end of the deserialized row by the DecodingFormat
+                final int deserializedPos = deserializedSize + i;
+                // we need to always add metadata to the end of the produced row
+                final int producePos = physicalSize + i;
+                deserializedToProducedPos.put(
+                        Collections.singletonList(deserializedPos), producePos);
+            }
+        }
+    }
+
+    /**
+     * This method generates a {@link Decoder} which pushes projections down directly into the
+     * {@link ProjectableDecodingFormat} which takes care of projecting the fields during the
+     * deserialization process itself.
+     */
+    private static Decoder projectInsideDeserializer(
+            final Context context,
+            final ProjectableDecodingFormat<DeserializationSchema<RowData>>
+                    projectableDecodingFormat,
+            final DataType physicalTableDataType,
+            final int[] physicalDataTypeProjection,
+            final @Nullable String prefix,
+            final int[][] projectedPhysicalFields,
+            final List<String> metadataKeys) {
+        final Map<Integer, Integer> tableToDeserializedTopLevelPos =
+                tableToDeserializedTopLevelPos(physicalDataTypeProjection);
+
+        final List<int[]> deserializerProjectedFields = new ArrayList<>();
+        final Map<List<Integer>, Integer> deserializedToProducedPos = new HashMap<>();
+        for (int producedPos = 0; producedPos < projectedPhysicalFields.length; producedPos++) {
+            final int[] tablePos = projectedPhysicalFields[producedPos];
+            final int tableTopLevelPos = tablePos[0];
+
+            final Integer dataTypeTopLevelPos =
+                    tableToDeserializedTopLevelPos.get(tableTopLevelPos);
+            if (dataTypeTopLevelPos != null) {
+                final int[] dataTypePos = copyArray(tablePos);
+                dataTypePos[0] = dataTypeTopLevelPos;
+
+                deserializerProjectedFields.add(dataTypePos);
+
+                final int deserializedPos = deserializerProjectedFields.size() - 1;
+                deserializedToProducedPos.put(
+                        Collections.singletonList(deserializedPos), producedPos);
+            }
+        }
+
+        addMetadataProjections(
+                projectableDecodingFormat,
+                deserializerProjectedFields.size(),
+                projectedPhysicalFields.length,
+                metadataKeys,
+                deserializedToProducedPos);
+
+        return new Decoder(
+                projectableDecodingFormat.createRuntimeDecoder(
+                        context,
+                        toPhysicalDataType(
+                                physicalTableDataType, physicalDataTypeProjection, prefix),
+                        deserializerProjectedFields.toArray(
+                                new int[deserializerProjectedFields.size()][])),
+                new ProjectorImpl(
+                        deserializedToProducedPos,
+                        deserializerProjectedFields.size(),
+                        metadataKeys.size()));
+    }
+
+    /**
+     * This method generates a {@link Decoder} for a {@link ProjectableDecodingFormat} that does not
+     * support <em>nested</em> projection. Only the required <em>top-level</em> fields are pushed
+     * down into the format, and any nested sub-fields are extracted from the deserialized row
+     * afterward by the {@link Projector}.
+     */
+    private static Decoder projectTopLevelInsideDeserializerThenNestedAfter(
+            final Context context,
+            final ProjectableDecodingFormat<DeserializationSchema<RowData>>
+                    projectableDecodingFormat,
+            final DataType physicalTableDataType,
+            final int[] physicalDataTypeProjection,
+            final @Nullable String prefix,
+            final int[][] projectedPhysicalFields,
+            final List<String> metadataKeys) {
+        final Map<Integer, Integer> tableToDeserializedTopLevelPos =
+                tableToDeserializedTopLevelPos(physicalDataTypeProjection);
+
+        // Top-level fields (in data type space) to push into the format, deduplicated so each
+        // required top-level field is only deserialized once.
+        final List<int[]> topLevelProjectedFields = new ArrayList<>();
+        final Map<Integer, Integer> dataTypeTopLevelToDeserializedPos = new HashMap<>();
+        final Map<List<Integer>, Integer> deserializedToProducedPos = new HashMap<>();
+        for (int producedPos = 0; producedPos < projectedPhysicalFields.length; producedPos++) {
+            final int[] tablePos = projectedPhysicalFields[producedPos];
+            final int tableTopLevelPos = tablePos[0];
+
+            final Integer dataTypeTopLevelPos =
+                    tableToDeserializedTopLevelPos.get(tableTopLevelPos);
+            if (dataTypeTopLevelPos != null) {
+                final int deserializedTopLevelPos =
+                        dataTypeTopLevelToDeserializedPos.computeIfAbsent(
+                                dataTypeTopLevelPos,
+                                k -> {
+                                    topLevelProjectedFields.add(new int[] {k});
+                                    return topLevelProjectedFields.size() - 1;
+                                });
+
+                // The remaining (nested) path is extracted from the deserialized row afterward.
+                final int[] deserializedPos = copyArray(tablePos);
+                deserializedPos[0] = deserializedTopLevelPos;
+                deserializedToProducedPos.put(
+                        Collections.unmodifiableList(
+                                Arrays.stream(deserializedPos)
+                                        .boxed()
+                                        .collect(Collectors.toList())),
+                        producedPos);
+            }
+        }
+
+        addMetadataProjections(
+                projectableDecodingFormat,
+                topLevelProjectedFields.size(),
+                projectedPhysicalFields.length,
+                metadataKeys,
+                deserializedToProducedPos);
+
+        return new Decoder(
+                projectableDecodingFormat.createRuntimeDecoder(
+                        context,
+                        toPhysicalDataType(
+                                physicalTableDataType, physicalDataTypeProjection, prefix),
+                        topLevelProjectedFields.toArray(new int[topLevelProjectedFields.size()][])),
+                new ProjectorImpl(
+                        deserializedToProducedPos,
+                        topLevelProjectedFields.size(),
+                        metadataKeys.size()));
+    }
+
+    /**
+     * This method generates a {@link Decoder} which deserializes the data fully using the {@link
+     * DecodingFormat} and then applies any projections afterward.
+     */
+    private static Decoder projectAfterDeserializing(
+            final Context context,
+            final DecodingFormat<DeserializationSchema<RowData>> decodingFormat,
+            final DataType physicalTableDataType,
+            final int[] physicalDataTypeProjection,
+            final @Nullable String prefix,
+            final int[][] projectedPhysicalFields,
+            final List<String> metadataKeys) {
+        final DataType physicalDataType =
+                toPhysicalDataType(physicalTableDataType, physicalDataTypeProjection, prefix);
+        final Map<Integer, Integer> tableToDeserializedTopLevelPos =
+                tableToDeserializedTopLevelPos(physicalDataTypeProjection);
+
+        final Map<List<Integer>, Integer> deserializedToProducedPos = new HashMap<>();
+        for (int producedPos = 0; producedPos < projectedPhysicalFields.length; producedPos++) {
+            final int[] tablePos = projectedPhysicalFields[producedPos];
+            int tableTopLevelPos = tablePos[0];
+
+            final Integer deserializedTopLevelPos =
+                    tableToDeserializedTopLevelPos.get(tableTopLevelPos);
+            if (deserializedTopLevelPos != null) {
+                final int[] deserializedPos = copyArray(tablePos);
+                deserializedPos[0] = deserializedTopLevelPos;
+
+                deserializedToProducedPos.put(
+                        Collections.unmodifiableList(
+                                Arrays.stream(deserializedPos)
+                                        .boxed()
+                                        .collect(Collectors.toList())),
+                        producedPos);
+            }
+        }
+
+        addMetadataProjections(
+                decodingFormat,
+                physicalDataTypeProjection.length,
+                projectedPhysicalFields.length,
+                metadataKeys,
+                deserializedToProducedPos);
+
+        return new Decoder(
+                decodingFormat.createRuntimeDecoder(context, physicalDataType),
+                new ProjectorImpl(
+                        deserializedToProducedPos,
+                        physicalDataTypeProjection.length,
+                        metadataKeys.size()));
+    }
+
+    /** Projects fields from the deserialized row to their positions in the final produced row. */
+    @Internal
+    public interface Projector extends Serializable {
+        /** Returns true if {@link #project} will not project any fields. */
+        boolean isEmptyProjection();
+
+        /**
+         * Returns true if projection is needed i.e. if the produced record is different from the
+         * deserialized record
+         */
+        boolean isProjectionNeeded();
+
+        /** Copies fields from the deserialized row to their final positions in the produced row. */
+        void project(final RowData deserialized, final GenericRowData producedRow);
+    }
+
+    private static class ProjectorImpl implements Projector {
+
+        private final Map<List<Integer>, Integer> deserializedToProducedPos;
+        private final boolean isProjectionNeeded;
+
+        ProjectorImpl(
+                final Map<List<Integer>, Integer> deserializedToProducedPos,
+                final int numDeserializedPhysicalFields,
+                final int numMetadataFields) {
+            this.deserializedToProducedPos = deserializedToProducedPos;
+            this.isProjectionNeeded =
+                    !(deserializedToProducedPos.size()
+                                    == (numDeserializedPhysicalFields + numMetadataFields)
+                            && samePositions(deserializedToProducedPos));
+        }
+
+        private static boolean samePositions(
+                Map<List<Integer>, Integer> deserializedToProducedPos) {
+            return deserializedToProducedPos.entrySet().stream()
+                    .allMatch(
+                            entry -> {
+                                final List<Integer> deserializedPos = entry.getKey();
+                                final List<Integer> producedPos =
+                                        Collections.singletonList(entry.getValue());
+                                return Objects.equals(producedPos, deserializedPos);
+                            });
+        }
+
+        @Override
+        public boolean isEmptyProjection() {
+            return deserializedToProducedPos.isEmpty();
+        }
+
+        @Override
+        public boolean isProjectionNeeded() {
+            return isProjectionNeeded;
+        }
+
+        @Override
+        public void project(final RowData deserialized, final GenericRowData producedRow) {
+            this.deserializedToProducedPos.forEach(
+                    (deserializedPos, targetPos) -> {
+                        Object value = deserialized;
+                        for (final Integer i : deserializedPos) {
+                            if (value == null) {
+                                break;
+                            }
+                            value = ((GenericRowData) value).getField(i);
+                        }
+                        producedRow.setField(targetPos, value);
+                    });
+        }
+    }
+}

--- a/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaTableSource.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaTableSource.java
@@ -36,7 +36,6 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.table.DynamicKafkaDeserializationSchema.MetadataConverter;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
@@ -49,6 +48,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -73,7 +73,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /** A {@link ScanTableSource} for {@link DynamicKafkaSource}. */
@@ -92,6 +91,12 @@ public class DynamicKafkaTableSource
 
     /** Metadata that is appended at the end of a physical source row. */
     protected List<String> metadataKeys;
+
+    /** Value format metadata keys. */
+    protected List<String> valueFormatMetadataKeys;
+
+    /** Indices that determine the physical fields and their positions in the produced row. */
+    protected int[][] projectedPhysicalFields;
 
     /** Watermark strategy that is used to generate per-partition watermark. */
     protected @Nullable WatermarkStrategy<RowData> watermarkStrategy;
@@ -212,6 +217,9 @@ public class DynamicKafkaTableSource
         // Mutable attributes
         this.producedDataType = physicalDataType;
         this.metadataKeys = Collections.emptyList();
+        this.valueFormatMetadataKeys = Collections.emptyList();
+        this.projectedPhysicalFields =
+                Decoder.identityProjection((RowType) physicalDataType.getLogicalType());
         this.watermarkStrategy = null;
         // Dynamic Kafka specific attributes
         Preconditions.checkArgument(
@@ -248,18 +256,33 @@ public class DynamicKafkaTableSource
 
     @Override
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext context) {
-        final DeserializationSchema<RowData> keyDeserialization =
-                createDeserialization(context, keyDecodingFormat, keyProjection, keyPrefix);
+        final Decoder keyDecoder =
+                Decoder.create(
+                        context,
+                        keyDecodingFormat,
+                        physicalDataType,
+                        keyProjection,
+                        keyPrefix,
+                        projectedPhysicalFields,
+                        Collections.emptyList(),
+                        false);
 
-        final DeserializationSchema<RowData> valueDeserialization =
-                createDeserialization(context, valueDecodingFormat, valueProjection, null);
+        final Decoder valueDecoder =
+                Decoder.create(
+                        context,
+                        valueDecodingFormat,
+                        physicalDataType,
+                        valueProjection,
+                        null,
+                        projectedPhysicalFields,
+                        valueFormatMetadataKeys,
+                        false);
 
         final TypeInformation<RowData> producedTypeInfo =
                 context.createTypeInformation(producedDataType);
 
         final DynamicKafkaSource<RowData> kafkaSource =
-                createDynamicKafkaSource(
-                        keyDeserialization, valueDeserialization, producedTypeInfo);
+                createDynamicKafkaSource(keyDecoder, valueDecoder, producedTypeInfo);
 
         return new DataStreamScanProvider() {
             @Override
@@ -311,25 +334,16 @@ public class DynamicKafkaTableSource
 
     @Override
     public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
-        // separate connector and format metadata
-        final List<String> formatMetadataKeys =
-                metadataKeys.stream()
-                        .filter(k -> k.startsWith(VALUE_METADATA_PREFIX))
-                        .collect(Collectors.toList());
-        final List<String> connectorMetadataKeys = new ArrayList<>(metadataKeys);
-        connectorMetadataKeys.removeAll(formatMetadataKeys);
-
-        // push down format metadata
-        final Map<String, DataType> formatMetadata = valueDecodingFormat.listReadableMetadata();
-        if (formatMetadata.size() > 0) {
-            final List<String> requestedFormatMetadataKeys =
-                    formatMetadataKeys.stream()
-                            .map(k -> k.substring(VALUE_METADATA_PREFIX.length()))
-                            .collect(Collectors.toList());
-            valueDecodingFormat.applyReadableMetadata(requestedFormatMetadataKeys);
+        this.valueFormatMetadataKeys = new ArrayList<>();
+        this.metadataKeys = new ArrayList<>();
+        for (final String key : metadataKeys) {
+            if (key.startsWith(VALUE_METADATA_PREFIX)) {
+                final String formatMetadataKey = key.substring(VALUE_METADATA_PREFIX.length());
+                this.valueFormatMetadataKeys.add(formatMetadataKey);
+            } else {
+                this.metadataKeys.add(key);
+            }
         }
-
-        this.metadataKeys = connectorMetadataKeys;
         this.producedDataType = producedDataType;
     }
 
@@ -368,6 +382,8 @@ public class DynamicKafkaTableSource
                         parallelism);
         copy.producedDataType = producedDataType;
         copy.metadataKeys = metadataKeys;
+        copy.valueFormatMetadataKeys = valueFormatMetadataKeys;
+        copy.projectedPhysicalFields = projectedPhysicalFields;
         copy.watermarkStrategy = watermarkStrategy;
         return copy;
     }
@@ -388,6 +404,8 @@ public class DynamicKafkaTableSource
         final DynamicKafkaTableSource that = (DynamicKafkaTableSource) o;
         return Objects.equals(producedDataType, that.producedDataType)
                 && Objects.equals(metadataKeys, that.metadataKeys)
+                && Objects.equals(valueFormatMetadataKeys, that.valueFormatMetadataKeys)
+                && Arrays.deepEquals(projectedPhysicalFields, that.projectedPhysicalFields)
                 && Objects.equals(physicalDataType, that.physicalDataType)
                 && Objects.equals(keyDecodingFormat, that.keyDecodingFormat)
                 && Objects.equals(valueDecodingFormat, that.valueDecodingFormat)
@@ -415,6 +433,8 @@ public class DynamicKafkaTableSource
         return Objects.hash(
                 producedDataType,
                 metadataKeys,
+                valueFormatMetadataKeys,
+                Arrays.deepHashCode(projectedPhysicalFields),
                 physicalDataType,
                 keyDecodingFormat,
                 valueDecodingFormat,
@@ -440,13 +460,10 @@ public class DynamicKafkaTableSource
     // --------------------------------------------------------------------------------------------
 
     protected DynamicKafkaSource<RowData> createDynamicKafkaSource(
-            DeserializationSchema<RowData> keyDeserialization,
-            DeserializationSchema<RowData> valueDeserialization,
-            TypeInformation<RowData> producedTypeInfo) {
+            Decoder keyDecoder, Decoder valueDecoder, TypeInformation<RowData> producedTypeInfo) {
 
         final KafkaRecordDeserializationSchema<RowData> kafkaDeserializer =
-                createKafkaDeserializationSchema(
-                        keyDeserialization, valueDeserialization, producedTypeInfo);
+                createKafkaDeserializationSchema(keyDecoder, valueDecoder, producedTypeInfo);
 
         final DynamicKafkaSourceBuilder<RowData> dynamicKafkaSourceBuilder =
                 DynamicKafkaSource.builder();
@@ -528,9 +545,7 @@ public class DynamicKafkaTableSource
     }
 
     private KafkaRecordDeserializationSchema<RowData> createKafkaDeserializationSchema(
-            DeserializationSchema<RowData> keyDeserialization,
-            DeserializationSchema<RowData> valueDeserialization,
-            TypeInformation<RowData> producedTypeInfo) {
+            Decoder keyDecoder, Decoder valueDecoder, TypeInformation<RowData> producedTypeInfo) {
         final MetadataConverter[] metadataConverters = new MetadataConverter[metadataKeys.size()];
         final boolean[] clusterMetadataPositions = new boolean[metadataKeys.size()];
         boolean hasClusterMetadata = false;
@@ -556,42 +571,17 @@ public class DynamicKafkaTableSource
         final int adjustedPhysicalArity =
                 DataType.getFieldDataTypes(producedDataType).size() - metadataKeys.size();
 
-        // adjust value format projection to include value format's metadata columns at the end
-        final int[] adjustedValueProjection =
-                IntStream.concat(
-                                IntStream.of(valueProjection),
-                                IntStream.range(
-                                        keyProjection.length + valueProjection.length,
-                                        adjustedPhysicalArity))
-                        .toArray();
-
         return new DynamicKafkaDeserializationSchema(
                 adjustedPhysicalArity,
-                keyDeserialization,
-                keyProjection,
-                valueDeserialization,
-                adjustedValueProjection,
+                keyDecoder.getDeserializationSchema(),
+                keyDecoder.getProjector(),
+                valueDecoder.getDeserializationSchema(),
+                valueDecoder.getProjector(),
                 hasMetadata,
                 metadataConverters,
                 producedTypeInfo,
                 upsertMode,
                 clusterPositions);
-    }
-
-    private @Nullable DeserializationSchema<RowData> createDeserialization(
-            DynamicTableSource.Context context,
-            @Nullable DecodingFormat<DeserializationSchema<RowData>> format,
-            int[] projection,
-            @Nullable String prefix) {
-        if (format == null) {
-            return null;
-        }
-        DataType physicalFormatDataType = Projection.of(projection).project(this.physicalDataType);
-        if (prefix != null) {
-            physicalFormatDataType =
-                    TableDataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
-        }
-        return format.createRuntimeDecoder(context, physicalFormatDataType);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaTableSource.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaTableSource.java
@@ -37,7 +37,6 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.table.DynamicKafkaDeserializationSchema.MetadataConverter;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
@@ -50,6 +49,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -73,7 +73,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /** A {@link ScanTableSource} for {@link DynamicKafkaSource}. */
@@ -92,6 +91,12 @@ public class DynamicKafkaTableSource
 
     /** Metadata that is appended at the end of a physical source row. */
     protected List<String> metadataKeys;
+
+    /** Value format metadata keys. */
+    protected List<String> valueFormatMetadataKeys;
+
+    /** Indices that determine the physical fields and their positions in the produced row. */
+    protected int[][] projectedPhysicalFields;
 
     /** Watermark strategy that is used to generate per-partition watermark. */
     protected @Nullable WatermarkStrategy<RowData> watermarkStrategy;
@@ -212,6 +217,9 @@ public class DynamicKafkaTableSource
         // Mutable attributes
         this.producedDataType = physicalDataType;
         this.metadataKeys = Collections.emptyList();
+        this.valueFormatMetadataKeys = Collections.emptyList();
+        this.projectedPhysicalFields =
+                Decoder.identityProjection((RowType) physicalDataType.getLogicalType());
         this.watermarkStrategy = null;
         // Dynamic Kafka specific attributes
         Preconditions.checkArgument(
@@ -248,18 +256,33 @@ public class DynamicKafkaTableSource
 
     @Override
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext context) {
-        final DeserializationSchema<RowData> keyDeserialization =
-                createDeserialization(context, keyDecodingFormat, keyProjection, keyPrefix);
+        final Decoder keyDecoder =
+                Decoder.create(
+                        context,
+                        keyDecodingFormat,
+                        physicalDataType,
+                        keyProjection,
+                        keyPrefix,
+                        projectedPhysicalFields,
+                        Collections.emptyList(),
+                        false);
 
-        final DeserializationSchema<RowData> valueDeserialization =
-                createDeserialization(context, valueDecodingFormat, valueProjection, null);
+        final Decoder valueDecoder =
+                Decoder.create(
+                        context,
+                        valueDecodingFormat,
+                        physicalDataType,
+                        valueProjection,
+                        null,
+                        projectedPhysicalFields,
+                        valueFormatMetadataKeys,
+                        false);
 
         final TypeInformation<RowData> producedTypeInfo =
                 context.createTypeInformation(producedDataType);
 
         final DynamicKafkaSource<RowData> kafkaSource =
-                createDynamicKafkaSource(
-                        keyDeserialization, valueDeserialization, producedTypeInfo);
+                createDynamicKafkaSource(keyDecoder, valueDecoder, producedTypeInfo);
 
         return new DataStreamScanProvider() {
             @Override
@@ -311,25 +334,16 @@ public class DynamicKafkaTableSource
 
     @Override
     public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
-        // separate connector and format metadata
-        final List<String> formatMetadataKeys =
-                metadataKeys.stream()
-                        .filter(k -> k.startsWith(VALUE_METADATA_PREFIX))
-                        .collect(Collectors.toList());
-        final List<String> connectorMetadataKeys = new ArrayList<>(metadataKeys);
-        connectorMetadataKeys.removeAll(formatMetadataKeys);
-
-        // push down format metadata
-        final Map<String, DataType> formatMetadata = valueDecodingFormat.listReadableMetadata();
-        if (formatMetadata.size() > 0) {
-            final List<String> requestedFormatMetadataKeys =
-                    formatMetadataKeys.stream()
-                            .map(k -> k.substring(VALUE_METADATA_PREFIX.length()))
-                            .collect(Collectors.toList());
-            valueDecodingFormat.applyReadableMetadata(requestedFormatMetadataKeys);
+        this.valueFormatMetadataKeys = new ArrayList<>();
+        this.metadataKeys = new ArrayList<>();
+        for (final String key : metadataKeys) {
+            if (key.startsWith(VALUE_METADATA_PREFIX)) {
+                final String formatMetadataKey = key.substring(VALUE_METADATA_PREFIX.length());
+                this.valueFormatMetadataKeys.add(formatMetadataKey);
+            } else {
+                this.metadataKeys.add(key);
+            }
         }
-
-        this.metadataKeys = connectorMetadataKeys;
         this.producedDataType = producedDataType;
     }
 
@@ -368,6 +382,8 @@ public class DynamicKafkaTableSource
                         parallelism);
         copy.producedDataType = producedDataType;
         copy.metadataKeys = metadataKeys;
+        copy.valueFormatMetadataKeys = valueFormatMetadataKeys;
+        copy.projectedPhysicalFields = projectedPhysicalFields;
         copy.watermarkStrategy = watermarkStrategy;
         return copy;
     }
@@ -388,6 +404,8 @@ public class DynamicKafkaTableSource
         final DynamicKafkaTableSource that = (DynamicKafkaTableSource) o;
         return Objects.equals(producedDataType, that.producedDataType)
                 && Objects.equals(metadataKeys, that.metadataKeys)
+                && Objects.equals(valueFormatMetadataKeys, that.valueFormatMetadataKeys)
+                && Arrays.deepEquals(projectedPhysicalFields, that.projectedPhysicalFields)
                 && Objects.equals(physicalDataType, that.physicalDataType)
                 && Objects.equals(keyDecodingFormat, that.keyDecodingFormat)
                 && Objects.equals(valueDecodingFormat, that.valueDecodingFormat)
@@ -415,6 +433,8 @@ public class DynamicKafkaTableSource
         return Objects.hash(
                 producedDataType,
                 metadataKeys,
+                valueFormatMetadataKeys,
+                Arrays.deepHashCode(projectedPhysicalFields),
                 physicalDataType,
                 keyDecodingFormat,
                 valueDecodingFormat,
@@ -440,14 +460,11 @@ public class DynamicKafkaTableSource
     // --------------------------------------------------------------------------------------------
 
     protected DynamicKafkaSource<RowData> createDynamicKafkaSource(
-            DeserializationSchema<RowData> keyDeserialization,
-            DeserializationSchema<RowData> valueDeserialization,
-            TypeInformation<RowData> producedTypeInfo) {
+            Decoder keyDecoder, Decoder valueDecoder, TypeInformation<RowData> producedTypeInfo) {
         KafkaConnectorOptionsUtil.validateAndNormalizeAutoOffsetResetStrategy(properties);
 
         final KafkaRecordDeserializationSchema<RowData> kafkaDeserializer =
-                createKafkaDeserializationSchema(
-                        keyDeserialization, valueDeserialization, producedTypeInfo);
+                createKafkaDeserializationSchema(keyDecoder, valueDecoder, producedTypeInfo);
 
         final DynamicKafkaSourceBuilder<RowData> dynamicKafkaSourceBuilder =
                 DynamicKafkaSource.builder();
@@ -520,9 +537,7 @@ public class DynamicKafkaTableSource
     }
 
     private KafkaRecordDeserializationSchema<RowData> createKafkaDeserializationSchema(
-            DeserializationSchema<RowData> keyDeserialization,
-            DeserializationSchema<RowData> valueDeserialization,
-            TypeInformation<RowData> producedTypeInfo) {
+            Decoder keyDecoder, Decoder valueDecoder, TypeInformation<RowData> producedTypeInfo) {
         final MetadataConverter[] metadataConverters = new MetadataConverter[metadataKeys.size()];
         final boolean[] clusterMetadataPositions = new boolean[metadataKeys.size()];
         boolean hasClusterMetadata = false;
@@ -548,42 +563,17 @@ public class DynamicKafkaTableSource
         final int adjustedPhysicalArity =
                 DataType.getFieldDataTypes(producedDataType).size() - metadataKeys.size();
 
-        // adjust value format projection to include value format's metadata columns at the end
-        final int[] adjustedValueProjection =
-                IntStream.concat(
-                                IntStream.of(valueProjection),
-                                IntStream.range(
-                                        keyProjection.length + valueProjection.length,
-                                        adjustedPhysicalArity))
-                        .toArray();
-
         return new DynamicKafkaDeserializationSchema(
                 adjustedPhysicalArity,
-                keyDeserialization,
-                keyProjection,
-                valueDeserialization,
-                adjustedValueProjection,
+                keyDecoder.getDeserializationSchema(),
+                keyDecoder.getProjector(),
+                valueDecoder.getDeserializationSchema(),
+                valueDecoder.getProjector(),
                 hasMetadata,
                 metadataConverters,
                 producedTypeInfo,
                 upsertMode,
                 clusterPositions);
-    }
-
-    private @Nullable DeserializationSchema<RowData> createDeserialization(
-            DynamicTableSource.Context context,
-            @Nullable DecodingFormat<DeserializationSchema<RowData>> format,
-            int[] projection,
-            @Nullable String prefix) {
-        if (format == null) {
-            return null;
-        }
-        DataType physicalFormatDataType = Projection.of(projection).project(this.physicalDataType);
-        if (prefix != null) {
-            physicalFormatDataType =
-                    TableDataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
-        }
-        return format.createRuntimeDecoder(context, physicalFormatDataType);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptions.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaConnectorOptions.java
@@ -110,6 +110,23 @@ public class KafkaConnectorOptions {
     public static final ConfigOption<Integer> SCAN_PARALLELISM = FactoryUtil.SOURCE_PARALLELISM;
     public static final ConfigOption<Integer> SINK_PARALLELISM = FactoryUtil.SINK_PARALLELISM;
 
+    private static final String PROJECTION_PUSHDOWN_DESCRIPTION =
+            "When enabled, query projections are pushed down into the format. How much is pushed "
+                    + "down depends on the format's level of projection-pushdown support (none, "
+                    + "top-level, or nested).";
+
+    public static final ConfigOption<Boolean> KEY_FORMAT_PROJECTION_PUSHDOWN_ENABLED =
+            ConfigOptions.key("key" + FORMAT_SUFFIX + ".projection-pushdown.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(PROJECTION_PUSHDOWN_DESCRIPTION);
+
+    public static final ConfigOption<Boolean> VALUE_FORMAT_PROJECTION_PUSHDOWN_ENABLED =
+            ConfigOptions.key("value" + FORMAT_SUFFIX + ".projection-pushdown.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(PROJECTION_PUSHDOWN_DESCRIPTION);
+
     // --------------------------------------------------------------------------------------------
     // Kafka specific options
     // --------------------------------------------------------------------------------------------

--- a/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
@@ -36,12 +36,12 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.table.DynamicKafkaDeserializationSchema.MetadataConverter;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.GenericArrayData;
@@ -51,6 +51,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -74,13 +75,15 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /** A version-agnostic Kafka {@link ScanTableSource}. */
 @Internal
 public class KafkaDynamicSource
-        implements ScanTableSource, SupportsReadingMetadata, SupportsWatermarkPushDown {
+        implements ScanTableSource,
+                SupportsReadingMetadata,
+                SupportsWatermarkPushDown,
+                SupportsProjectionPushDown {
 
     private static final String KAFKA_TRANSFORMATION = "kafka";
 
@@ -91,11 +94,17 @@ public class KafkaDynamicSource
     /** Data type that describes the final output of the source. */
     protected DataType producedDataType;
 
-    /** Metadata that is appended at the end of a physical source row. */
+    /** Value format metadata that is appended at the end of a physical source row. */
+    protected List<String> valueFormatMetadataKeys;
+
+    /** Connector metadata that is appended at the end of a physical source row. */
     protected List<String> metadataKeys;
 
     /** Watermark strategy that is used to generate per-partition watermark. */
     protected @Nullable WatermarkStrategy<RowData> watermarkStrategy;
+
+    /** Field index paths of all fields that must be present in the physically produced data. */
+    protected int[][] projectedPhysicalFields;
 
     // --------------------------------------------------------------------------------------------
     // Format attributes
@@ -112,14 +121,18 @@ public class KafkaDynamicSource
     /** Format for decoding values from Kafka. */
     protected final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat;
 
-    /** Indices that determine the key fields and the target position in the produced row. */
+    /** Indices that determine the key fields and their position in the table schema. */
     protected final int[] keyProjection;
 
-    /** Indices that determine the value fields and the target position in the produced row. */
+    /** Indices that determine the value fields and their position in the table schema. */
     protected final int[] valueProjection;
 
     /** Prefix that needs to be removed from fields when constructing the physical data type. */
     protected final @Nullable String keyPrefix;
+
+    protected final boolean keyProjectionPushdownEnabled;
+
+    protected final boolean valueProjectionPushdownEnabled;
 
     // --------------------------------------------------------------------------------------------
     // Kafka-specific attributes
@@ -192,7 +205,9 @@ public class KafkaDynamicSource
             long boundedTimestampMillis,
             boolean upsertMode,
             String tableIdentifier,
-            @Nullable Integer parallelism) {
+            @Nullable Integer parallelism,
+            boolean keyProjectionPushdownEnabled,
+            boolean valueProjectionPushdownEnabled) {
         // Format attributes
         this.physicalDataType =
                 Preconditions.checkNotNull(
@@ -206,10 +221,15 @@ public class KafkaDynamicSource
         this.valueProjection =
                 Preconditions.checkNotNull(valueProjection, "Value projection must not be null.");
         this.keyPrefix = keyPrefix;
+        this.keyProjectionPushdownEnabled = keyProjectionPushdownEnabled;
+        this.valueProjectionPushdownEnabled = valueProjectionPushdownEnabled;
         // Mutable attributes
         this.producedDataType = physicalDataType;
+        this.valueFormatMetadataKeys = Collections.emptyList();
         this.metadataKeys = Collections.emptyList();
         this.watermarkStrategy = null;
+        this.projectedPhysicalFields =
+                Decoder.identityProjection((RowType) physicalDataType.getLogicalType());
         // Kafka-specific attributes
         Preconditions.checkArgument(
                 (topics != null && topicPattern == null)
@@ -242,17 +262,33 @@ public class KafkaDynamicSource
 
     @Override
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext context) {
-        final DeserializationSchema<RowData> keyDeserialization =
-                createDeserialization(context, keyDecodingFormat, keyProjection, keyPrefix);
+        final Decoder keyDecoder =
+                Decoder.create(
+                        context,
+                        keyDecodingFormat,
+                        physicalDataType,
+                        keyProjection,
+                        keyPrefix,
+                        projectedPhysicalFields,
+                        Collections.emptyList(),
+                        keyProjectionPushdownEnabled);
 
-        final DeserializationSchema<RowData> valueDeserialization =
-                createDeserialization(context, valueDecodingFormat, valueProjection, null);
+        final Decoder valueDecoder =
+                Decoder.create(
+                        context,
+                        valueDecodingFormat,
+                        physicalDataType,
+                        valueProjection,
+                        null,
+                        projectedPhysicalFields,
+                        valueFormatMetadataKeys,
+                        valueProjectionPushdownEnabled);
 
         final TypeInformation<RowData> producedTypeInfo =
                 context.createTypeInformation(producedDataType);
 
         final KafkaSource<RowData> kafkaSource =
-                createKafkaSource(keyDeserialization, valueDeserialization, producedTypeInfo);
+                createKafkaSource(keyDecoder, valueDecoder, producedTypeInfo);
 
         return new DataStreamScanProvider() {
             @Override
@@ -302,36 +338,32 @@ public class KafkaDynamicSource
 
     @Override
     public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
-        // separate connector and format metadata
-        final List<String> formatMetadataKeys =
-                metadataKeys.stream()
-                        .filter(k -> k.startsWith(VALUE_METADATA_PREFIX))
-                        .collect(Collectors.toList());
-        final List<String> connectorMetadataKeys = new ArrayList<>(metadataKeys);
-        connectorMetadataKeys.removeAll(formatMetadataKeys);
-
-        // push down format metadata
-        final Map<String, DataType> formatMetadata = valueDecodingFormat.listReadableMetadata();
-        if (formatMetadata.size() > 0) {
-            final List<String> requestedFormatMetadataKeys =
-                    formatMetadataKeys.stream()
-                            .map(k -> k.substring(VALUE_METADATA_PREFIX.length()))
-                            .collect(Collectors.toList());
-            valueDecodingFormat.applyReadableMetadata(requestedFormatMetadataKeys);
+        this.valueFormatMetadataKeys = new ArrayList<>();
+        this.metadataKeys = new ArrayList<>();
+        for (final String key : metadataKeys) {
+            if (key.startsWith(VALUE_METADATA_PREFIX)) {
+                final String formatMetadataKey = key.substring(VALUE_METADATA_PREFIX.length());
+                this.valueFormatMetadataKeys.add(formatMetadataKey);
+            } else {
+                this.metadataKeys.add(key);
+            }
         }
-
-        this.metadataKeys = connectorMetadataKeys;
         this.producedDataType = producedDataType;
-    }
-
-    @Override
-    public boolean supportsMetadataProjection() {
-        return false;
     }
 
     @Override
     public void applyWatermark(WatermarkStrategy<RowData> watermarkStrategy) {
         this.watermarkStrategy = watermarkStrategy;
+    }
+
+    @Override
+    public boolean supportsNestedProjection() {
+        return true;
+    }
+
+    @Override
+    public void applyProjection(final int[][] projectedFields, final DataType producedDataType) {
+        this.projectedPhysicalFields = projectedFields;
     }
 
     @Override
@@ -355,10 +387,14 @@ public class KafkaDynamicSource
                         boundedTimestampMillis,
                         upsertMode,
                         tableIdentifier,
-                        parallelism);
+                        parallelism,
+                        keyProjectionPushdownEnabled,
+                        valueProjectionPushdownEnabled);
         copy.producedDataType = producedDataType;
+        copy.valueFormatMetadataKeys = valueFormatMetadataKeys;
         copy.metadataKeys = metadataKeys;
         copy.watermarkStrategy = watermarkStrategy;
+        copy.projectedPhysicalFields = projectedPhysicalFields;
         return copy;
     }
 
@@ -377,6 +413,7 @@ public class KafkaDynamicSource
         }
         final KafkaDynamicSource that = (KafkaDynamicSource) o;
         return Objects.equals(producedDataType, that.producedDataType)
+                && Objects.equals(valueFormatMetadataKeys, that.valueFormatMetadataKeys)
                 && Objects.equals(metadataKeys, that.metadataKeys)
                 && Objects.equals(physicalDataType, that.physicalDataType)
                 && Objects.equals(keyDecodingFormat, that.keyDecodingFormat)
@@ -396,13 +433,17 @@ public class KafkaDynamicSource
                 && Objects.equals(upsertMode, that.upsertMode)
                 && Objects.equals(tableIdentifier, that.tableIdentifier)
                 && Objects.equals(watermarkStrategy, that.watermarkStrategy)
-                && Objects.equals(parallelism, that.parallelism);
+                && Objects.equals(parallelism, that.parallelism)
+                && Arrays.deepEquals(projectedPhysicalFields, that.projectedPhysicalFields)
+                && keyProjectionPushdownEnabled == that.keyProjectionPushdownEnabled
+                && valueProjectionPushdownEnabled == that.valueProjectionPushdownEnabled;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
                 producedDataType,
+                valueFormatMetadataKeys,
                 metadataKeys,
                 physicalDataType,
                 keyDecodingFormat,
@@ -422,19 +463,19 @@ public class KafkaDynamicSource
                 upsertMode,
                 tableIdentifier,
                 watermarkStrategy,
-                parallelism);
+                parallelism,
+                Arrays.deepHashCode(projectedPhysicalFields),
+                keyProjectionPushdownEnabled,
+                valueProjectionPushdownEnabled);
     }
 
     // --------------------------------------------------------------------------------------------
 
     protected KafkaSource<RowData> createKafkaSource(
-            DeserializationSchema<RowData> keyDeserialization,
-            DeserializationSchema<RowData> valueDeserialization,
-            TypeInformation<RowData> producedTypeInfo) {
+            Decoder keyDecoder, Decoder valueDecoder, TypeInformation<RowData> producedTypeInfo) {
 
         final KafkaRecordDeserializationSchema<RowData> kafkaDeserializer =
-                createKafkaDeserializationSchema(
-                        keyDeserialization, valueDeserialization, producedTypeInfo);
+                createKafkaDeserializationSchema(keyDecoder, valueDecoder, producedTypeInfo);
 
         final KafkaSourceBuilder<RowData> kafkaSourceBuilder = KafkaSource.builder();
 
@@ -520,9 +561,7 @@ public class KafkaDynamicSource
     }
 
     private KafkaRecordDeserializationSchema<RowData> createKafkaDeserializationSchema(
-            DeserializationSchema<RowData> keyDeserialization,
-            DeserializationSchema<RowData> valueDeserialization,
-            TypeInformation<RowData> producedTypeInfo) {
+            Decoder keyDecoder, Decoder valueDecoder, TypeInformation<RowData> producedTypeInfo) {
         final MetadataConverter[] metadataConverters =
                 metadataKeys.stream()
                         .map(
@@ -541,41 +580,16 @@ public class KafkaDynamicSource
         final int adjustedPhysicalArity =
                 DataType.getFieldDataTypes(producedDataType).size() - metadataKeys.size();
 
-        // adjust value format projection to include value format's metadata columns at the end
-        final int[] adjustedValueProjection =
-                IntStream.concat(
-                                IntStream.of(valueProjection),
-                                IntStream.range(
-                                        keyProjection.length + valueProjection.length,
-                                        adjustedPhysicalArity))
-                        .toArray();
-
         return new DynamicKafkaDeserializationSchema(
                 adjustedPhysicalArity,
-                keyDeserialization,
-                keyProjection,
-                valueDeserialization,
-                adjustedValueProjection,
+                keyDecoder.getDeserializationSchema(),
+                keyDecoder.getProjector(),
+                valueDecoder.getDeserializationSchema(),
+                valueDecoder.getProjector(),
                 hasMetadata,
                 metadataConverters,
                 producedTypeInfo,
                 upsertMode);
-    }
-
-    private @Nullable DeserializationSchema<RowData> createDeserialization(
-            DynamicTableSource.Context context,
-            @Nullable DecodingFormat<DeserializationSchema<RowData>> format,
-            int[] projection,
-            @Nullable String prefix) {
-        if (format == null) {
-            return null;
-        }
-        DataType physicalFormatDataType = Projection.of(projection).project(this.physicalDataType);
-        if (prefix != null) {
-            physicalFormatDataType =
-                    TableDataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
-        }
-        return format.createRuntimeDecoder(context, physicalFormatDataType);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
@@ -37,12 +37,12 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.table.DynamicKafkaDeserializationSchema.MetadataConverter;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
 import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.GenericArrayData;
@@ -52,6 +52,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -74,13 +75,15 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /** A version-agnostic Kafka {@link ScanTableSource}. */
 @Internal
 public class KafkaDynamicSource
-        implements ScanTableSource, SupportsReadingMetadata, SupportsWatermarkPushDown {
+        implements ScanTableSource,
+                SupportsReadingMetadata,
+                SupportsWatermarkPushDown,
+                SupportsProjectionPushDown {
 
     private static final String KAFKA_TRANSFORMATION = "kafka";
 
@@ -91,11 +94,17 @@ public class KafkaDynamicSource
     /** Data type that describes the final output of the source. */
     protected DataType producedDataType;
 
-    /** Metadata that is appended at the end of a physical source row. */
+    /** Value format metadata that is appended at the end of a physical source row. */
+    protected List<String> valueFormatMetadataKeys;
+
+    /** Connector metadata that is appended at the end of a physical source row. */
     protected List<String> metadataKeys;
 
     /** Watermark strategy that is used to generate per-partition watermark. */
     protected @Nullable WatermarkStrategy<RowData> watermarkStrategy;
+
+    /** Field index paths of all fields that must be present in the physically produced data. */
+    protected int[][] projectedPhysicalFields;
 
     // --------------------------------------------------------------------------------------------
     // Format attributes
@@ -112,14 +121,18 @@ public class KafkaDynamicSource
     /** Format for decoding values from Kafka. */
     protected final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat;
 
-    /** Indices that determine the key fields and the target position in the produced row. */
+    /** Indices that determine the key fields and their position in the table schema. */
     protected final int[] keyProjection;
 
-    /** Indices that determine the value fields and the target position in the produced row. */
+    /** Indices that determine the value fields and their position in the table schema. */
     protected final int[] valueProjection;
 
     /** Prefix that needs to be removed from fields when constructing the physical data type. */
     protected final @Nullable String keyPrefix;
+
+    protected final boolean keyProjectionPushdownEnabled;
+
+    protected final boolean valueProjectionPushdownEnabled;
 
     // --------------------------------------------------------------------------------------------
     // Kafka-specific attributes
@@ -192,7 +205,9 @@ public class KafkaDynamicSource
             long boundedTimestampMillis,
             boolean upsertMode,
             String tableIdentifier,
-            @Nullable Integer parallelism) {
+            @Nullable Integer parallelism,
+            boolean keyProjectionPushdownEnabled,
+            boolean valueProjectionPushdownEnabled) {
         // Format attributes
         this.physicalDataType =
                 Preconditions.checkNotNull(
@@ -206,10 +221,15 @@ public class KafkaDynamicSource
         this.valueProjection =
                 Preconditions.checkNotNull(valueProjection, "Value projection must not be null.");
         this.keyPrefix = keyPrefix;
+        this.keyProjectionPushdownEnabled = keyProjectionPushdownEnabled;
+        this.valueProjectionPushdownEnabled = valueProjectionPushdownEnabled;
         // Mutable attributes
         this.producedDataType = physicalDataType;
+        this.valueFormatMetadataKeys = Collections.emptyList();
         this.metadataKeys = Collections.emptyList();
         this.watermarkStrategy = null;
+        this.projectedPhysicalFields =
+                Decoder.identityProjection((RowType) physicalDataType.getLogicalType());
         // Kafka-specific attributes
         Preconditions.checkArgument(
                 (topics != null && topicPattern == null)
@@ -242,17 +262,33 @@ public class KafkaDynamicSource
 
     @Override
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext context) {
-        final DeserializationSchema<RowData> keyDeserialization =
-                createDeserialization(context, keyDecodingFormat, keyProjection, keyPrefix);
+        final Decoder keyDecoder =
+                Decoder.create(
+                        context,
+                        keyDecodingFormat,
+                        physicalDataType,
+                        keyProjection,
+                        keyPrefix,
+                        projectedPhysicalFields,
+                        Collections.emptyList(),
+                        keyProjectionPushdownEnabled);
 
-        final DeserializationSchema<RowData> valueDeserialization =
-                createDeserialization(context, valueDecodingFormat, valueProjection, null);
+        final Decoder valueDecoder =
+                Decoder.create(
+                        context,
+                        valueDecodingFormat,
+                        physicalDataType,
+                        valueProjection,
+                        null,
+                        projectedPhysicalFields,
+                        valueFormatMetadataKeys,
+                        valueProjectionPushdownEnabled);
 
         final TypeInformation<RowData> producedTypeInfo =
                 context.createTypeInformation(producedDataType);
 
         final KafkaSource<RowData> kafkaSource =
-                createKafkaSource(keyDeserialization, valueDeserialization, producedTypeInfo);
+                createKafkaSource(keyDecoder, valueDecoder, producedTypeInfo);
 
         return new DataStreamScanProvider() {
             @Override
@@ -302,36 +338,32 @@ public class KafkaDynamicSource
 
     @Override
     public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
-        // separate connector and format metadata
-        final List<String> formatMetadataKeys =
-                metadataKeys.stream()
-                        .filter(k -> k.startsWith(VALUE_METADATA_PREFIX))
-                        .collect(Collectors.toList());
-        final List<String> connectorMetadataKeys = new ArrayList<>(metadataKeys);
-        connectorMetadataKeys.removeAll(formatMetadataKeys);
-
-        // push down format metadata
-        final Map<String, DataType> formatMetadata = valueDecodingFormat.listReadableMetadata();
-        if (formatMetadata.size() > 0) {
-            final List<String> requestedFormatMetadataKeys =
-                    formatMetadataKeys.stream()
-                            .map(k -> k.substring(VALUE_METADATA_PREFIX.length()))
-                            .collect(Collectors.toList());
-            valueDecodingFormat.applyReadableMetadata(requestedFormatMetadataKeys);
+        this.valueFormatMetadataKeys = new ArrayList<>();
+        this.metadataKeys = new ArrayList<>();
+        for (final String key : metadataKeys) {
+            if (key.startsWith(VALUE_METADATA_PREFIX)) {
+                final String formatMetadataKey = key.substring(VALUE_METADATA_PREFIX.length());
+                this.valueFormatMetadataKeys.add(formatMetadataKey);
+            } else {
+                this.metadataKeys.add(key);
+            }
         }
-
-        this.metadataKeys = connectorMetadataKeys;
         this.producedDataType = producedDataType;
-    }
-
-    @Override
-    public boolean supportsMetadataProjection() {
-        return false;
     }
 
     @Override
     public void applyWatermark(WatermarkStrategy<RowData> watermarkStrategy) {
         this.watermarkStrategy = watermarkStrategy;
+    }
+
+    @Override
+    public boolean supportsNestedProjection() {
+        return true;
+    }
+
+    @Override
+    public void applyProjection(final int[][] projectedFields, final DataType producedDataType) {
+        this.projectedPhysicalFields = projectedFields;
     }
 
     @Override
@@ -355,10 +387,14 @@ public class KafkaDynamicSource
                         boundedTimestampMillis,
                         upsertMode,
                         tableIdentifier,
-                        parallelism);
+                        parallelism,
+                        keyProjectionPushdownEnabled,
+                        valueProjectionPushdownEnabled);
         copy.producedDataType = producedDataType;
+        copy.valueFormatMetadataKeys = valueFormatMetadataKeys;
         copy.metadataKeys = metadataKeys;
         copy.watermarkStrategy = watermarkStrategy;
+        copy.projectedPhysicalFields = projectedPhysicalFields;
         return copy;
     }
 
@@ -377,6 +413,7 @@ public class KafkaDynamicSource
         }
         final KafkaDynamicSource that = (KafkaDynamicSource) o;
         return Objects.equals(producedDataType, that.producedDataType)
+                && Objects.equals(valueFormatMetadataKeys, that.valueFormatMetadataKeys)
                 && Objects.equals(metadataKeys, that.metadataKeys)
                 && Objects.equals(physicalDataType, that.physicalDataType)
                 && Objects.equals(keyDecodingFormat, that.keyDecodingFormat)
@@ -396,13 +433,17 @@ public class KafkaDynamicSource
                 && Objects.equals(upsertMode, that.upsertMode)
                 && Objects.equals(tableIdentifier, that.tableIdentifier)
                 && Objects.equals(watermarkStrategy, that.watermarkStrategy)
-                && Objects.equals(parallelism, that.parallelism);
+                && Objects.equals(parallelism, that.parallelism)
+                && Arrays.deepEquals(projectedPhysicalFields, that.projectedPhysicalFields)
+                && keyProjectionPushdownEnabled == that.keyProjectionPushdownEnabled
+                && valueProjectionPushdownEnabled == that.valueProjectionPushdownEnabled;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
                 producedDataType,
+                valueFormatMetadataKeys,
                 metadataKeys,
                 physicalDataType,
                 keyDecodingFormat,
@@ -422,20 +463,20 @@ public class KafkaDynamicSource
                 upsertMode,
                 tableIdentifier,
                 watermarkStrategy,
-                parallelism);
+                parallelism,
+                Arrays.deepHashCode(projectedPhysicalFields),
+                keyProjectionPushdownEnabled,
+                valueProjectionPushdownEnabled);
     }
 
     // --------------------------------------------------------------------------------------------
 
     protected KafkaSource<RowData> createKafkaSource(
-            DeserializationSchema<RowData> keyDeserialization,
-            DeserializationSchema<RowData> valueDeserialization,
-            TypeInformation<RowData> producedTypeInfo) {
+            Decoder keyDecoder, Decoder valueDecoder, TypeInformation<RowData> producedTypeInfo) {
         KafkaConnectorOptionsUtil.validateAndNormalizeAutoOffsetResetStrategy(properties);
 
         final KafkaRecordDeserializationSchema<RowData> kafkaDeserializer =
-                createKafkaDeserializationSchema(
-                        keyDeserialization, valueDeserialization, producedTypeInfo);
+                createKafkaDeserializationSchema(keyDecoder, valueDecoder, producedTypeInfo);
 
         final KafkaSourceBuilder<RowData> kafkaSourceBuilder = KafkaSource.builder();
 
@@ -513,9 +554,7 @@ public class KafkaDynamicSource
     }
 
     private KafkaRecordDeserializationSchema<RowData> createKafkaDeserializationSchema(
-            DeserializationSchema<RowData> keyDeserialization,
-            DeserializationSchema<RowData> valueDeserialization,
-            TypeInformation<RowData> producedTypeInfo) {
+            Decoder keyDecoder, Decoder valueDecoder, TypeInformation<RowData> producedTypeInfo) {
         final MetadataConverter[] metadataConverters =
                 metadataKeys.stream()
                         .map(
@@ -534,41 +573,16 @@ public class KafkaDynamicSource
         final int adjustedPhysicalArity =
                 DataType.getFieldDataTypes(producedDataType).size() - metadataKeys.size();
 
-        // adjust value format projection to include value format's metadata columns at the end
-        final int[] adjustedValueProjection =
-                IntStream.concat(
-                                IntStream.of(valueProjection),
-                                IntStream.range(
-                                        keyProjection.length + valueProjection.length,
-                                        adjustedPhysicalArity))
-                        .toArray();
-
         return new DynamicKafkaDeserializationSchema(
                 adjustedPhysicalArity,
-                keyDeserialization,
-                keyProjection,
-                valueDeserialization,
-                adjustedValueProjection,
+                keyDecoder.getDeserializationSchema(),
+                keyDecoder.getProjector(),
+                valueDecoder.getDeserializationSchema(),
+                valueDecoder.getProjector(),
                 hasMetadata,
                 metadataConverters,
                 producedTypeInfo,
                 upsertMode);
-    }
-
-    private @Nullable DeserializationSchema<RowData> createDeserialization(
-            DynamicTableSource.Context context,
-            @Nullable DecodingFormat<DeserializationSchema<RowData>> format,
-            int[] projection,
-            @Nullable String prefix) {
-        if (format == null) {
-            return null;
-        }
-        DataType physicalFormatDataType = Projection.of(projection).project(this.physicalDataType);
-        if (prefix != null) {
-            physicalFormatDataType =
-                    TableDataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
-        }
-        return format.createRuntimeDecoder(context, physicalFormatDataType);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactory.java
@@ -70,6 +70,7 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOp
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.KEY_FIELDS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.KEY_FIELDS_PREFIX;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.KEY_FORMAT;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.KEY_FORMAT_PROJECTION_PUSHDOWN_ENABLED;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_BOOTSTRAP_SERVERS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.PROPS_GROUP_ID;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.SCAN_BOUNDED_MODE;
@@ -88,6 +89,7 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOp
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.TRANSACTION_NAMING_STRATEGY;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.VALUE_FIELDS_INCLUDE;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.VALUE_FORMAT;
+import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptions.VALUE_FORMAT_PROJECTION_PUSHDOWN_ENABLED;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.PROPERTIES_PREFIX;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.StartupOptions;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaConnectorOptionsUtil.autoCompleteSchemaRegistrySubject;
@@ -138,6 +140,8 @@ public class KafkaDynamicTableFactory
         options.add(KEY_FORMAT);
         options.add(KEY_FIELDS);
         options.add(KEY_FIELDS_PREFIX);
+        options.add(KEY_FORMAT_PROJECTION_PUSHDOWN_ENABLED);
+        options.add(VALUE_FORMAT_PROJECTION_PUSHDOWN_ENABLED);
         options.add(VALUE_FORMAT);
         options.add(VALUE_FIELDS_INCLUDE);
         options.add(TOPIC);
@@ -224,6 +228,12 @@ public class KafkaDynamicTableFactory
 
         final Integer parallelism = tableOptions.getOptional(SCAN_PARALLELISM).orElse(null);
 
+        final boolean keyProjectionPushdownEnabled =
+                tableOptions.get(KEY_FORMAT_PROJECTION_PUSHDOWN_ENABLED);
+
+        final boolean valueProjectionPushdownEnabled =
+                tableOptions.get(VALUE_FORMAT_PROJECTION_PUSHDOWN_ENABLED);
+
         return createKafkaTableSource(
                 physicalDataType,
                 keyDecodingFormat.orElse(null),
@@ -241,7 +251,9 @@ public class KafkaDynamicTableFactory
                 boundedOptions.specificOffsets,
                 boundedOptions.boundedTimestampMillis,
                 context.getObjectIdentifier().asSummaryString(),
-                parallelism);
+                parallelism,
+                keyProjectionPushdownEnabled,
+                valueProjectionPushdownEnabled);
     }
 
     @Override
@@ -408,7 +420,9 @@ public class KafkaDynamicTableFactory
             Map<TopicPartition, Long> specificEndOffsets,
             long endTimestampMillis,
             String tableIdentifier,
-            Integer parallelism) {
+            Integer parallelism,
+            boolean keyProjectionPushdownEnabled,
+            boolean valueProjectionPushdownEnabled) {
         return new KafkaDynamicSource(
                 physicalDataType,
                 keyDecodingFormat,
@@ -427,7 +441,9 @@ public class KafkaDynamicTableFactory
                 endTimestampMillis,
                 false,
                 tableIdentifier,
-                parallelism);
+                parallelism,
+                keyProjectionPushdownEnabled,
+                valueProjectionPushdownEnabled);
     }
 
     protected KafkaDynamicSink createKafkaTableSink(

--- a/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactory.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactory.java
@@ -184,7 +184,9 @@ public class UpsertKafkaDynamicTableFactory
                 boundedOptions.boundedTimestampMillis,
                 true,
                 context.getObjectIdentifier().asSummaryString(),
-                parallelism);
+                parallelism,
+                false,
+                false);
     }
 
     @Override

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/DecoderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/DecoderTest.java
@@ -1,0 +1,1569 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.table;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.kafka.testutils.SimpleCollector;
+import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.formats.json.JsonFormatFactory;
+import org.apache.flink.formats.json.debezium.DebeziumJsonDecodingFormat;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link Decoder}. */
+class DecoderTest {
+
+    private static ProjectableDecodingFormat<DeserializationSchema<RowData>> jsonDecodingFormat() {
+        return (ProjectableDecodingFormat<DeserializationSchema<RowData>>)
+                new JsonFormatFactory().createDecodingFormat(null, new Configuration());
+    }
+
+    private static ProjectableDecodingFormat<DeserializationSchema<RowData>>
+            debeziumJsonDecodingFormat() {
+        return new DebeziumJsonDecodingFormat(false, false, TimestampFormat.ISO_8601);
+    }
+
+    private abstract static class RecordingDecodingFormat<T> implements DecodingFormat<T> {
+
+        final DecodingFormat<T> underlying;
+
+        private List<String> appliedMetadataKeys = null;
+        protected int[][] projectedFields = null;
+
+        RecordingDecodingFormat(final DecodingFormat<T> underlying) {
+            this.underlying = underlying;
+        }
+
+        @Override
+        public ChangelogMode getChangelogMode() {
+            return underlying.getChangelogMode();
+        }
+
+        @Override
+        public Map<String, DataType> listReadableMetadata() {
+            return underlying.listReadableMetadata();
+        }
+
+        @Override
+        public void applyReadableMetadata(List<String> metadataKeys) {
+            this.appliedMetadataKeys = metadataKeys;
+            underlying.applyReadableMetadata(metadataKeys);
+        }
+
+        List<String> getAppliedMetadataKeys() {
+            return appliedMetadataKeys;
+        }
+
+        /** The projection pushed into the format, or null if none was pushed. */
+        int[][] getProjectedFields() {
+            return projectedFields;
+        }
+    }
+
+    private static class RecordingNonProjectableFormat<T> extends RecordingDecodingFormat<T> {
+
+        RecordingNonProjectableFormat(final DecodingFormat<T> underlying) {
+            super(underlying);
+        }
+
+        @Override
+        public T createRuntimeDecoder(
+                DynamicTableSource.Context context, DataType physicalDataType) {
+            return underlying.createRuntimeDecoder(context, physicalDataType);
+        }
+    }
+
+    private static class RecordingProjectableFormat<T> extends RecordingDecodingFormat<T>
+            implements ProjectableDecodingFormat<T> {
+
+        private final boolean supportsNestedProjection;
+
+        RecordingProjectableFormat(
+                final ProjectableDecodingFormat<T> underlying,
+                final boolean supportsNestedProjection) {
+            super(underlying);
+            this.supportsNestedProjection = supportsNestedProjection;
+        }
+
+        @Override
+        public boolean supportsNestedProjection() {
+            return supportsNestedProjection;
+        }
+
+        @Override
+        public T createRuntimeDecoder(
+                DynamicTableSource.Context context, DataType physicalDataType) {
+            return underlying.createRuntimeDecoder(context, physicalDataType);
+        }
+
+        @Override
+        public T createRuntimeDecoder(
+                DynamicTableSource.Context context,
+                DataType physicalDataType,
+                int[][] projectedFields) {
+            this.projectedFields = projectedFields;
+            return ((ProjectableDecodingFormat<T>) underlying)
+                    .createRuntimeDecoder(context, physicalDataType, projectedFields);
+        }
+    }
+
+    private static void assertThatIsProjectionNeeded(
+            final boolean pushdownEnabled,
+            final DecodingFormat<DeserializationSchema<RowData>> format,
+            final Decoder decoder,
+            final boolean forPushdownDisabled,
+            final boolean forNonProjectableDecodingFormat,
+            final boolean forProjectableDecodingFormat,
+            final boolean forProjectableTopLevelOnlyDecodingFormat) {
+        final boolean expected =
+                expectedForVariant(
+                        pushdownEnabled,
+                        format,
+                        forPushdownDisabled,
+                        forNonProjectableDecodingFormat,
+                        forProjectableDecodingFormat,
+                        forProjectableTopLevelOnlyDecodingFormat);
+
+        assertThat(decoder.getProjector().isProjectionNeeded()).isEqualTo(expected);
+    }
+
+    private static void assertThatPushedProjectionEquals(
+            final boolean pushdownEnabled,
+            final DecodingFormat<DeserializationSchema<RowData>> format,
+            final int[][] forPushdownDisabled,
+            final int[][] forNonProjectableDecodingFormat,
+            final int[][] forProjectableDecodingFormat,
+            final int[][] forProjectableTopLevelOnlyDecodingFormat) {
+        final int[][] expected =
+                expectedForVariant(
+                        pushdownEnabled,
+                        format,
+                        forPushdownDisabled,
+                        forNonProjectableDecodingFormat,
+                        forProjectableDecodingFormat,
+                        forProjectableTopLevelOnlyDecodingFormat);
+
+        final int[][] result = ((RecordingDecodingFormat<?>) format).getProjectedFields();
+        if (expected == null) {
+            assertThat(result).isNull();
+        } else {
+            assertThat(result).isDeepEqualTo(expected);
+        }
+    }
+
+    private static <T> T expectedForVariant(
+            final boolean pushdownEnabled,
+            final DecodingFormat<DeserializationSchema<RowData>> format,
+            final T forPushdownDisabled,
+            final T forNonProjectableDecodingFormat,
+            final T forProjectableDecodingFormat,
+            final T forProjectableTopLevelOnlyDecodingFormat) {
+        if (pushdownEnabled) {
+            if (format instanceof ProjectableDecodingFormat) {
+                if (((ProjectableDecodingFormat<?>) format).supportsNestedProjection()) {
+                    return forProjectableDecodingFormat;
+                } else {
+                    return forProjectableTopLevelOnlyDecodingFormat;
+                }
+            } else {
+                return forNonProjectableDecodingFormat;
+            }
+        } else {
+            return forPushdownDisabled;
+        }
+    }
+
+    private static Stream<Arguments> jsonTestCases() {
+        return testCases(DecoderTest::jsonDecodingFormat);
+    }
+
+    // debezium-json format exposes some metadata fields (unlike json format)
+    private static Stream<Arguments> debeziumJsonTestCases() {
+        return testCases(DecoderTest::debeziumJsonDecodingFormat);
+    }
+
+    private static Stream<Arguments> testCases(
+            final Supplier<ProjectableDecodingFormat<DeserializationSchema<RowData>>> baseFormat) {
+        return Stream.of(
+                testCase(
+                        "Non-Projectable (Pushdown Disabled)",
+                        () -> new RecordingNonProjectableFormat<>(baseFormat.get()),
+                        false),
+                testCase(
+                        "Projectable (Pushdown Disabled)",
+                        () -> new RecordingProjectableFormat<>(baseFormat.get(), true),
+                        false),
+                testCase(
+                        "Projectable Top-Level-Only (Pushdown Disabled)",
+                        () -> new RecordingProjectableFormat<>(baseFormat.get(), false),
+                        false),
+                testCase(
+                        "Non-Projectable (Pushdown Enabled)",
+                        () -> new RecordingNonProjectableFormat<>(baseFormat.get()),
+                        true),
+                testCase(
+                        "Projectable (Pushdown Enabled)",
+                        () -> new RecordingProjectableFormat<>(baseFormat.get(), true),
+                        true),
+                testCase(
+                        "Projectable Top-Level-Only (Pushdown Enabled)",
+                        () -> new RecordingProjectableFormat<>(baseFormat.get(), false),
+                        true));
+    }
+
+    private static Arguments testCase(
+            final String name,
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> format,
+            final boolean pushdownEnabled) {
+        return Arguments.of(Named.of(name, format), pushdownEnabled);
+    }
+
+    private static final DataType TABLE_DATA_TYPE =
+            DataTypes.ROW(
+                    DataTypes.FIELD("a", DataTypes.STRING()),
+                    DataTypes.FIELD("b", DataTypes.STRING()),
+                    DataTypes.FIELD("c", DataTypes.STRING()));
+
+    private static final String TABLE_INPUT = "{\"a\":\"a\", \"b\":\"b\", \"c\":\"c\"}";
+
+    private static final int[] DATA_TYPE_PROJECTION = new int[] {0, 1, 2};
+
+    private static final DataType NESTED_TABLE_DATA_TYPE =
+            DataTypes.ROW(
+                    DataTypes.FIELD(
+                            "a0",
+                            DataTypes.ROW(
+                                    DataTypes.FIELD("a1", DataTypes.STRING()),
+                                    DataTypes.FIELD("b1", DataTypes.STRING()))),
+                    DataTypes.FIELD(
+                            "b0",
+                            DataTypes.ROW(
+                                    DataTypes.FIELD("a1", DataTypes.STRING()),
+                                    DataTypes.FIELD("b1", DataTypes.STRING()))));
+
+    private static class MockContext implements DynamicTableSource.Context {
+        @Override
+        public <T> TypeInformation<T> createTypeInformation(DataType producedDataType) {
+            return InternalTypeInfo.of(producedDataType.getLogicalType());
+        }
+
+        @Override
+        public <T> TypeInformation<T> createTypeInformation(LogicalType producedLogicalType) {
+            return InternalTypeInfo.of(producedLogicalType);
+        }
+
+        @Override
+        public DynamicTableSource.DataStructureConverter createDataStructureConverter(
+                DataType producedDataType) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static void produceRow(
+            final Decoder decoder, final String input, final GenericRowData producedRow) {
+        // decode
+        final RowData deserialized;
+        try {
+            final DeserializationSchema<RowData> deserializationSchema =
+                    decoder.getDeserializationSchema();
+            deserializationSchema.open(null);
+            final SimpleCollector<RowData> collector = new SimpleCollector<>();
+            deserializationSchema.deserialize(input.getBytes(), collector);
+            deserialized = collector.getList().get(0);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        // project
+        decoder.getProjector().project(deserialized, producedRow);
+    }
+
+    @Test
+    void testProjectsNothingWhenFormatIsNull() {
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        null,
+                        TABLE_DATA_TYPE,
+                        new int[] {},
+                        null,
+                        new int[][] {},
+                        Collections.emptyList(),
+                        false);
+
+        assertThat(decoder.getDeserializationSchema()).isNull();
+        assertThat(decoder.getProjector().isEmptyProjection()).isTrue();
+        assertThat(decoder.getProjector().isProjectionNeeded()).isFalse();
+    }
+
+    @Test
+    void testProjectsNothingWhenProjectionIsEmpty() {
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        jsonDecodingFormat(),
+                        TABLE_DATA_TYPE,
+                        DATA_TYPE_PROJECTION,
+                        null,
+                        new int[][] {},
+                        Collections.emptyList(),
+                        false);
+
+        assertThat(decoder.getDeserializationSchema()).isNotNull();
+        assertThat(decoder.getProjector().isEmptyProjection()).isTrue();
+        assertThat(decoder.getProjector().isProjectionNeeded()).isTrue();
+
+        final GenericRowData producedRow = new GenericRowData(0);
+        produceRow(decoder, TABLE_INPUT, producedRow);
+
+        assertThat(producedRow.toString()).isEqualTo(new GenericRowData(0).toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsAllFields(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final int[][] projectedFields =
+                new int[][] {
+                    new int[] {0}, new int[] {1}, new int[] {2},
+                };
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        TABLE_DATA_TYPE,
+                        DATA_TYPE_PROJECTION,
+                        null,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {
+                    new int[] {0}, new int[] {1}, new int[] {2}
+                },
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {
+                    new int[] {0}, new int[] {1}, new int[] {2}
+                });
+
+        final int expectedArity = 3;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(decoder, TABLE_INPUT, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, "a");
+        expected.setField(1, "b");
+        expected.setField(2, "c");
+
+        assertThat(decoder.getProjector().isEmptyProjection()).isFalse();
+        assertThatIsProjectionNeeded(
+                isPushdownEnabled,
+                format,
+                decoder,
+                /* forPushdownDisabled= */ false,
+                /* forNonProjectableDecodingFormat= */ false,
+                /* forProjectableDecodingFormat= */ false,
+                /* forProjectableTopLevelOnlyDecodingFormat= */ false);
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsFirstField(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final int[][] projectedFields = new int[][] {new int[] {0}};
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        TABLE_DATA_TYPE,
+                        DATA_TYPE_PROJECTION,
+                        null,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {new int[] {0}},
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {new int[] {0}});
+
+        assertThat(decoder.getProjector().isEmptyProjection()).isFalse();
+        assertThatIsProjectionNeeded(
+                isPushdownEnabled,
+                format,
+                decoder,
+                /* forPushdownDisabled= */ true,
+                /* forNonProjectableDecodingFormat= */ true,
+                /* forProjectableDecodingFormat= */ false,
+                /* forProjectableTopLevelOnlyDecodingFormat= */ false);
+
+        final int expectedArity = 1;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(decoder, TABLE_INPUT, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, "a");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsSecondField(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final int[][] projectedFields = new int[][] {new int[] {1}};
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        TABLE_DATA_TYPE,
+                        DATA_TYPE_PROJECTION,
+                        null,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {new int[] {1}},
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {new int[] {1}});
+
+        assertThat(decoder.getProjector().isEmptyProjection()).isFalse();
+        assertThatIsProjectionNeeded(
+                isPushdownEnabled,
+                format,
+                decoder,
+                /* forPushdownDisabled= */ true,
+                /* forNonProjectableDecodingFormat= */ true,
+                /* forProjectableDecodingFormat= */ false,
+                /* forProjectableTopLevelOnlyDecodingFormat= */ false);
+
+        final int expectedArity = 1;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(decoder, TABLE_INPUT, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, "b");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsAllFieldsInDifferentOrder(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        // Reverse order of table schema
+        final int[][] projectedFields =
+                new int[][] {
+                    new int[] {2}, new int[] {1}, new int[] {0},
+                };
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        TABLE_DATA_TYPE,
+                        DATA_TYPE_PROJECTION,
+                        null,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {
+                    new int[] {2}, new int[] {1}, new int[] {0}
+                },
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {
+                    new int[] {2}, new int[] {1}, new int[] {0}
+                });
+
+        final int expectedArity = 3;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(decoder, TABLE_INPUT, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, "c");
+        expected.setField(1, "b");
+        expected.setField(2, "a");
+
+        assertThat(decoder.getProjector().isEmptyProjection()).isFalse();
+        assertThatIsProjectionNeeded(
+                isPushdownEnabled,
+                format,
+                decoder,
+                /* forPushdownDisabled= */ true,
+                /* forNonProjectableDecodingFormat= */ true,
+                /* forProjectableDecodingFormat= */ false,
+                /* forProjectableTopLevelOnlyDecodingFormat= */ false);
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsContiguousSubsetOfFields(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final int[][] projectedFields =
+                new int[][] {
+                    new int[] {0}, new int[] {1},
+                };
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        TABLE_DATA_TYPE,
+                        DATA_TYPE_PROJECTION,
+                        null,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {new int[] {0}, new int[] {1}},
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {
+                    new int[] {0}, new int[] {1}
+                });
+
+        assertThat(decoder.getProjector().isEmptyProjection()).isFalse();
+        assertThatIsProjectionNeeded(
+                isPushdownEnabled,
+                format,
+                decoder,
+                /* forPushdownDisabled= */ true,
+                /* forNonProjectableDecodingFormat= */ true,
+                /* forProjectableDecodingFormat= */ false,
+                /* forProjectableTopLevelOnlyDecodingFormat= */ false);
+
+        final int expectedArity = 2;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(decoder, TABLE_INPUT, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, "a");
+        expected.setField(1, "b");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsNonContiguousSubsetOfFields(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final int[] valueProjection = new int[] {0, 2};
+        final int[][] projectedFields =
+                new int[][] {
+                    new int[] {0}, new int[] {1}, new int[] {2},
+                };
+
+        final Decoder valueDecoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        TABLE_DATA_TYPE,
+                        valueProjection,
+                        null,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {new int[] {0}, new int[] {1}},
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {
+                    new int[] {0}, new int[] {1}
+                });
+
+        assertThat(valueDecoder.getProjector().isEmptyProjection()).isFalse();
+        assertThatIsProjectionNeeded(
+                isPushdownEnabled,
+                format,
+                valueDecoder,
+                /* forPushdownDisabled= */ true,
+                /* forNonProjectableDecodingFormat= */ true,
+                /* forProjectableDecodingFormat= */ true,
+                /* forProjectableTopLevelOnlyDecodingFormat= */ true);
+
+        final int expectedArity = 3;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(valueDecoder, TABLE_INPUT, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, "a");
+        expected.setField(2, "c");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsContiguousSubsetOfFieldsInDifferentOrder(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final int[][] projectedFields =
+                new int[][] {
+                    new int[] {1}, new int[] {0},
+                };
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        TABLE_DATA_TYPE,
+                        DATA_TYPE_PROJECTION,
+                        null,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {new int[] {1}, new int[] {0}},
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {
+                    new int[] {1}, new int[] {0}
+                });
+
+        assertThat(decoder.getProjector().isEmptyProjection()).isFalse();
+        assertThatIsProjectionNeeded(
+                isPushdownEnabled,
+                format,
+                decoder,
+                /* forPushdownDisabled= */ true,
+                /* forNonProjectableDecodingFormat= */ true,
+                /* forProjectableDecodingFormat= */ false,
+                /* forProjectableTopLevelOnlyDecodingFormat= */ false);
+
+        final int expectedArity = 2;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(decoder, TABLE_INPUT, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, "b");
+        expected.setField(1, "a");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsFieldWithKeyPrefix(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final String prefix = "k_";
+        final DataType tableDataType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(prefix + "a", DataTypes.STRING()), // key field
+                        DataTypes.FIELD(prefix + "b", DataTypes.STRING()), // key field
+                        DataTypes.FIELD("a", DataTypes.STRING()), // value field
+                        DataTypes.FIELD("b", DataTypes.STRING()) // value field
+                        );
+
+        final int[] dataTypeProjection = new int[] {0, 1};
+        final String input = "{\"a\":\"a\", \"b\":\"b\"}";
+
+        final int[][] projectedFields = new int[][] {new int[] {1}};
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        tableDataType,
+                        dataTypeProjection,
+                        prefix,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {new int[] {1}},
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {new int[] {1}});
+
+        final int expectedArity = 1;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(decoder, input, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, "b");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsNestedFields(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final int[] dataTypeProjection = new int[] {0, 1};
+        final String input =
+                "{"
+                        + "\"a0\":{\"a1\":\"a0_a1\", \"b1\":\"a0_b1\"}, "
+                        + "\"b0\":{\"a1\":\"b0_a1\", \"b1\":\"b0_b1\"}"
+                        + "}";
+
+        final int[][] projectedFields =
+                new int[][] {
+                    new int[] {0, 1}, // a0.b1
+                    new int[] {1, 0} // b0.a1
+                };
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        NESTED_TABLE_DATA_TYPE,
+                        dataTypeProjection,
+                        null,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        // Each format variant must only ever receive a projection it supports: the nested-capable
+        // format gets the full nested paths, a top-level-only projectable format gets just the
+        // (deduplicated) top-level parents (never nested paths, which would violate the {@link
+        // ProjectableDecodingFormat#supportsNestedProjection()} contract), and the
+        // project-after-deserializing variants get nothing pushed in. Any nested sub-fields are
+        // extracted afterward.
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {
+                    new int[] {0, 1}, new int[] {1, 0}
+                },
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {
+                    new int[] {0}, new int[] {1}
+                });
+
+        assertThat(decoder.getProjector().isEmptyProjection()).isFalse();
+        assertThatIsProjectionNeeded(
+                isPushdownEnabled,
+                format,
+                decoder,
+                /* forPushdownDisabled= */ true,
+                /* forNonProjectableDecodingFormat= */ true,
+                /* forProjectableDecodingFormat= */ false,
+                /* forProjectableTopLevelOnlyDecodingFormat= */ true);
+
+        final int expectedArity = 2;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(decoder, input, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, "a0_b1");
+        expected.setField(1, "b0_a1");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsNestedFieldsWithNullParent(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final int[][] projectedFields =
+                new int[][] {
+                    new int[] {0, 1}, // a0.b1 -> a0 is null
+                    new int[] {1, 0} // b0.a1
+                };
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        NESTED_TABLE_DATA_TYPE,
+                        new int[] {0, 1},
+                        null,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {
+                    new int[] {0, 1}, new int[] {1, 0}
+                },
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {
+                    new int[] {0}, new int[] {1}
+                });
+
+        final String input = "{\"a0\":null, \"b0\":{\"a1\":\"b0_a1\", \"b1\":\"b0_b1\"}}";
+
+        final GenericRowData producedRow = new GenericRowData(2);
+        produceRow(decoder, input, producedRow);
+
+        final GenericRowData expected = new GenericRowData(2);
+        expected.setField(0, null);
+        expected.setField(1, "b0_a1");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsDeeplyNestedFields(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final DataType tableDataType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(
+                                "a0",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD(
+                                                "a1",
+                                                DataTypes.ROW(
+                                                        DataTypes.FIELD("a2", DataTypes.STRING()),
+                                                        DataTypes.FIELD("b2", DataTypes.STRING()))),
+                                        DataTypes.FIELD(
+                                                "b1",
+                                                DataTypes.ROW(
+                                                        DataTypes.FIELD("a2", DataTypes.STRING()),
+                                                        DataTypes.FIELD(
+                                                                "b2", DataTypes.STRING()))))),
+                        DataTypes.FIELD(
+                                "b0",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD(
+                                                "a1",
+                                                DataTypes.ROW(
+                                                        DataTypes.FIELD("a2", DataTypes.STRING()),
+                                                        DataTypes.FIELD("b2", DataTypes.STRING()))),
+                                        DataTypes.FIELD(
+                                                "b1",
+                                                DataTypes.ROW(
+                                                        DataTypes.FIELD("a2", DataTypes.STRING()),
+                                                        DataTypes.FIELD(
+                                                                "b2", DataTypes.STRING()))))));
+
+        final int[] dataTypeProjection = new int[] {0, 1};
+        final String input =
+                "{\n"
+                        + "  \"a0\": {\n"
+                        + "    \"a1\": {\n"
+                        + "      \"a2\": \"a0_a1_a2\",\n"
+                        + "      \"b2\": \"a0_a1_b2\"\n"
+                        + "    },\n"
+                        + "    \"b1\": {\n"
+                        + "      \"a2\": \"a0_b1_a2\",\n"
+                        + "      \"b2\": \"a0_b1_b2\"\n"
+                        + "    }\n"
+                        + "  },\n"
+                        + "  \"b0\": {\n"
+                        + "    \"a1\": {\n"
+                        + "      \"a2\": \"b0_a1_a2\",\n"
+                        + "      \"b2\": \"b0_a1_b2\"\n"
+                        + "    },\n"
+                        + "    \"b1\": {\n"
+                        + "      \"a2\": \"b0_b1_a2\",\n"
+                        + "      \"b2\": \"b0_b1_b2\"\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}";
+
+        final int[][] projectedFields =
+                new int[][] {
+                    new int[] {0, 1, 1}, // a0.b1.b2
+                    new int[] {1, 0, 0} // b0.a1.a2
+                };
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        tableDataType,
+                        dataTypeProjection,
+                        null,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {
+                    new int[] {0, 1, 1}, new int[] {1, 0, 0}
+                },
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {
+                    new int[] {0}, new int[] {1}
+                });
+
+        assertThat(decoder.getProjector().isEmptyProjection()).isFalse();
+        assertThatIsProjectionNeeded(
+                isPushdownEnabled,
+                format,
+                decoder,
+                /* forPushdownDisabled= */ true,
+                /* forNonProjectableDecodingFormat= */ true,
+                /* forProjectableDecodingFormat= */ false,
+                /* forProjectableTopLevelOnlyDecodingFormat= */ true);
+
+        final int expectedArity = 2;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(decoder, input, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, "a0_b1_b2");
+        expected.setField(1, "b0_a1_a2");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsDeeplyNestedFieldsWithNullIntermediateParent(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final DataType tableDataType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(
+                                "a0",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD(
+                                                "a1",
+                                                DataTypes.ROW(
+                                                        DataTypes.FIELD("a2", DataTypes.STRING()),
+                                                        DataTypes.FIELD("b2", DataTypes.STRING()))),
+                                        DataTypes.FIELD(
+                                                "b1",
+                                                DataTypes.ROW(
+                                                        DataTypes.FIELD("a2", DataTypes.STRING()),
+                                                        DataTypes.FIELD(
+                                                                "b2", DataTypes.STRING()))))),
+                        DataTypes.FIELD(
+                                "b0",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD(
+                                                "a1",
+                                                DataTypes.ROW(
+                                                        DataTypes.FIELD("a2", DataTypes.STRING()),
+                                                        DataTypes.FIELD("b2", DataTypes.STRING()))),
+                                        DataTypes.FIELD(
+                                                "b1",
+                                                DataTypes.ROW(
+                                                        DataTypes.FIELD("a2", DataTypes.STRING()),
+                                                        DataTypes.FIELD(
+                                                                "b2", DataTypes.STRING()))))));
+
+        final int[] dataTypeProjection = new int[] {0, 1};
+        // a0 is present but its intermediate child a0.b1 is null, so projecting a0.b1.b2 must
+        // null-short-circuit mid-descent (rather than NPE) and yield null.
+        final String input =
+                "{\n"
+                        + "  \"a0\": {\n"
+                        + "    \"a1\": {\n"
+                        + "      \"a2\": \"a0_a1_a2\",\n"
+                        + "      \"b2\": \"a0_a1_b2\"\n"
+                        + "    },\n"
+                        + "    \"b1\": null\n"
+                        + "  },\n"
+                        + "  \"b0\": {\n"
+                        + "    \"a1\": {\n"
+                        + "      \"a2\": \"b0_a1_a2\",\n"
+                        + "      \"b2\": \"b0_a1_b2\"\n"
+                        + "    },\n"
+                        + "    \"b1\": {\n"
+                        + "      \"a2\": \"b0_b1_a2\",\n"
+                        + "      \"b2\": \"b0_b1_b2\"\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}";
+
+        final int[][] projectedFields =
+                new int[][] {
+                    new int[] {0, 1, 1}, // a0.b1.b2 -> a0.b1 is null
+                    new int[] {1, 0, 0} // b0.a1.a2
+                };
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        tableDataType,
+                        dataTypeProjection,
+                        null,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {
+                    new int[] {0, 1, 1}, new int[] {1, 0, 0}
+                },
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {
+                    new int[] {0}, new int[] {1}
+                });
+
+        final GenericRowData producedRow = new GenericRowData(2);
+        produceRow(decoder, input, producedRow);
+
+        final GenericRowData expected = new GenericRowData(2);
+        expected.setField(0, null);
+        expected.setField(1, "b0_a1_a2");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    /**
+     * Two nested fields under the same top-level parent: a top-level-only projectable format must
+     * receive that parent exactly once (the pushed-down top-level projection is deduplicated),
+     * while a nested-capable format receives both distinct nested paths.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsNestedFieldsUnderSameParent(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final int[][] projectedFields =
+                new int[][] {
+                    new int[] {0, 0}, // a0.a1
+                    new int[] {0, 1} // a0.b1
+                };
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        NESTED_TABLE_DATA_TYPE,
+                        new int[] {0, 1},
+                        null,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {
+                    new int[] {0, 0}, new int[] {0, 1}
+                },
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {new int[] {0}});
+
+        final String input =
+                "{"
+                        + "\"a0\":{\"a1\":\"a0_a1\", \"b1\":\"a0_b1\"}, "
+                        + "\"b0\":{\"a1\":\"b0_a1\", \"b1\":\"b0_b1\"}"
+                        + "}";
+
+        final GenericRowData producedRow = new GenericRowData(2);
+        produceRow(decoder, input, producedRow);
+
+        final GenericRowData expected = new GenericRowData(2);
+        expected.setField(0, "a0_a1");
+        expected.setField(1, "a0_b1");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("debeziumJsonTestCases")
+    void testProjectsOneMetadataField(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final DataType tableDataType = DataTypes.ROW(DataTypes.FIELD("a", DataTypes.STRING()));
+
+        final int[] dataTypeProjection = new int[] {0};
+        final String input =
+                "{"
+                        + "\"before\":null,"
+                        + "\"after\":{\"a\":\"a\"},"
+                        + "\"op\":\"c\","
+                        + "\"ts_ms\":0"
+                        + "}";
+
+        final int[][] projectedFields = new int[][] {new int[] {0}};
+
+        final List<String> metadataKeys = Collections.singletonList("ingestion-timestamp");
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        tableDataType,
+                        dataTypeProjection,
+                        null,
+                        projectedFields,
+                        metadataKeys,
+                        isPushdownEnabled);
+
+        assertThat(((RecordingDecodingFormat<?>) format).getAppliedMetadataKeys())
+                .isEqualTo(metadataKeys);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {new int[] {0}},
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {new int[] {0}});
+
+        assertThat(decoder.getProjector().isEmptyProjection()).isFalse();
+        assertThatIsProjectionNeeded(
+                isPushdownEnabled,
+                format,
+                decoder,
+                /* forPushdownDisabled= */ false,
+                /* forNonProjectableDecodingFormat= */ false,
+                /* forProjectableDecodingFormat= */ false,
+                /* forProjectableTopLevelOnlyDecodingFormat= */ false);
+
+        final int expectedArity = 2;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(decoder, input, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, "a");
+        expected.setField(1, TimestampData.fromEpochMillis(0));
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("debeziumJsonTestCases")
+    void testProjectsTwoMetadataFields(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final DataType tableDataType = DataTypes.ROW(DataTypes.FIELD("a", DataTypes.STRING()));
+
+        final int[] dataTypeProjection = new int[] {0};
+        final String input =
+                "{"
+                        + "\"before\":null,"
+                        + "\"after\":{\"a\":\"a\"},"
+                        + "\"source\":{\"version\":\"1.1.1.Final\",\"connector\":\"mysql\",\"name\":\"dbserver1\",\"ts_ms\":0,\"snapshot\":\"true\",\"db\":\"inventory\",\"table\":\"products\",\"server_id\":0,\"gtid\":null,\"file\":\"mysql-bin.000003\",\"pos\":154,\"row\":0,\"thread\":null,\"query\":null},"
+                        + "\"op\":\"c\","
+                        + "\"ts_ms\":0"
+                        + "}";
+
+        final int[][] projectedFields = new int[][] {new int[] {0}};
+
+        final List<String> metadataKeys =
+                Collections.unmodifiableList(
+                        Arrays.asList("ingestion-timestamp", "source.database"));
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        tableDataType,
+                        dataTypeProjection,
+                        null,
+                        projectedFields,
+                        metadataKeys,
+                        isPushdownEnabled);
+
+        assertThat(((RecordingDecodingFormat<?>) format).getAppliedMetadataKeys())
+                .isEqualTo(metadataKeys);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {new int[] {0}},
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {new int[] {0}});
+
+        assertThat(decoder.getProjector().isEmptyProjection()).isFalse();
+        assertThatIsProjectionNeeded(
+                isPushdownEnabled,
+                format,
+                decoder,
+                /* forPushdownDisabled= */ false,
+                /* forNonProjectableDecodingFormat= */ false,
+                /* forProjectableDecodingFormat= */ false,
+                /* forProjectableTopLevelOnlyDecodingFormat= */ false);
+
+        final int expectedArity = 3;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(decoder, input, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, "a");
+        expected.setField(1, TimestampData.fromEpochMillis(0));
+        expected.setField(2, "inventory");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("debeziumJsonTestCases")
+    void testProjectsReorderedFieldsWithMetadata(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        final DataType tableDataType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("a", DataTypes.STRING()),
+                        DataTypes.FIELD("b", DataTypes.STRING()));
+
+        final int[] dataTypeProjection = new int[] {0, 1};
+        final String input =
+                "{"
+                        + "\"before\":null,"
+                        + "\"after\":{\"a\":\"a\", \"b\":\"b\"},"
+                        + "\"op\":\"c\","
+                        + "\"ts_ms\":0"
+                        + "}";
+
+        // Reorder the physical columns (b, a) and append a metadata field after them.
+        final int[][] projectedFields = new int[][] {new int[] {1}, new int[] {0}};
+
+        final List<String> metadataKeys = Collections.singletonList("ingestion-timestamp");
+
+        final Decoder decoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        tableDataType,
+                        dataTypeProjection,
+                        null,
+                        projectedFields,
+                        metadataKeys,
+                        isPushdownEnabled);
+
+        assertThat(((RecordingDecodingFormat<?>) format).getAppliedMetadataKeys())
+                .isEqualTo(metadataKeys);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {new int[] {1}, new int[] {0}},
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {
+                    new int[] {1}, new int[] {0}
+                });
+
+        assertThat(decoder.getProjector().isEmptyProjection()).isFalse();
+        assertThatIsProjectionNeeded(
+                isPushdownEnabled,
+                format,
+                decoder,
+                /* forPushdownDisabled= */ true,
+                /* forNonProjectableDecodingFormat= */ true,
+                /* forProjectableDecodingFormat= */ false,
+                /* forProjectableTopLevelOnlyDecodingFormat= */ false);
+
+        final int expectedArity = 3;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(decoder, input, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, "b");
+        expected.setField(1, "a");
+        expected.setField(2, TimestampData.fromEpochMillis(0));
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsKeyAndValueSubsetInDifferentOrder(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> format = formatSupplier.get();
+
+        // key fields are prefix
+        // fields are in different order in the key/value as compared to the table schema
+        // projected fields both reorders and subsets the table schema
+
+        final String keyPrefix = "key_";
+        final String valuePrefix = null;
+
+        final DataType tableDataType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(keyPrefix + "a", DataTypes.STRING()),
+                        DataTypes.FIELD("a", DataTypes.STRING()),
+                        DataTypes.FIELD(keyPrefix + "b", DataTypes.INT()),
+                        DataTypes.FIELD(keyPrefix + "c", DataTypes.STRING()),
+                        DataTypes.FIELD("c", DataTypes.STRING()));
+
+        final int[] keyProjection = new int[] {3, 0, 2};
+        final String keyInput = "{\"c\":\"k_c\", \"a\":\"k_a\", \"b\":1}";
+
+        final int[] valueProjection = new int[] {1, 4};
+        final String valueInput = "{\"a\":\"v_a\", \"c\":\"v_c\"}";
+
+        final int[][] projectedFields = new int[][] {new int[] {2}, new int[] {1}};
+
+        final Decoder keyDecoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        tableDataType,
+                        keyProjection,
+                        keyPrefix,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {new int[] {2}},
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {new int[] {2}});
+
+        final Decoder valueDecoder =
+                Decoder.create(
+                        new MockContext(),
+                        format,
+                        tableDataType,
+                        valueProjection,
+                        valuePrefix,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                format,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {new int[] {0}},
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {new int[] {0}});
+
+        final int expectedArity = 2;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(keyDecoder, keyInput, producedRow);
+        produceRow(valueDecoder, valueInput, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, 1);
+        expected.setField(1, "v_a");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonTestCases")
+    void testProjectsKeyAndValueNestedSubsetInDifferentOrder(
+            final Supplier<DecodingFormat<DeserializationSchema<RowData>>> formatSupplier,
+            final Boolean isPushdownEnabled) {
+        final DecodingFormat<DeserializationSchema<RowData>> keyFormat = formatSupplier.get();
+        final DecodingFormat<DeserializationSchema<RowData>> valueFormat = formatSupplier.get();
+
+        // key fields are prefix
+        // fields are in different order in the key/value as compared to the table schema
+        // projected fields both reorders, subsets, and un-nests the table schema
+
+        final String keyPrefix = "key_";
+        final String valuePrefix = null;
+
+        final DataType tableDataType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(keyPrefix + "a", DataTypes.STRING()),
+                        DataTypes.FIELD("a", DataTypes.STRING()),
+                        DataTypes.FIELD(keyPrefix + "b", DataTypes.INT()),
+                        DataTypes.FIELD(keyPrefix + "c", DataTypes.STRING()),
+                        DataTypes.FIELD("c", DataTypes.STRING()),
+                        DataTypes.FIELD(
+                                "d",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("e", DataTypes.STRING()),
+                                        DataTypes.FIELD("f", DataTypes.STRING().nullable()))));
+
+        final int[] keyProjection = new int[] {3, 0, 2};
+        final String keyInput = "{\"c\":\"k_c\", \"a\":\"k_a\", \"b\":1}";
+
+        final int[] valueProjection = new int[] {1, 4, 5};
+        final String valueInput = "{\"a\":\"v_a\", \"c\":\"v_c\", \"d\":{\"e\":\"v_e\"}}";
+
+        final int[][] projectedFields =
+                new int[][] {
+                    new int[] {2}, // k_b
+                    new int[] {1}, // a
+                    new int[] {5, 0} // d.e
+                };
+
+        final Decoder keyDecoder =
+                Decoder.create(
+                        new MockContext(),
+                        keyFormat,
+                        tableDataType,
+                        keyProjection,
+                        keyPrefix,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                keyFormat,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {new int[] {2}},
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {new int[] {2}});
+
+        final Decoder valueDecoder =
+                Decoder.create(
+                        new MockContext(),
+                        valueFormat,
+                        tableDataType,
+                        valueProjection,
+                        valuePrefix,
+                        projectedFields,
+                        Collections.emptyList(),
+                        isPushdownEnabled);
+
+        assertThatPushedProjectionEquals(
+                isPushdownEnabled,
+                valueFormat,
+                /* forPushdownDisabled= */ null,
+                /* forNonProjectableDecodingFormat= */ null,
+                /* forProjectableDecodingFormat= */ new int[][] {new int[] {0}, new int[] {2, 0}},
+                /* forProjectableTopLevelOnlyDecodingFormat= */ new int[][] {
+                    new int[] {0}, new int[] {2}
+                });
+
+        final int expectedArity = 3;
+
+        final GenericRowData producedRow = new GenericRowData(expectedArity);
+        produceRow(keyDecoder, keyInput, producedRow);
+        produceRow(valueDecoder, valueInput, producedRow);
+
+        final GenericRowData expected = new GenericRowData(expectedArity);
+        expected.setField(0, 1);
+        expected.setField(1, "v_a");
+        expected.setField(2, "v_e");
+
+        assertThat(producedRow.toString()).isEqualTo(expected.toString());
+    }
+}

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaDeserializationSchemaTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/DynamicKafkaDeserializationSchemaTest.java
@@ -51,13 +51,48 @@ public class DynamicKafkaDeserializationSchemaTest {
                     }
                 };
 
+        // Empty key projector (no key)
+        Decoder.Projector emptyKeyProjector =
+                new Decoder.Projector() {
+                    @Override
+                    public boolean isEmptyProjection() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isProjectionNeeded() {
+                        return false;
+                    }
+
+                    @Override
+                    public void project(RowData deserialized, GenericRowData producedRow) {}
+                };
+        // Value projector: copy field 0 to position 0
+        Decoder.Projector valueProjector =
+                new Decoder.Projector() {
+                    @Override
+                    public boolean isEmptyProjection() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isProjectionNeeded() {
+                        return true;
+                    }
+
+                    @Override
+                    public void project(RowData deserialized, GenericRowData producedRow) {
+                        producedRow.setField(0, ((GenericRowData) deserialized).getField(0));
+                    }
+                };
+
         DynamicKafkaDeserializationSchema schema =
                 new DynamicKafkaDeserializationSchema(
                         1,
                         null,
-                        new int[0],
+                        emptyKeyProjector,
                         new SingleRowDeserializationSchema(),
-                        new int[] {0},
+                        valueProjector,
                         true,
                         metadataConverters,
                         TypeInformation.of(RowData.class),

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -83,16 +83,19 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
@@ -436,9 +439,90 @@ class KafkaDynamicTableFactoryTest {
                         0,
                         null);
         expectedKafkaSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
+        expectedKafkaSource.valueFormatMetadataKeys = Collections.singletonList("metadata_2");
         expectedKafkaSource.metadataKeys = Collections.singletonList("timestamp");
 
         assertThat(actualSource).isEqualTo(expectedKafkaSource);
+    }
+
+    private static class NotIdempotentDecodingFormat
+            implements DecodingFormat<DeserializationSchema<RowData>> {
+        private final List<String> metadataKeys = new ArrayList<>();
+
+        @Override
+        public Map<String, DataType> listReadableMetadata() {
+            return Collections.singletonMap("a", DataTypes.STRING());
+        }
+
+        @Override
+        public void applyReadableMetadata(List<String> metadataKeys) {
+            // this is deliberately not idempotent for testing purposes
+            this.metadataKeys.addAll(metadataKeys);
+        }
+
+        @Override
+        public DeserializationSchema<RowData> createRuntimeDecoder(
+                DynamicTableSource.Context context, DataType physicalDataType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChangelogMode getChangelogMode() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            NotIdempotentDecodingFormat that = (NotIdempotentDecodingFormat) o;
+            return Objects.equals(metadataKeys, that.metadataKeys);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(metadataKeys);
+        }
+    }
+
+    @Test
+    public void testApplyReadableMetadataIsIdempotent() {
+        final KafkaDynamicSource kafkaSource =
+                new KafkaDynamicSource(
+                        SCHEMA_WITH_METADATA.toPhysicalRowDataType(),
+                        null,
+                        new NotIdempotentDecodingFormat(),
+                        new int[] {},
+                        new int[] {},
+                        null,
+                        TOPIC_LIST,
+                        null,
+                        new Properties(),
+                        StartupMode.EARLIEST,
+                        Collections.emptyMap(),
+                        0L,
+                        BoundedMode.GROUP_OFFSETS,
+                        Collections.emptyMap(),
+                        0L,
+                        false,
+                        "abc",
+                        1,
+                        false,
+                        false);
+
+        final Supplier<Integer> runnable =
+                () -> {
+                    kafkaSource.applyReadableMetadata(
+                            Arrays.asList("timestamp", "value.a"),
+                            SCHEMA_WITH_METADATA.toSourceRowDataType());
+                    return kafkaSource.hashCode();
+                };
+
+        assertThat(runnable.get()).isEqualTo(runnable.get());
     }
 
     @Test
@@ -1445,7 +1529,9 @@ class KafkaDynamicTableFactoryTest {
                 0,
                 false,
                 FactoryMocks.IDENTIFIER.asSummaryString(),
-                parallelism);
+                parallelism,
+                false,
+                false);
     }
 
     private static KafkaDynamicSink createExpectedSink(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -83,6 +83,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -90,10 +91,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
@@ -437,9 +440,90 @@ class KafkaDynamicTableFactoryTest {
                         0,
                         null);
         expectedKafkaSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
+        expectedKafkaSource.valueFormatMetadataKeys = Collections.singletonList("metadata_2");
         expectedKafkaSource.metadataKeys = Collections.singletonList("timestamp");
 
         assertThat(actualSource).isEqualTo(expectedKafkaSource);
+    }
+
+    private static class NotIdempotentDecodingFormat
+            implements DecodingFormat<DeserializationSchema<RowData>> {
+        private final List<String> metadataKeys = new ArrayList<>();
+
+        @Override
+        public Map<String, DataType> listReadableMetadata() {
+            return Collections.singletonMap("a", DataTypes.STRING());
+        }
+
+        @Override
+        public void applyReadableMetadata(List<String> metadataKeys) {
+            // this is deliberately not idempotent for testing purposes
+            this.metadataKeys.addAll(metadataKeys);
+        }
+
+        @Override
+        public DeserializationSchema<RowData> createRuntimeDecoder(
+                DynamicTableSource.Context context, DataType physicalDataType) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChangelogMode getChangelogMode() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            NotIdempotentDecodingFormat that = (NotIdempotentDecodingFormat) o;
+            return Objects.equals(metadataKeys, that.metadataKeys);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(metadataKeys);
+        }
+    }
+
+    @Test
+    public void testApplyReadableMetadataIsIdempotent() {
+        final KafkaDynamicSource kafkaSource =
+                new KafkaDynamicSource(
+                        SCHEMA_WITH_METADATA.toPhysicalRowDataType(),
+                        null,
+                        new NotIdempotentDecodingFormat(),
+                        new int[] {},
+                        new int[] {},
+                        null,
+                        TOPIC_LIST,
+                        null,
+                        new Properties(),
+                        StartupMode.EARLIEST,
+                        Collections.emptyMap(),
+                        0L,
+                        BoundedMode.GROUP_OFFSETS,
+                        Collections.emptyMap(),
+                        0L,
+                        false,
+                        "abc",
+                        1,
+                        false,
+                        false);
+
+        final Supplier<Integer> runnable =
+                () -> {
+                    kafkaSource.applyReadableMetadata(
+                            Arrays.asList("timestamp", "value.a"),
+                            SCHEMA_WITH_METADATA.toSourceRowDataType());
+                    return kafkaSource.hashCode();
+                };
+
+        assertThat(runnable.get()).isEqualTo(runnable.get());
     }
 
     @Test
@@ -1500,7 +1584,9 @@ class KafkaDynamicTableFactoryTest {
                 0,
                 false,
                 FactoryMocks.IDENTIFIER.asSummaryString(),
-                parallelism);
+                parallelism,
+                false,
+                false);
     }
 
     private static KafkaDynamicSink createExpectedSink(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
@@ -27,14 +27,21 @@ import org.apache.flink.connector.kafka.sink.KafkaPartitioner;
 import org.apache.flink.connector.kafka.sink.TransactionNamingStrategy;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.SavepointFormatType;
+import org.apache.flink.formats.json.JsonParseException;
 import org.apache.flink.runtime.messages.FlinkJobTerminatedWithoutCancellationException;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.legacy.SinkFunction;
+import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.writer.BinaryRowWriter;
+import org.apache.flink.table.data.writer.BinaryWriter;
 import org.apache.flink.table.utils.EncodingUtils;
 import org.apache.flink.test.util.SuccessException;
 import org.apache.flink.types.Row;
@@ -80,6 +87,7 @@ import static org.apache.flink.table.utils.TableTestMatchers.deepEqualTo;
 import static org.apache.flink.util.CollectionUtil.entry;
 import static org.apache.flink.util.CollectionUtil.map;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.HamcrestCondition.matching;
 
@@ -182,7 +190,7 @@ class KafkaTableITCase extends KafkaTableTestBase {
                         "+I(2019-12-12 00:00:05.000,2019-12-12,00:00:03,2019-12-12 00:00:04.004,3,50.00)",
                         "+I(2019-12-12 00:00:10.000,2019-12-12,00:00:05,2019-12-12 00:00:06.006,2,5.33)");
 
-        assertThat(TestingSinkFunction.rows).isEqualTo(expected);
+        assertThat(TestingSinkFunction.getStringRows()).isEqualTo(expected);
 
         // ------------- cleanup -------------------
 
@@ -662,8 +670,9 @@ class KafkaTableITCase extends KafkaTableTestBase {
             }
         }
         List<String> expected = Arrays.asList("+I(Dollar)", "+I(Dummy)", "+I(Euro)", "+I(Yen)");
-        TestingSinkFunction.rows.sort(Comparator.naturalOrder());
-        assertThat(TestingSinkFunction.rows).isEqualTo(expected);
+        List<String> rows = TestingSinkFunction.getStringRows();
+        rows.sort(Comparator.naturalOrder());
+        assertThat(rows).isEqualTo(expected);
 
         // ------------- cleanup -------------------
         topics.forEach(super::deleteTestTopic);
@@ -979,13 +988,17 @@ class KafkaTableITCase extends KafkaTableTestBase {
                                 + "  'properties.bootstrap.servers' = '%s',\n"
                                 + "  'properties.group.id' = '%s',\n"
                                 + "  'scan.startup.mode' = 'earliest-offset',\n"
-                                + "  'key.format' = '%s',\n"
+                                + "  %s,\n"
                                 + "  'key.fields' = 'k_event_id; k_user_id',\n"
                                 + "  'key.fields-prefix' = 'k_',\n"
-                                + "  'value.format' = '%s',\n"
+                                + "  %s,\n"
                                 + "  'value.fields-include' = 'EXCEPT_KEY'\n"
                                 + ")",
-                        topic, bootstraps, groupId, format, format);
+                        topic,
+                        bootstraps,
+                        groupId,
+                        keyFormatOptions(format),
+                        valueFormatOptions(format));
 
         tEnv.executeSql(createTable);
 
@@ -1062,12 +1075,16 @@ class KafkaTableITCase extends KafkaTableTestBase {
                                 + "  'properties.bootstrap.servers' = '%s',\n"
                                 + "  'properties.group.id' = '%s',\n"
                                 + "  'scan.startup.mode' = 'earliest-offset',\n"
-                                + "  'key.format' = '%s',\n"
+                                + "  %s,\n"
                                 + "  'key.fields' = 'event_id; user_id',\n"
-                                + "  'value.format' = '%s',\n"
+                                + "  %s,\n"
                                 + "  'value.fields-include' = 'ALL'\n"
                                 + ")",
-                        topic, bootstraps, groupId, format, format);
+                        topic,
+                        bootstraps,
+                        groupId,
+                        keyFormatOptions(format),
+                        valueFormatOptions(format));
 
         tEnv.executeSql(createTable);
 
@@ -1149,9 +1166,9 @@ class KafkaTableITCase extends KafkaTableTestBase {
                                 + "  'scan.startup.mode' = 'earliest-offset',\n"
                                 + "  'properties.bootstrap.servers' = '%s',\n"
                                 + "  'properties.group.id' = '%s',\n"
-                                + "  'format' = '%s'\n"
+                                + "  %s\n"
                                 + ")",
-                        orderTopic, bootstraps, groupId, format);
+                        orderTopic, bootstraps, groupId, formatOptions(format));
         tEnv.executeSql(orderTableDDL);
         String orderInitialValues =
                 "INSERT INTO ordersTable\n"
@@ -1181,9 +1198,9 @@ class KafkaTableITCase extends KafkaTableTestBase {
                                 + "  'scan.startup.mode' = 'earliest-offset',\n"
                                 + "  'properties.bootstrap.servers' = '%s',\n"
                                 + "  'properties.group.id' = '%s',\n"
-                                + "  'value.format' = 'debezium-json'\n"
+                                + "  %s\n"
                                 + ")",
-                        productTopic, bootstraps, groupId);
+                        productTopic, bootstraps, groupId, valueFormatOptions("debezium-json"));
         tEnv.executeSql(productTableDDL);
 
         // use raw format to initial the changelog data
@@ -1281,9 +1298,13 @@ class KafkaTableITCase extends KafkaTableTestBase {
                                 + "  'properties.group.id' = '%s',\n"
                                 + "  'scan.startup.mode' = 'earliest-offset',\n"
                                 + "  'sink.partitioner' = '%s',\n"
-                                + "  'format' = '%s'\n"
+                                + "  %s\n"
                                 + ")",
-                        topic, bootstraps, groupId, TestPartitioner.class.getName(), format);
+                        topic,
+                        bootstraps,
+                        groupId,
+                        TestPartitioner.class.getName(),
+                        formatOptions(format));
 
         tEnv.executeSql(createTable);
 
@@ -1373,9 +1394,13 @@ class KafkaTableITCase extends KafkaTableTestBase {
                                 + "  'properties.group.id' = '%s',\n"
                                 + "  'scan.startup.mode' = 'earliest-offset',\n"
                                 + "  'sink.partitioner' = '%s',\n"
-                                + "  'format' = '%s'\n"
+                                + "  %s\n"
                                 + ")",
-                        topic, bootstraps, groupId, TestPartitioner.class.getName(), format);
+                        topic,
+                        bootstraps,
+                        groupId,
+                        TestPartitioner.class.getName(),
+                        formatOptions(format));
 
         tEnv.executeSql(createTable);
 
@@ -1448,9 +1473,13 @@ class KafkaTableITCase extends KafkaTableTestBase {
                                 + "  'properties.group.id' = '%s',\n"
                                 + "  'scan.startup.mode' = 'latest-offset',\n"
                                 + "  'sink.partitioner' = '%s',\n"
-                                + "  'format' = '%s'\n"
+                                + "  %s\n"
                                 + ")",
-                        topic, bootstraps, groupId, TestPartitioner.class.getName(), format);
+                        topic,
+                        bootstraps,
+                        groupId,
+                        TestPartitioner.class.getName(),
+                        formatOptions(format));
 
         tEnv.executeSql(createTable);
 
@@ -1629,7 +1658,7 @@ class KafkaTableITCase extends KafkaTableTestBase {
                         + "  'properties.auto.offset.reset' = '%s',\n"
                         + "  'properties.enable.auto.commit' = 'true',\n"
                         + "  'properties.auto.commit.interval.ms' = '1000',\n"
-                        + "  'format' = '%s'\n"
+                        + "  %s\n"
                         + ")";
         tEnv.executeSql(
                 String.format(
@@ -1639,7 +1668,7 @@ class KafkaTableITCase extends KafkaTableTestBase {
                         bootstraps,
                         groupId,
                         resetStrategy,
-                        format));
+                        formatOptions(format)));
 
         String initialValues =
                 "INSERT INTO "
@@ -1721,6 +1750,504 @@ class KafkaTableITCase extends KafkaTableTestBase {
         }
     }
 
+    private void projectionPushdownSetupData(final String format, final String topic)
+            throws Exception {
+        createTestTopic(topic, 1, 1);
+
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
+
+        final String createTable =
+                String.format(
+                        "CREATE TABLE kafka (\n"
+                                + "  `a` STRING,\n"
+                                + "  `b` STRING,\n"
+                                + "  `topic` STRING NOT NULL METADATA VIRTUAL,\n"
+                                + "  `c` STRING,\n"
+                                + "  `partition` INT NOT NULL METADATA VIRTUAL,\n"
+                                + "  `d` STRING\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'kafka',\n"
+                                + "  'topic' = '%s',\n"
+                                + "  'properties.bootstrap.servers' = '%s',\n"
+                                + "  'properties.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  %s,\n"
+                                + "  'key.fields' = 'a; b',\n"
+                                + "  %s,\n"
+                                + "  'value.fields-include' = 'EXCEPT_KEY'\n"
+                                + ")",
+                        topic,
+                        bootstraps,
+                        groupId,
+                        keyFormatOptions(format),
+                        valueFormatOptions(format));
+        tEnv.executeSql(createTable);
+
+        final String initialValues = "INSERT INTO kafka (a, b, c, d) SELECT 'a', 'b', 'c', 'd'";
+        tEnv.executeSql(initialValues).await();
+    }
+
+    @ParameterizedTest(name = "format: {0}")
+    @MethodSource("formats")
+    public void testProjectionPushdownSelectAllFields(final String format) throws Exception {
+        final String topic = "testProjectionPushdown_" + format + "_" + UUID.randomUUID();
+        projectionPushdownSetupData(format, topic);
+
+        assertQueryResult(
+                "SELECT * FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "Calc(select=[a, b, topic, c, partition, d])\n"
+                        + "+- TableSourceScan(table=[[default_catalog, default_database, kafka, metadata=[topic, partition]]], fields=[a, b, c, d, topic, partition])\n",
+                Collections.singletonList(String.format("+I(a,b,%s,c,%d,d)", topic, 0)));
+
+        cleanupTopic(topic);
+    }
+
+    @ParameterizedTest(name = "format: {0}")
+    @MethodSource("formats")
+    public void testProjectionPushdownSelectSpecificPhysicalFields(final String format)
+            throws Exception {
+        final String topic = "testProjectionPushdown_" + format + "_" + UUID.randomUUID();
+        projectionPushdownSetupData(format, topic);
+
+        assertQueryResult(
+                "SELECT a, c FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "TableSourceScan(table=[[default_catalog, default_database, kafka, project=[a, c], metadata=[]]], fields=[a, c])\n",
+                Collections.singletonList("+I(a,c)"));
+
+        cleanupTopic(topic);
+    }
+
+    @ParameterizedTest(name = "format: {0}")
+    @MethodSource("formats")
+    public void
+            testProjectionPushdownSelectNonContiguousPhysicalFieldsInDifferentOrderFromTableSchema(
+                    final String format) throws Exception {
+        final String topic = "testProjectionPushdown_" + format + "_" + UUID.randomUUID();
+        projectionPushdownSetupData(format, topic);
+
+        assertQueryResult(
+                "SELECT c, a FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "TableSourceScan(table=[[default_catalog, default_database, kafka, project=[c, a], metadata=[]]], fields=[c, a])\n",
+                Collections.singletonList("+I(c,a)"));
+
+        cleanupTopic(topic);
+    }
+
+    @ParameterizedTest(name = "format: {0}")
+    @MethodSource("formats")
+    public void
+            testProjectionPushdownSelectSpecificPhysicalAndMetadataFieldsInDifferentOrderFromTableSchema(
+                    final String format) throws Exception {
+        final String topic = "testProjectionPushdown_" + format + "_" + UUID.randomUUID();
+        projectionPushdownSetupData(format, topic);
+
+        assertQueryResult(
+                "SELECT c, `partition`, a, topic FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "Calc(select=[c, partition, a, topic])\n"
+                        + "+- TableSourceScan(table=[[default_catalog, default_database, kafka, project=[c, a], metadata=[topic, partition]]], fields=[c, a, topic, partition])\n",
+                Collections.singletonList(String.format("+I(c,%s,a,%s)", 0, topic)));
+
+        cleanupTopic(topic);
+    }
+
+    @ParameterizedTest(name = "format: {0}")
+    @MethodSource("formats")
+    public void testProjectionPushdownSelectSameColumnTwice(final String format) throws Exception {
+        final String topic = "testProjectionPushdown_" + format + "_" + UUID.randomUUID();
+        projectionPushdownSetupData(format, topic);
+
+        assertQueryResult(
+                "SELECT b AS b1, b AS b2 FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "Calc(select=[b AS b1, b AS b2])\n"
+                        + "+- TableSourceScan(table=[[default_catalog, default_database, kafka, project=[b], metadata=[]]], fields=[b])\n",
+                Collections.singletonList("+I(b,b)"));
+
+        cleanupTopic(topic);
+    }
+
+    @ParameterizedTest(name = "format: {0}")
+    @MethodSource("formats")
+    public void testProjectionPushdownNestColumns(final String format) throws Exception {
+        final String topic = "testProjectionPushdown_" + format + "_" + UUID.randomUUID();
+        projectionPushdownSetupData(format, topic);
+
+        final String query = "SELECT ROW(b, a) AS nested FROM kafka";
+
+        final String expectedPlanEndsWith =
+                "== Optimized Execution Plan ==\n"
+                        + "Calc(select=[ROW(b, a) AS nested])\n"
+                        + "+- TableSourceScan(table=[[default_catalog, default_database, kafka, project=[b, a], metadata=[]]], fields=[b, a])\n";
+
+        final BinaryRowData nested = new BinaryRowData(2);
+        final BinaryWriter binaryWriter = new BinaryRowWriter(nested);
+        binaryWriter.writeString(0, StringData.fromString("b"));
+        binaryWriter.writeString(1, StringData.fromString("a"));
+        binaryWriter.complete();
+        final GenericRowData row = new GenericRowData(1);
+        row.setField(0, nested);
+        final List<RowData> expected = Collections.singletonList(row);
+
+        final Table table = tEnv.sqlQuery(query);
+
+        assertThat(table.explain()).endsWith(expectedPlanEndsWith);
+
+        final DataStream<RowData> result =
+                tEnv.toRetractStream(table, RowData.class).map(tuple -> tuple.f1);
+        final TestingSinkFunction sink = new TestingSinkFunction(expected.size());
+        result.addSink(sink).setParallelism(1);
+        try {
+            env.execute("Job_2");
+        } catch (Throwable e) {
+            if (!isCausedByJobFinished(e)) {
+                throw e;
+            }
+        }
+        assertThat(TestingSinkFunction.getRows()).isEqualTo(expected);
+
+        cleanupTopic(topic);
+    }
+
+    private void nestedProjectionPushdownSetupData(final String topic) throws Exception {
+        // Only JSON format supports nested projection pushdown currently
+        final String format = "json";
+
+        createTestTopic(topic, 1, 1);
+
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
+
+        final String createTable =
+                String.format(
+                        "CREATE TABLE kafka (\n"
+                                + "  `a` ROW(a1 STRING, a2 STRING),\n"
+                                + "  `b` ROW(b1 STRING, b2 STRING),\n"
+                                + "  `topic` STRING NOT NULL METADATA VIRTUAL,\n"
+                                + "  `c` ROW(c1 STRING, c2 STRING),\n"
+                                + "  `partition` INT NOT NULL METADATA VIRTUAL,\n"
+                                + "  `d` ROW(d1 ROW(d2 STRING, d3 STRING))\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'kafka',\n"
+                                + "  'topic' = '%s',\n"
+                                + "  'properties.bootstrap.servers' = '%s',\n"
+                                + "  'properties.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  %s,\n"
+                                + "  'key.fields' = 'a; b',\n"
+                                + "  %s,\n"
+                                + "  'value.fields-include' = 'EXCEPT_KEY'\n"
+                                + ")",
+                        topic,
+                        bootstraps,
+                        groupId,
+                        keyFormatOptions(format),
+                        valueFormatOptions(format));
+        tEnv.executeSql(createTable);
+
+        tEnv.executeSql(
+                        "INSERT INTO kafka \n"
+                                + "SELECT \n"
+                                + "    ROW('a1', 'a2'), \n"
+                                + "    ROW('b1', 'b2'), \n"
+                                + "    ROW('c1', 'c2'), \n"
+                                + "    ROW(ROW('d2', 'd3'))")
+                .await();
+    }
+
+    @Test
+    public void testNestedProjectionPushdownSelectAllFields() throws Exception {
+        final String topic = "testNestedProjectionPushdown_" + "_" + UUID.randomUUID();
+        nestedProjectionPushdownSetupData(topic);
+
+        assertQueryResult(
+                "SELECT * FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "Calc(select=[a, b, topic, c, partition, d])\n"
+                        + "+- TableSourceScan(table=[[default_catalog, default_database, kafka, metadata=[topic, partition]]], fields=[a, b, c, d, topic, partition])\n",
+                Collections.singletonList(
+                        String.format(
+                                "+I(+I(a1,a2),+I(b1,b2),%s,+I(c1,c2),0,+I(+I(d2,d3)))", topic)));
+
+        cleanupTopic(topic);
+    }
+
+    @Test
+    public void testNestedProjectionPushdownSelectSpecificNestedPhysicalFields() throws Exception {
+        final String topic = "testNestedProjectionPushdown_" + "_" + UUID.randomUUID();
+        nestedProjectionPushdownSetupData(topic);
+
+        assertQueryResult(
+                "SELECT a.a1, d.d1.d3 FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "TableSourceScan(table=[[default_catalog, default_database, kafka, project=[a_a1, d_d1_d3], metadata=[]]], fields=[a_a1, d_d1_d3])\n",
+                Collections.singletonList("+I(a1,d3)"));
+
+        cleanupTopic(topic);
+    }
+
+    @Test
+    public void
+            testNestedProjectionPushdownSelectSpecificNestedPhysicalFieldsInDifferentOrderFromTableSchema()
+                    throws Exception {
+        final String topic = "testNestedProjectionPushdown_" + "_" + UUID.randomUUID();
+        nestedProjectionPushdownSetupData(topic);
+
+        assertQueryResult(
+                "SELECT d.d1.d3, a.a1 FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "TableSourceScan(table=[[default_catalog, default_database, kafka, project=[d_d1_d3, a_a1], metadata=[]]], fields=[d_d1_d3, a_a1])\n",
+                Collections.singletonList("+I(d3,a1)"));
+
+        cleanupTopic(topic);
+    }
+
+    @Test
+    public void
+            testNestedProjectionPushdownSelectSpecificNestedPhysicalAndMetadataFieldsInDifferentOrderFromTableSchema()
+                    throws Exception {
+        final String topic = "testNestedProjectionPushdown_" + "_" + UUID.randomUUID();
+        nestedProjectionPushdownSetupData(topic);
+
+        assertQueryResult(
+                "SELECT d.d1.d3, `partition`, a.a1, topic FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "Calc(select=[d_d1_d3 AS d3, partition, a_a1 AS a1, topic])\n"
+                        + "+- TableSourceScan(table=[[default_catalog, default_database, kafka, project=[d_d1_d3, a_a1], metadata=[topic, partition]]], fields=[d_d1_d3, a_a1, topic, partition])\n",
+                Collections.singletonList(String.format("+I(d3,%s,a1,%s)", 0, topic)));
+
+        cleanupTopic(topic);
+    }
+
+    @Test
+    public void
+            testNestedProjectionPushdownSelectSpecificNestedAndNonNestedPhysicalAndMetadataFieldsInDifferentOrderFromTableSchema()
+                    throws Exception {
+        final String topic = "testNestedProjectionPushdown_" + "_" + UUID.randomUUID();
+        nestedProjectionPushdownSetupData(topic);
+
+        assertQueryResult(
+                "SELECT d.d1.d3, d, `partition`, a.a1, topic FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "Calc(select=[d.d1.d3 AS d3, d, partition, a_a1 AS a1, topic])\n"
+                        + "+- TableSourceScan(table=[[default_catalog, default_database, kafka, project=[d, a_a1], metadata=[topic, partition]]], fields=[d, a_a1, topic, partition])\n",
+                Collections.singletonList(
+                        String.format("+I(d3,+I(+I(d2,d3)),%s,a1,%s)", 0, topic)));
+
+        cleanupTopic(topic);
+    }
+
+    @Test
+    public void testProjectionPushdownWithJsonFormatAndBreakingSchemaChange() throws Exception {
+        // Only self-contained formats like JSON can use projection pushdown to
+        // avoid deserializing fields that aren't needed for a query and thus avoid
+        // errors from breaking schema changes.
+        final String format = "json";
+
+        // Setup data
+
+        final String topic = "testProjectionPushdown_" + format + "_" + UUID.randomUUID();
+        createTestTopic(topic, 1, 1);
+
+        String groupId = getStandardProps().getProperty("group.id");
+        String bootstraps = getBootstrapServers();
+
+        final String originalCreateTable =
+                String.format(
+                        "CREATE TABLE kafka (\n"
+                                + "  `a` INT,\n" // `a` is originally an INT  field
+                                + "  `b` STRING\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'kafka',\n"
+                                + "  'topic' = '%s',\n"
+                                + "  'properties.bootstrap.servers' = '%s',\n"
+                                + "  'properties.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  %s,\n"
+                                + "  'key.fields' = 'a; b',\n"
+                                + "  %s,\n"
+                                + "  'value.fields-include' = 'EXCEPT_KEY'\n"
+                                + ")",
+                        topic,
+                        bootstraps,
+                        groupId,
+                        keyFormatOptions(format),
+                        valueFormatOptions(format));
+        tEnv.executeSql(originalCreateTable);
+        final int a1 = 1;
+        final String b1 = "b1";
+        tEnv.executeSql(
+                        String.format(
+                                "INSERT INTO kafka SELECT * FROM (VALUES (%d, '%s'))", a1, b1))
+                .await();
+        tEnv.executeSql("DROP TABLE kafka").await();
+
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE kafka (\n"
+                                + "  `a` STRING,\n" // `a` is now a STRING field
+                                + "  `b` STRING\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'kafka',\n"
+                                + "  'topic' = '%s',\n"
+                                + "  'properties.bootstrap.servers' = '%s',\n"
+                                + "  'properties.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  %s,\n"
+                                + "  'key.fields' = 'a; b',\n"
+                                + "  %s,\n"
+                                + "  'value.fields-include' = 'EXCEPT_KEY'\n"
+                                + ")",
+                        topic,
+                        bootstraps,
+                        groupId,
+                        keyFormatOptions(format),
+                        valueFormatOptions(format)));
+        final String a2 = "a2";
+        final String b2 = "b2";
+        tEnv.executeSql(
+                        String.format(
+                                "INSERT INTO kafka SELECT * FROM (VALUES ('%s', '%s'))", a2, b2))
+                .await();
+        tEnv.executeSql("DROP TABLE kafka").await();
+
+        // Read data using original create table statement where `a` is still typed as an INT
+        tEnv.executeSql(originalCreateTable);
+
+        // If you try to read all the fields, you naturally you get a deserialization exception
+        // because of the breaking schema change to field `a`
+        assertThatThrownBy(() -> tEnv.executeSql("SELECT * FROM kafka").await())
+                .hasRootCauseInstanceOf(JsonParseException.class)
+                .hasRootCauseMessage("Fail to deserialize at field: a.");
+
+        // If you try to read just the fields that didn't have any breaking schema changes
+        // the query will work because projection pushdown ensures that fields that aren't needed
+        // aren't deserialized
+        assertQueryResult(
+                "SELECT b FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "TableSourceScan(table=[[default_catalog, default_database, kafka, project=[b], metadata=[]]], fields=[b])\n",
+                Arrays.asList(String.format("+I(%s)", b1), String.format("+I(%s)", b2)));
+
+        // clean up
+        cleanupTopic(topic);
+    }
+
+    @Test
+    public void testNestedProjectionPushdownDisabledStillProjectsNestedFieldsAndHandlesNullParent()
+            throws Exception {
+        // Even with format projection pushdown disabled, the source advertises nested projection
+        // support: the planner pushes the nested projection into the scan and the fields are
+        // extracted after full deserialization. A null nested parent must produce a null sub-field
+        // rather than a NullPointerException.
+        final String format = "json";
+
+        final String topic = "testNestedProjectionPushdownDisabled_" + UUID.randomUUID();
+        createTestTopic(topic, 1, 1);
+
+        final String groupId = getStandardProps().getProperty("group.id");
+        final String bootstraps = getBootstrapServers();
+
+        final String createTable =
+                String.format(
+                        "CREATE TABLE kafka (\n"
+                                + "  `a` ROW(a1 STRING, a2 STRING),\n"
+                                + "  `d` ROW(d1 ROW(d2 STRING, d3 STRING))\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'kafka',\n"
+                                + "  'topic' = '%s',\n"
+                                + "  'properties.bootstrap.servers' = '%s',\n"
+                                + "  'properties.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  'value.format' = '%s',\n"
+                                + "  '%s' = 'false'\n"
+                                + ")",
+                        topic,
+                        bootstraps,
+                        groupId,
+                        format,
+                        KafkaConnectorOptions.VALUE_FORMAT_PROJECTION_PUSHDOWN_ENABLED.key());
+        tEnv.executeSql(createTable);
+
+        tEnv.executeSql(
+                        "INSERT INTO kafka SELECT CAST(NULL AS ROW<a1 STRING, a2 STRING>), ROW(ROW('d2_2', 'd3_2'))")
+                .await();
+
+        // The nested projection is still pushed into the scan (project=[a_a1, d_d1_d3]) even though
+        // format pushdown is disabled, because the source applies it after deserialization.
+        assertQueryResult(
+                "SELECT a.a1, d.d1.d3 FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "TableSourceScan(table=[[default_catalog, default_database, kafka, project=[a_a1, d_d1_d3], metadata=[]]], fields=[a_a1, d_d1_d3])\n",
+                Arrays.asList("+I(null,d3_2)"));
+
+        cleanupTopic(topic);
+    }
+
+    private void setupValueOnlyData(final String format, final String topic)
+            throws ExecutionException, InterruptedException {
+        createTestTopic(topic, 1, 1);
+
+        final String groupId = getStandardProps().getProperty("group.id");
+        final String bootstraps = getBootstrapServers();
+
+        final String createTable =
+                String.format(
+                        "CREATE TABLE kafka (\n"
+                                + "  `a` STRING,\n"
+                                + "  `b` STRING,\n"
+                                + "  `c` STRING \n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'kafka',\n"
+                                + "  'topic' = '%s',\n"
+                                + "  'properties.bootstrap.servers' = '%s',\n"
+                                + "  'properties.group.id' = '%s',\n"
+                                + "  'scan.startup.mode' = 'earliest-offset',\n"
+                                + "  %s\n"
+                                + ")",
+                        topic, bootstraps, groupId, valueFormatOptions(format));
+        tEnv.executeSql(createTable);
+
+        final String initialValues = "INSERT INTO kafka (a, b, c) SELECT 'a', 'b', 'c'";
+        tEnv.executeSql(initialValues).await();
+    }
+
+    @ParameterizedTest(name = "format: {0}")
+    @MethodSource("formats")
+    public void testShortcutWhenNoKeyAndNoConnectorMetadataAndSelectingAllFields(
+            final String format) throws Exception {
+        final String topic = "testSelectAllFields_" + format + "_" + UUID.randomUUID();
+        setupValueOnlyData(format, topic);
+
+        assertQueryResult(
+                "SELECT * FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "TableSourceScan(table=[[default_catalog, default_database, kafka]], fields=[a, b, c])\n",
+                Collections.singletonList("+I(a,b,c)"));
+
+        cleanupTopic(topic);
+    }
+
+    @ParameterizedTest(name = "format: {0}")
+    @MethodSource("formats")
+    public void testShortcutWhenNoKeyAndNoConnectorMetadataAndSelectingOnlyFirstField(
+            final String format) throws Exception {
+        final String topic = "testSelectFirstField_" + format + "_" + UUID.randomUUID();
+        setupValueOnlyData(format, topic);
+
+        assertQueryResult(
+                "SELECT a FROM kafka",
+                "== Optimized Execution Plan ==\n"
+                        + "TableSourceScan(table=[[default_catalog, default_database, kafka, project=[a], metadata=[]]], fields=[a])\n",
+                Collections.singletonList("+I(a)"));
+
+        cleanupTopic(topic);
+    }
+
     // --------------------------------------------------------------------------------------------
     // Utilities
     // --------------------------------------------------------------------------------------------
@@ -1738,14 +2265,56 @@ class KafkaTableITCase extends KafkaTableTestBase {
         }
     }
 
+    private static boolean projectionPushdownEnabled(final String format) {
+        if ("avro".equals(format)) {
+            // Avro doesn't support projection pushdown properly:
+            // https://issues.apache.org/jira/browse/FLINK-35324
+            return false;
+        } else if ("csv".equals(format)) {
+            return true;
+        } else if ("json".equals(format)) {
+            return true;
+        } else if ("debezium-json".equals(format)) {
+            return true;
+        } else {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Whether the %s format supports projection pushdown is unknown",
+                            format));
+        }
+    }
+
     private String formatOptions(final String format) {
-        return String.format("'format' = '%s'", format);
+        final boolean enabled = projectionPushdownEnabled(format);
+        return String.format(
+                "'format' = '%s',\n" + "'%s' = '%s',\n" + "'%s' = '%s'",
+                format,
+                KafkaConnectorOptions.KEY_FORMAT_PROJECTION_PUSHDOWN_ENABLED.key(),
+                enabled,
+                KafkaConnectorOptions.VALUE_FORMAT_PROJECTION_PUSHDOWN_ENABLED.key(),
+                enabled);
+    }
+
+    private static String keyFormatOptions(final String format) {
+        return String.format(
+                "'key.format' = '%s',\n" + "'%s' = '%s'",
+                format,
+                KafkaConnectorOptions.KEY_FORMAT_PROJECTION_PUSHDOWN_ENABLED.key(),
+                projectionPushdownEnabled(format));
+    }
+
+    private static String valueFormatOptions(final String format) {
+        return String.format(
+                "'value.format' = '%s',\n" + "'%s' = '%s'",
+                format,
+                KafkaConnectorOptions.VALUE_FORMAT_PROJECTION_PUSHDOWN_ENABLED.key(),
+                projectionPushdownEnabled(format));
     }
 
     private static final class TestingSinkFunction implements SinkFunction<RowData> {
 
         private static final long serialVersionUID = 455430015321124493L;
-        private static List<String> rows = new ArrayList<>();
+        private static final List<RowData> rows = new ArrayList<>();
 
         private final int expectedSize;
 
@@ -1756,11 +2325,19 @@ class KafkaTableITCase extends KafkaTableTestBase {
 
         @Override
         public void invoke(RowData value, Context context) {
-            rows.add(value.toString());
+            rows.add(value);
             if (rows.size() >= expectedSize) {
                 // job finish
                 throw new SuccessException();
             }
+        }
+
+        private static List<RowData> getRows() {
+            return rows;
+        }
+
+        private static List<String> getStringRows() {
+            return getRows().stream().map(RowData::toString).collect(Collectors.toList());
         }
     }
 
@@ -1801,5 +2378,26 @@ class KafkaTableITCase extends KafkaTableTestBase {
             // check if the exception is one of the ignored ones
             assertThat(ex).satisfiesAnyOf(ignoreIf);
         }
+    }
+
+    private void assertQueryResult(
+            final String query, final String expectedPlanEndsWith, final List<String> expected)
+            throws Exception {
+        final Table table = tEnv.sqlQuery(query);
+
+        assertThat(table.explain()).endsWith(expectedPlanEndsWith);
+
+        final DataStream<RowData> result =
+                tEnv.toRetractStream(table, RowData.class).map(tuple -> tuple.f1);
+        final TestingSinkFunction sink = new TestingSinkFunction(expected.size());
+        result.addSink(sink).setParallelism(1);
+        try {
+            env.execute("Job_2");
+        } catch (Throwable e) {
+            if (!isCausedByJobFinished(e)) {
+                throw e;
+            }
+        }
+        assertThat(TestingSinkFunction.getStringRows()).isEqualTo(expected);
     }
 }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactoryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/UpsertKafkaDynamicTableFactoryTest.java
@@ -991,7 +991,9 @@ class UpsertKafkaDynamicTableFactoryTest {
                 0,
                 true,
                 FactoryMocks.IDENTIFIER.asSummaryString(),
-                parallelism);
+                parallelism,
+                false,
+                false);
     }
 
     private static KafkaDynamicSink createExpectedSink(


### PR DESCRIPTION
Implements `SupportsProjectionPushDown` for `KafkaDynamicSource`, allowing queries to skip deserializing columns they don't need.

### How it works

The source always reports to the planner that it supports projection pushdown (including nested projection pushdown) so the planner pushes projections down to the connector. Whether those projections are *also* pushed all the way down into the underlying key/value formats - so the formats only deserialize the required fields - is opt-in per key/value. When enabled, the format pushdown level is determined automatically based on whether the format implements `ProjectableDecodingFormat` and `ProjectableDecodingFormat.supportsNestedProjection()`.

For each of key and value, the `Decoder` picks one of three strategies:

| Condition | Strategy |
|-----------|----------|
| Pushdown disabled or<br>Pushdown enabled + format does not support projection pushdown | Deserialize all fields, then project afterward |
| Pushdown enabled + format supports nested projection pushdown | Push the full (nested) projection into the format |
| Pushdown enabled + format supports only top-level projection pushdown | Push top-level fields into the format, extract nested sub-fields afterward |

### Configuration

| Option | Default | Type |
|--------|---------|------|
| `key.format.projection-pushdown.enabled` | `false` | boolean |
| `value.format.projection-pushdown.enabled` | `false` | boolean |

### Benefits

1. **Better Schema evolution tolerance** - Queries only fail on breaking changes to fields they actually use. For example, if column `a` changes from `INT` to `STRING`, the query `SELECT b FROM kafka` still succeeds because `a` is never deserialized. (Only applies to formats that decode fields independently, e.g. `json`, `avro-confluent`, `debezium-avro-confluent`.)

2. **Better Performance** - Unneeded columns are filtered at the `TableSourceScan` node rather than downstream. 

### Why opt-in?

If a format implements projection-pushdown incorrectly, it can cause runtime errors or maybe even incorrect results. Enabling is therefore opt-in. Notably, the `avro` format does not support projection pushdown correctly (see [FLINK-35324](https://issues.apache.org/jira/browse/FLINK-35324)).

Enabling it should be safe for other formats e.g. `json`, `debezium-json-confluent`, `csv`, `avro-confluent`, `debezium-avro-confluent`.

### Why not push projections all the way down into Kafka?

Kafka does not support projection pushdown so the furthest we can push down the projections is into the formats (if applicable). 