### PR TITLE
[FLINK-38322] Update to Kafka client 4.1.0

### DIFF
--- a/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.kafka:kafka-clients:4.0.0
+- org.apache.kafka:kafka-clients:4.1.0

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@ under the License.
 		<!-- Main Dependencies -->
 		<confluent.version>7.9.2</confluent.version>
 		<flink.version>2.1.0</flink.version>
-		<kafka.version>4.0.0</kafka.version>
+		<kafka.version>4.1.0</kafka.version>
 
 		<!-- Other Dependencies -->
 		<avro.version>1.12.0</avro.version>


### PR DESCRIPTION
This PR updates to the newly [released](https://github.com/tomncooper/flink-connector-kafka/pull/new/kafka-4.1.0) Kafka 4.1.0 client library version.