### PR TITLE
[hotfix] Set version to 4.0-SNAPSHOT

### DIFF
--- a/flink-connector-kafka-e2e-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-connector-kafka-e2e-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-kafka-e2e-tests</artifactId>
-        <version>4.0.0</version>
+        <version>4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-connector-kafka-e2e-tests/flink-streaming-kafka-test-base/pom.xml
+++ b/flink-connector-kafka-e2e-tests/flink-streaming-kafka-test-base/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-kafka-e2e-tests</artifactId>
-        <version>4.0.0</version>
+        <version>4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-connector-kafka-e2e-tests/flink-streaming-kafka-test/pom.xml
+++ b/flink-connector-kafka-e2e-tests/flink-streaming-kafka-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-kafka-e2e-tests</artifactId>
-        <version>4.0.0</version>
+        <version>4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-connector-kafka-e2e-tests/pom.xml
+++ b/flink-connector-kafka-e2e-tests/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-kafka-parent</artifactId>
-        <version>4.0.0</version>
+        <version>4.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/flink-connector-kafka/pom.xml
+++ b/flink-connector-kafka/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connector-kafka-parent</artifactId>
-		<version>4.0.0</version>
+		<version>4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-kafka</artifactId>

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-kafka-parent</artifactId>
-        <version>4.0.0</version>
+        <version>4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-connector-kafka-python</artifactId>

--- a/flink-sql-connector-kafka/pom.xml
+++ b/flink-sql-connector-kafka/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-connector-kafka-parent</artifactId>
-        <version>4.0.0</version>
+        <version>4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-sql-connector-kafka</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>flink-connector-kafka-parent</artifactId>
-	<version>4.0.0</version>
+	<version>4.0-SNAPSHOT</version>
 	<name>Flink : Connectors : Kafka : Parent</name>
 	<packaging>pom</packaging>
 	<inceptionYear>2022</inceptionYear>


### PR DESCRIPTION
During the release, we accidentally overwrote the snapshot version on the branch.  The fixed versions are only meant to be used on release tags but not on the active branches.