### PR TITLE
[FLINK-37983] Update to Kafka client 3.9.1 

### DIFF
--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/DockerImageVersions.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/DockerImageVersions.java
@@ -24,9 +24,9 @@ package org.apache.flink.connector.kafka.testutils;
  */
 public class DockerImageVersions {
 
-    public static final String KAFKA = "confluentinc/cp-kafka:7.7.2";
+    public static final String KAFKA = "confluentinc/cp-kafka:7.9.2";
 
-    public static final String SCHEMA_REGISTRY = "confluentinc/cp-schema-registry:7.7.2";
+    public static final String SCHEMA_REGISTRY = "confluentinc/cp-schema-registry:7.9.2";
 
     public static final String ZOOKEEPER = "zookeeper:3.8.4";
 }

--- a/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.kafka:kafka-clients:3.9.0
+- org.apache.kafka:kafka-clients:3.9.1

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@ under the License.
 		<junit4.version>4.13.2</junit4.version>
 		<junit5.version>5.9.1</junit5.version>
 		<assertj.version>3.23.1</assertj.version>
-		<testcontainers.version>1.17.2</testcontainers.version>
+		<testcontainers.version>1.21.2</testcontainers.version>
 		<mockito.version>3.4.6</mockito.version>
 		<powermock.version>2.0.9</powermock.version>
 		<hamcrest.version>1.3</hamcrest.version>
@@ -499,7 +499,7 @@ under the License.
 			<dependency>
 				<groupId>com.github.docker-java</groupId>
 				<artifactId>docker-java-api</artifactId>
-				<version>3.2.13</version>
+				<version>3.5.1</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@ under the License.
 
 	<properties>
 		<flink.version>2.0.0</flink.version>
-		<kafka.version>3.9.0</kafka.version>
-		<confluent.version>7.8.2</confluent.version>
+		<kafka.version>3.9.1</kafka.version>
+		<confluent.version>7.9.2</confluent.version>
 
 		<jackson-bom.version>2.16.2</jackson-bom.version>
 		<junit4.version>4.13.2</junit4.version>


### PR DESCRIPTION
This PR:
- Updates the Kafka client libraries to 3.9.1. This release has numerous bug and performance fixes as well as several CVE fixes, notably [CVE-2025-27817](https://nvd.nist.gov/vuln/detail/CVE-2025-27817).
- Updates the various confluent library and containers versions to 7.9.2 which matches the Kafka 3.9.x releases.
- Updates the test containers and docker-java-api version to fix podman support for the integrations tests.
- Addresses #179 