### PR TITLE
[FLINK-8093][connectors/kafka] Add client.id.prefix support to KafkaSink

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkOptions.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkOptions.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+/** Configurations for KafkaSink. */
+@Internal
+public class KafkaSinkOptions {
+
+    public static final ConfigOption<String> CLIENT_ID_PREFIX =
+            ConfigOptions.key("client.id.prefix")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The prefix to use for Kafka producer client IDs.");
+}

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkBuilderTest.java
@@ -88,6 +88,54 @@ class KafkaSinkBuilderTest {
     }
 
     @Test
+    void testClientIdPrefixSetting() {
+        validateProducerConfig(
+                getBasicBuilder().setClientIdPrefix("my-producer"),
+                p -> {
+                    assertThat(p)
+                            .containsEntry(
+                                    KafkaSinkOptions.CLIENT_ID_PREFIX.key(), "my-producer");
+                });
+    }
+
+    @Test
+    void testDefaultClientIdPrefixGenerated() {
+        validateProducerConfig(
+                getBasicBuilder(),
+                p -> {
+                    String prefix = p.getProperty(KafkaSinkOptions.CLIENT_ID_PREFIX.key());
+                    assertThat(prefix).isNotNull().startsWith("KafkaSink-");
+                });
+    }
+
+    @Test
+    void testDefaultClientIdPrefixUsesTransactionalIdPrefix() {
+        validateProducerConfig(
+                getBasicBuilder()
+                        .setDeliveryGuarantee(DeliveryGuarantee.EXACTLY_ONCE)
+                        .setTransactionalIdPrefix("my-txn-prefix"),
+                p -> {
+                    assertThat(p)
+                            .containsEntry(
+                                    KafkaSinkOptions.CLIENT_ID_PREFIX.key(), "my-txn-prefix");
+                });
+    }
+
+    @Test
+    void testClientIdPrefixPreservesUserValue() {
+        validateProducerConfig(
+                getBasicBuilder()
+                        .setClientIdPrefix("user-prefix")
+                        .setDeliveryGuarantee(DeliveryGuarantee.EXACTLY_ONCE)
+                        .setTransactionalIdPrefix("my-txn-prefix"),
+                p -> {
+                    assertThat(p)
+                            .containsEntry(
+                                    KafkaSinkOptions.CLIENT_ID_PREFIX.key(), "user-prefix");
+                });
+    }
+
+    @Test
     void testTransactionalIdSanityCheck() {
         assertThatThrownBy(
                         () ->


### PR DESCRIPTION
When multiple KafkaSink subtasks run in the same TaskManager, Kafka auto-generates identical client.id values for producers, causing InstanceAlreadyExistsException from JMX MBean registration collisions.

This adds client.id.prefix support to KafkaSink, mirroring the existing KafkaSource implementation (FLINK-28842):

- Add KafkaSinkOptions with CLIENT_ID_PREFIX config option
- Add KafkaSinkBuilder.setClientIdPrefix() API method
- Auto-generate default prefix from transactionalIdPrefix or random value
- Set per-subtask client.id ({prefix}-{subtaskId}) in restoreWriter() before passing config to writer constructors