### PR TITLE
[FLINK-39234][tests] Wait for topic intialization in KafkaWriterTestBase based tests

### DIFF
--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterTestBase.java
@@ -37,9 +37,6 @@ import org.apache.flink.runtime.metrics.groups.ProxyMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.util.UserCodeClassLoader;
 
-import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.junit.jupiter.api.AfterEach;
@@ -56,9 +53,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.PriorityQueue;
@@ -68,6 +63,7 @@ import java.util.function.Consumer;
 
 import static org.apache.flink.connector.kafka.testutils.KafkaUtil.checkProducerLeak;
 import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createKafkaContainer;
+import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createNewTopicAndWaitForPartitionAssignment;
 import static org.apache.kafka.clients.admin.AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG;
 
 /** Test base for KafkaWriter. */
@@ -104,11 +100,9 @@ public abstract class KafkaWriterTestBase {
         // Use the display name if it already contains the method name,
         // otherwise combine them to ensure uniqueness for parameterized tests.
         topic = displayName.startsWith(methodName) ? displayName : methodName + "_" + displayName;
-        Map<String, Object> properties = new java.util.HashMap<>();
+        Properties properties = new Properties();
         properties.put(BOOTSTRAP_SERVERS_CONFIG, KAFKA_CONTAINER.getBootstrapServers());
-        try (Admin admin = AdminClient.create(properties)) {
-            admin.createTopics(Collections.singleton(new NewTopic(topic, 10, (short) 1)));
-        }
+        createNewTopicAndWaitForPartitionAssignment(topic, 10, (short) 1, properties);
     }
 
     @AfterEach

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/DynamicKafkaSourceExternalContext.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/DynamicKafkaSourceExternalContext.java
@@ -33,7 +33,6 @@ import org.apache.flink.connector.testframe.external.source.DataStreamSourceExte
 import org.apache.flink.connector.testframe.external.source.TestingSourceSettings;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.streaming.connectors.kafka.DynamicKafkaSourceTestHelper;
