### PR TITLE
[FLINK-37906] Fix flink_compatibility parsing issue

### DIFF
--- a/docs/data/kafka.yml
+++ b/docs/data/kafka.yml
@@ -17,7 +17,7 @@
 ################################################################################
 
 version: 4.0.0
-flink_compatibility: [2.0]
+flink_compatibility: ["2.0"]
 variants:
   - maven: flink-connector-kafka
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka/$full_version/flink-sql-connector-kafka-$full_version.jar


### PR DESCRIPTION
We have to use string instead of number for flink version. Otherwise it would be parsed without the trailing `0`(i.e. 2.0 -> 2).