-import org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironmentImpl;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -59,6 +58,8 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createNewTopicAndWaitForPartitionAssignment;
 
 /** A external context for {@link DynamicKafkaSource} connector testing framework. */
 public class DynamicKafkaSourceExternalContext implements DataStreamSourceExternalContext<String> {
@@ -134,7 +135,7 @@ public class DynamicKafkaSourceExternalContext implements DataStreamSourceExtern
         for (Tuple2<String, String> clusterTopic : clusterTopics) {
             String cluster = clusterTopic.f0;
             String topic = clusterTopic.f1;
-            KafkaTestEnvironmentImpl.createNewTopic(
+            createNewTopicAndWaitForPartitionAssignment(
                     topic, NUM_PARTITIONS, 1, clusterPropertiesMap.get(cluster));
         }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/KafkaUtil.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/KafkaUtil.java
@@ -18,6 +18,11 @@
 
 package org.apache.flink.connector.kafka.testutils;
 
+import org.apache.flink.core.testutils.CommonTestUtils;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -33,11 +38,14 @@ import org.testcontainers.utility.DockerImageName;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.fail;
@@ -47,6 +55,7 @@ public class KafkaUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(KafkaUtil.class);
     private static final Duration CONSUMER_POLL_DURATION = Duration.ofSeconds(1);
+    private static final int REQUEST_TIMEOUT_SECONDS = 30;
 
     private KafkaUtil() {}
 
@@ -233,5 +242,41 @@ public class KafkaUtil {
             Map.Entry<Thread, StackTraceElement[]> threadStackTrace) {
         return threadStackTrace.getKey().getState() != Thread.State.TERMINATED
                 && threadStackTrace.getKey().getName().contains("kafka-producer-network-thread");
+    }
+
+    public static void createNewTopicAndWaitForPartitionAssignment(
+            String topic, int numberOfPartitions, int replicationFactor, Properties properties) {
+        LOG.info("Creating topic {}", topic);
+        try (AdminClient adminClient = AdminClient.create(properties)) {
+            NewTopic topicObj = new NewTopic(topic, numberOfPartitions, (short) replicationFactor);
+            adminClient.createTopics(Collections.singleton(topicObj)).all().get();
+            CommonTestUtils.waitUtil(
+                    () -> {
+                        try {
+                            // Ensure all partitions have a leader elected and logs initialized
+                            Map<TopicPartition, OffsetSpec> offsetSpecs = new HashMap<>();
+                            for (int i = 0; i < numberOfPartitions; i++) {
+                                offsetSpecs.put(
+                                        new TopicPartition(topic, i), OffsetSpec.earliest());
+                            }
+                            adminClient
+                                    .listOffsets(offsetSpecs)
+                                    .all()
+                                    .get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                            return true;
+                        } catch (Exception e) {
+                            LOG.warn(
+                                    "Partitions for topic {} not yet ready to serve requests",
+                                    topic,
+                                    e);
+                            return false;
+                        }
+                    },
+                    Duration.ofSeconds(30),
+                    String.format("New topic \"%s\" is not ready within timeout", topicObj));
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Create test topic : " + topic + " failed, " + e.getMessage());
+        }
     }
 }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
@@ -82,7 +82,7 @@ public abstract class KafkaTestEnvironment {
             String topic, int numberOfPartitions, int replicationFactor, Properties properties);
 
     public void createTestTopic(String topic, int numberOfPartitions, int replicationFactor) {
-        this.createTestTopic(topic, numberOfPartitions, replicationFactor, new Properties());
+        this.createTestTopic(topic, numberOfPartitions, replicationFactor, getStandardProperties());
     }
 
     public abstract Properties getStandardProperties();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -23,8 +23,6 @@ import org.apache.flink.connector.kafka.testutils.TestKafkaContainer;
 import org.apache.flink.core.testutils.CommonTestUtils;
 
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.admin.TopicListing;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -46,10 +44,10 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createNewTopicAndWaitForPartitionAssignment;
 import static org.assertj.core.api.Assertions.fail;
 
 /** An implementation of the KafkaServerProvider. */
@@ -139,43 +137,8 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
     @Override
     public void createTestTopic(
             String topic, int numberOfPartitions, int replicationFactor, Properties properties) {
-        createNewTopic(topic, numberOfPartitions, replicationFactor, getStandardProperties());
-    }
-
-    public static void createNewTopic(
-            String topic, int numberOfPartitions, int replicationFactor, Properties properties) {
-        LOG.info("Creating topic {}", topic);
-        try (AdminClient adminClient = AdminClient.create(properties)) {
-            NewTopic topicObj = new NewTopic(topic, numberOfPartitions, (short) replicationFactor);
-            adminClient.createTopics(Collections.singleton(topicObj)).all().get();
-            CommonTestUtils.waitUtil(
-                    () -> {
-                        try {
-                            // Ensure all partitions have a leader elected and logs initialized
-                            Map<TopicPartition, OffsetSpec> offsetSpecs = new HashMap<>();
-                            for (int i = 0; i < numberOfPartitions; i++) {
-                                offsetSpecs.put(
-                                        new TopicPartition(topic, i), OffsetSpec.earliest());
-                            }
-                            adminClient
-                                    .listOffsets(offsetSpecs)
-                                    .all()
-                                    .get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-                            return true;
-                        } catch (Exception e) {
-                            LOG.warn(
-                                    "Partitions for topic {} not yet ready to serve requests",
-                                    topic,
-                                    e);
-                            return false;
-                        }
-                    },
-                    Duration.ofSeconds(30),
-                    String.format("New topic \"%s\" is not ready within timeout", topicObj));
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail("Create test topic : " + topic + " failed, " + e.getMessage());
-        }
+        createNewTopicAndWaitForPartitionAssignment(
+                topic, numberOfPartitions, replicationFactor, properties);
     }
 
     @Override


### PR DESCRIPTION
`KafkaWriterFaultToleranceITCase#testFlushExceptionWhenKafkaUnavailable` is flaky in CI due to org.apache.kafka.common.errors.NotLeaderOrFollowerException thrown instead of other expected exceptions (NetworkException / TimeoutException). This is because the topic isn't fully initialized, (see https://github.com/apache/flink-connector-kafka/pull/228) and the failure due to the missing topic races actual failures in the closing KAFKA_CONTAINER