### PR TITLE
[FLINK-39218] Introduce Flink-Kafka Transactions Management Tool

### DIFF
--- a/flink-connector-kafka-transaction-tool/pom.xml
+++ b/flink-connector-kafka-transaction-tool/pom.xml
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-connector-kafka-parent</artifactId>
+		<version>5.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>flink-connector-kafka-transaction-tool</artifactId>
+	<name>Flink : Connectors : Kafka : Transaction Tool</name>
+
+	<packaging>jar</packaging>
+
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
+	<dependencies>
+
+		<!-- Flink Kafka Connector -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<!-- Kafka Clients -->
+
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+		</dependency>
+
+		<!-- CLI -->
+
+		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+		</dependency>
+
+		<!-- Logging -->
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
+
+		<!-- Flink Core -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-annotations</artifactId>
+		</dependency>
+
+		<!-- Test Dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kafka</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-datagen</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-clients</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>kafka</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze-deps</id>
+						<goals>
+							<goal>analyze</goal>
+						</goals>
+						<phase>verify</phase>
+						<configuration>
+							<ignoredUnusedDeclaredDependencies>
+								org.slf4j:slf4j-simple,org.apache.flink:flink-streaming-java,org.testcontainers:kafka
+							</ignoredUnusedDeclaredDependencies>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-transaction-tool</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadedArtifactAttached>true</shadedArtifactAttached>
+							<shadedClassifierName>uber-jar</shadedClassifierName>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>org.apache.flink.connector.kafka.tool.KafkaTransactionTool</mainClass>
+								</transformer>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+							</transformers>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+										<exclude>META-INF/LICENSE.txt</exclude>
+										<exclude>LICENSE</exclude>
+										<exclude>NOTICE</exclude>
+									</excludes>
+								</filter>
+								<!-- Exclude transitive dependencies not needed by the tool's runtime code path.
+									 The tool only uses FlinkKafkaInternalProducer (transaction management),
+									 Preconditions (validation), and kafka-clients. -->
+								<filter>
+									<!-- Flink serialization framework — tool performs no state serialization -->
+									<artifact>com.esotericsoftware:*</artifact>
+									<excludes><exclude>**</exclude></excludes>
+								</filter>
+								<filter>
+									<artifact>org.objenesis:objenesis</artifact>
+									<excludes><exclude>**</exclude></excludes>
+								</filter>
+								<filter>
+									<!-- Bytecode manipulation — not used in transaction management -->
+									<artifact>org.apache.flink:flink-shaded-asm-9</artifact>
+									<excludes><exclude>**</exclude></excludes>
+								</filter>
+								<filter>
+									<!-- JSON processing — tool uses Properties, not JSON config -->
+									<artifact>org.apache.flink:flink-shaded-jackson</artifact>
+									<excludes><exclude>**</exclude></excludes>
+								</filter>
+								<filter>
+									<!-- YAML config parsing — tool uses CLI args, not flink-conf.yaml -->
+									<artifact>org.snakeyaml:snakeyaml-engine</artifact>
+									<excludes><exclude>**</exclude></excludes>
+								</filter>
+								<filter>
+									<!-- File compression — tool performs no file I/O -->
+									<artifact>org.apache.commons:commons-compress</artifact>
+									<excludes><exclude>**</exclude></excludes>
+								</filter>
+								<filter>
+									<artifact>commons-codec:commons-codec</artifact>
+									<excludes><exclude>**</exclude></excludes>
+								</filter>
+								<filter>
+									<!-- JSON — used by connector for source/sink config, not transactions -->
+									<artifact>com.fasterxml.jackson.core:*</artifact>
+									<excludes><exclude>**</exclude></excludes>
+								</filter>
+								<filter>
+									<artifact>com.fasterxml.jackson.datatype:*</artifact>
+									<excludes><exclude>**</exclude></excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-connector-kafka-transaction-tool/src/main/java/org/apache/flink/connector/kafka/tool/KafkaTransactionManager.java
+++ b/flink-connector-kafka-transaction-tool/src/main/java/org/apache/flink/connector/kafka/tool/KafkaTransactionManager.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.tool;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.kafka.sink.internal.FlinkKafkaInternalProducer;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+/**
+ * Manager to handle lingering Kafka transactions.
+ *
+ * <p>Allows operators to manually intervene when a Flink job is no longer running and has left
+ * transactions in an {@code ONGOING} state, blocking downstream consumers (LSO).
+ *
+ * <p>It supports two operations:
+ *
+ * <ul>
+ *   <li><b>Abort:</b> Connects with the same {@code transactional.id} to "fence" the previous
+ *       producer, forcing the broker to abort the open transaction.
+ *   <li><b>Commit:</b> Resumes the specific transaction using Flink's internal producer logic and
+ *       commits it. <b>WARNING:</b> This requires the exact {@code producerId} and {@code epoch}
+ *       from the Flink checkpoint state. Committing incorrectly can lead to data loss or
+ *       duplication.
+ * </ul>
+ */
+@Internal
+public final class KafkaTransactionManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTransactionManager.class);
+    private static final String TIMEOUT_MS = "10000";
+
+    /**
+     * Aborts an ongoing transaction for the given transactional ID.
+     *
+     * <p>This method utilizes the Kafka protocol's "fencing" mechanism. By initializing a new
+     * producer with the same {@code transactional.id}, the Kafka Broker will increment the epoch
+     * and automatically abort any lingering transactions from previous epochs.
+     *
+     * @param bootstrapServers Kafka bootstrap servers (e.g., "localhost:9092").
+     * @param transactionalId The transactional ID of the transaction to abort.
+     * @throws RuntimeException if the abort operation fails.
+     */
+    public void abortTransaction(String bootstrapServers, String transactionalId) {
+        validateInput(bootstrapServers, transactionalId);
+        LOG.info(
+                "Attempting to ABORT transaction: '{}' on servers: '{}'",
+                transactionalId,
+                bootstrapServers);
+
+        Properties props = createProducerProperties(bootstrapServers, transactionalId);
+
+        // Use standard KafkaProducer. The side-effect of initTransactions() performs the abort.
+        try (KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(props)) {
+            producer.initTransactions();
+            LOG.info("Successfully fenced and aborted transaction: {}", transactionalId);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    String.format("Failed to abort transaction '%s'", transactionalId), e);
+        }
+    }
+
+    /**
+     * Commits a transaction for the given transactional ID, producer ID, and epoch.
+     *
+     * <p><b>Note:</b> This method uses Flink's internal {@link FlinkKafkaInternalProducer}, which
+     * internally uses reflection to resume the transaction state. It is critical that the {@code
+     * producerId} and {@code epoch} match exactly what was recorded in the Flink checkpoint,
+     * otherwise, the broker will reject the commit or fence this attempt.
+     *
+     * @param bootstrapServers Kafka bootstrap servers (e.g., "localhost:9092").
+     * @param transactionalId The transactional ID of the transaction to commit.
+     * @param producerId The internal Kafka Producer ID (PID) obtained from Flink state/logs.
+     * @param epoch The internal Kafka Producer Epoch obtained from Flink state/logs.
+     * @throws RuntimeException if the commit operation fails.
+     */
+    public void commitTransaction(
+            String bootstrapServers, String transactionalId, long producerId, short epoch) {
+        validateInput(bootstrapServers, transactionalId);
+        Preconditions.checkArgument(producerId >= 0, "Producer ID must be non-negative");
+        Preconditions.checkArgument(epoch >= 0, "Epoch must be non-negative");
+
+        LOG.info(
+                "Attempting to RESUME and COMMIT transaction: '{}' (PID: {}, Epoch: {}) on servers: '{}'",
+                transactionalId,
+                producerId,
+                epoch,
+                bootstrapServers);
+
+        Properties props = createProducerProperties(bootstrapServers, transactionalId);
+
+        try (FlinkKafkaInternalProducer<byte[], byte[]> producer =
+                new FlinkKafkaInternalProducer<>(props, transactionalId)) {
+
+            producer.resumeTransaction(producerId, epoch);
+            producer.commitTransaction();
+
+            LOG.info("Successfully committed transaction: {}", transactionalId);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    String.format(
+                            "Failed to commit transaction '%s'. Possible causes: incorrect ProducerId (%d) or Epoch (%d), transaction already aborted or timed out, or producer fenced by another instance. Check Kafka broker logs for details.",
+                            transactionalId, producerId, epoch),
+                    e);
+        }
+    }
+
+    private Properties createProducerProperties(String bootstrapServers, String transactionalId) {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+        props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, TIMEOUT_MS);
+        // We use ByteArraySerializer as we are only managing transaction control messages,
+        // not sending actual data records.
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        props.put(
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+        return props;
+    }
+
+    private void validateInput(String bootstrapServers, String transactionalId) {
+        Preconditions.checkNotNull(bootstrapServers, "Bootstrap servers cannot be null");
+        Preconditions.checkArgument(
+                !bootstrapServers.isEmpty(), "Bootstrap servers cannot be empty");
+
+        Preconditions.checkNotNull(transactionalId, "Transactional ID cannot be null");
+        Preconditions.checkArgument(!transactionalId.isEmpty(), "Transactional ID cannot be empty");
+    }
+}

--- a/flink-connector-kafka-transaction-tool/src/main/java/org/apache/flink/connector/kafka/tool/KafkaTransactionTool.java
+++ b/flink-connector-kafka-transaction-tool/src/main/java/org/apache/flink/connector/kafka/tool/KafkaTransactionTool.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.tool;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+/**
+ * Command-line tool for manually managing lingering Kafka transactions.
+ *
+ * <p>This tool is designed for scenarios where a Flink job has failed or been stopped, but the
+ * Kafka transaction remains {@code ONGOING}.
+ *
+ * <p><b>Impact of Lingering Transactions:</b>
+ *
+ * <ul>
+ *   <li><b>LSO Blocking:</b> Downstream consumers reading with {@code
+ *       isolation.level=read_committed} will be blocked at the Last Stable Offset (LSO) and stop
+ *       processing new data.
+ *   <li><b>Data Unavailability:</b> The data is persisted in Kafka but invisible to consumers with
+ *       {@code isolation.level=read_committed}. Aborting this transaction results in <b>data
+ *       loss</b> for these consumers (as they will skip the aborted data). Committing it makes the
+ *       data visible.
+ * </ul>
+ *
+ * <h3>Building the Tool</h3>
+ *
+ * <p>The tool is packaged as a standalone "Uber Jar" in the {@code
+ * flink-connector-kafka-transaction-tool} module, which bundles all necessary dependencies like
+ * {@code kafka-clients} and {@code commons-cli}.
+ *
+ * <pre>
+ * mvn clean package -pl flink-connector-kafka-transaction-tool -DskipTests
+ * </pre>
+ *
+ * <p>The resulting JAR will be located in the {@code target/} directory, usually named: {@code
+ * flink-connector-kafka-transaction-tool-X.Y-SNAPSHOT-uber-jar.jar}.
+ *
+ * <h3>Usage</h3>
+ *
+ * <p>You can execute the JAR directly using Java.
+ *
+ * <p><b>Abort Transaction:</b><br>
+ * Uses the Kafka "fencing" mechanism to force-abort a lingering transaction.
+ *
+ * <pre>
+ * java -jar flink-connector-kafka-transaction-tool-*-uber-jar.jar \
+ * --action abort \
+ * --bootstrap-servers localhost:9092 \
+ * --transactional-id flink-tx-1
+ * </pre>
+ *
+ * <p><b>Commit Transaction:</b><br>
+ * Resumes and commits a specific transaction state. <br>
+ * <b>WARNING:</b> You must provide the exact {@code producer-id} and {@code epoch} from <b>Flink
+ * logs</b> or Checkpoints. <br>
+ * <i>It is possible to retrieve these values from the active Kafka Broker state (e.g. via {@code
+ * kafka-transactions.sh}). However, if the job has restarted, the broker state reflects the
+ * <b>new</b> running transaction. Manually committing the new transaction using this tool will
+ * corrupt the state of the running job.</i>
+ *
+ * <pre>
+ * java -jar flink-connector-kafka-transaction-tool-*-uber-jar.jar \
+ * --action commit \
+ * --bootstrap-servers localhost:9092 \
+ * --transactional-id flink-tx-1 \
+ * --producer-id 1005 \
+ * --epoch 4
+ * </pre>
+ */
+@Internal
+public final class KafkaTransactionTool {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTransactionTool.class);
+
+    static final String OPTION_ACTION = "action";
+    static final String OPTION_BOOTSTRAP_SERVERS = "bootstrap-servers";
+    static final String OPTION_TRANSACTIONAL_ID = "transactional-id";
+    static final String OPTION_PRODUCER_ID = "producer-id";
+    static final String OPTION_EPOCH = "epoch";
+    static final String OPTION_HELP = "help";
+
+    private KafkaTransactionTool() {}
+
+    public static void main(String[] args) {
+        System.exit(run(args));
+    }
+
+    static int run(String[] args) {
+        final Options options = getOptions();
+        CommandLineParser parser = new DefaultParser();
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.setWidth(120);
+
+        // Pre-check for --help
+        if (Arrays.asList(args).contains("--" + OPTION_HELP) || args.length == 0) {
+            printHelp(formatter, options);
+            return 0;
+        }
+
+        try {
+            CommandLine cmd = parser.parse(options, args);
+
+            String action = cmd.getOptionValue(OPTION_ACTION);
+            String bootstrapServers = cmd.getOptionValue(OPTION_BOOTSTRAP_SERVERS);
+            String transactionalId = cmd.getOptionValue(OPTION_TRANSACTIONAL_ID);
+
+            KafkaTransactionManager manager = new KafkaTransactionManager();
+
+            if ("abort".equalsIgnoreCase(action)) {
+                manager.abortTransaction(bootstrapServers, transactionalId);
+            } else if ("commit".equalsIgnoreCase(action)) {
+                // Conditional validation: Commit requires extra args
+                if (!cmd.hasOption(OPTION_PRODUCER_ID) || !cmd.hasOption(OPTION_EPOCH)) {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Action 'commit' requires --%s and --%s.",
+                                    OPTION_PRODUCER_ID, OPTION_EPOCH));
+                }
+
+                final long producerId = Long.parseLong(cmd.getOptionValue(OPTION_PRODUCER_ID));
+                final short epoch = Short.parseShort(cmd.getOptionValue(OPTION_EPOCH));
+
+                manager.commitTransaction(bootstrapServers, transactionalId, producerId, epoch);
+            } else {
+                throw new IllegalArgumentException(
+                        "Unknown action: " + action + ". Supported actions: 'abort', 'commit'.");
+            }
+
+            return 0;
+        } catch (ParseException e) {
+            System.err.println("Error parsing command line arguments: " + e.getMessage());
+            formatter.printHelp("KafkaTransactionTool", options);
+            return 1;
+        } catch (NumberFormatException e) {
+            System.err.println(
+                    "Invalid numeric value: "
+                            + e.getMessage()
+                            + ". --producer-id must be a valid long,"
+                            + " --epoch must be a valid short (0-32767).");
+            return 2;
+        } catch (Exception e) {
+            LOG.error("Execution failed", e);
+            return 2;
+        }
+    }
+
+    private static Options getOptions() {
+        final Options options = new Options();
+
+        options.addOption(
+                Option.builder()
+                        .longOpt(OPTION_ACTION)
+                        .hasArg()
+                        .required()
+                        .desc("Operation to perform: 'abort' or 'commit'.")
+                        .build());
+
+        options.addOption(
+                Option.builder()
+                        .longOpt(OPTION_BOOTSTRAP_SERVERS)
+                        .hasArg()
+                        .required()
+                        .desc("Kafka brokers list (e.g. localhost:9092).")
+                        .build());
+
+        options.addOption(
+                Option.builder()
+                        .longOpt(OPTION_TRANSACTIONAL_ID)
+                        .hasArg()
+                        .required()
+                        .desc("The Kafka Transactional ID.")
+                        .build());
+
+        options.addOption(
+                Option.builder()
+                        .longOpt(OPTION_PRODUCER_ID)
+                        .hasArg()
+                        .desc("(Commit only) Internal Producer ID from Flink State.")
+                        .build());
+
+        options.addOption(
+                Option.builder()
+                        .longOpt(OPTION_EPOCH)
+                        .hasArg()
+                        .desc("(Commit only) Internal Producer Epoch from Flink State.")
+                        .build());
+
+        options.addOption(
+                Option.builder().longOpt(OPTION_HELP).desc("Show this help message.").build());
+
+        return options;
+    }
+
+    private static void printHelp(HelpFormatter formatter, Options options) {
+        formatter.printHelp(
+                "KafkaTransactionTool",
+                "Tool to manually manage lingering Flink Kafka transactions.",
+                options,
+                "Examples:\n"
+                        + "  abort:  --action abort --bootstrap-servers localhost:9092 --transactional-id flink-tx-1\n"
+                        + "  commit: --action commit --bootstrap-servers localhost:9092 --transactional-id flink-tx-1 --producer-id 100 --epoch 5",
+                true);
+    }
+}

--- a/flink-connector-kafka-transaction-tool/src/test/java/org/apache/flink/connector/kafka/tool/KafkaAdminAssert.java
+++ b/flink-connector-kafka-transaction-tool/src/test/java/org/apache/flink/connector/kafka/tool/KafkaAdminAssert.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.tool;
+
+import org.apache.flink.connector.kafka.testutils.TestKafkaContainer;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.TransactionListing;
+import org.apache.kafka.clients.admin.TransactionState;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.MapAssert;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+/** Custom AssertJ assertions for Kafka Admin Client to verify transactions. */
+public class KafkaAdminAssert extends AbstractAssert<KafkaAdminAssert, Admin>
+        implements AutoCloseable {
+
+    private final boolean selfManaged;
+
+    private KafkaAdminAssert(Admin admin, boolean selfManaged) {
+        super(admin, KafkaAdminAssert.class);
+        this.selfManaged = selfManaged;
+    }
+
+    /** Entry point using a TestContainer. Creates and manages the Admin client lifecycle. */
+    public static KafkaAdminAssert assertThat(TestKafkaContainer kafkaContainer) {
+        Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        return new KafkaAdminAssert(Admin.create(props), true);
+    }
+
+    /** Entry point using an existing Admin client. */
+    public static KafkaAdminAssert assertThat(Admin admin) {
+        return new KafkaAdminAssert(admin, false);
+    }
+
+    /** Fetches all transactions and switches context to Transaction assertions. */
+    public KafkaTransactionsAssert transactions() {
+        try {
+            Collection<TransactionListing> listings = actual.listTransactions().all().get();
+            return new KafkaTransactionsAssert(listings);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to list transactions from Kafka", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (selfManaged && actual != null) {
+            actual.close();
+        }
+    }
+
+    /** Assertions for a collection of Kafka Transactions. */
+    public static class KafkaTransactionsAssert
+            extends AbstractAssert<KafkaTransactionsAssert, Collection<TransactionListing>> {
+
+        public KafkaTransactionsAssert(Collection<TransactionListing> actual) {
+            super(actual, KafkaTransactionsAssert.class);
+        }
+
+        /** Extracts IDs and returns a standard ListAssert. */
+        public ListAssert<String> extractingIds() {
+            List<String> ids =
+                    actual.stream()
+                            .map(TransactionListing::transactionalId)
+                            .collect(Collectors.toList());
+            return Assertions.assertThat(ids);
+        }
+
+        /** Extracts ID -> State map and returns a standard MapAssert. */
+        public MapAssert<String, TransactionState> extractingStates() {
+            Map<String, TransactionState> stateMap =
+                    actual.stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            TransactionListing::transactionalId,
+                                            TransactionListing::state));
+            return Assertions.assertThat(stateMap);
+        }
+    }
+}

--- a/flink-connector-kafka-transaction-tool/src/test/java/org/apache/flink/connector/kafka/tool/KafkaTransactionManagerITCase.java
+++ b/flink-connector-kafka-transaction-tool/src/test/java/org/apache/flink/connector/kafka/tool/KafkaTransactionManagerITCase.java
@@ -1,0 +1,656 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.tool;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.CommitterInitContext;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.apache.flink.api.connector.source.util.ratelimit.RateLimiterStrategy;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.connector.datagen.source.DataGeneratorSource;
+import org.apache.flink.connector.kafka.sink.KafkaCommittable;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.connector.kafka.sink.KafkaWriterState;
+import org.apache.flink.connector.kafka.sink.TwoPhaseCommittingStatefulSink;
+import org.apache.flink.connector.kafka.sink.internal.FlinkKafkaInternalProducer;
+import org.apache.flink.connector.kafka.testutils.KafkaUtil;
+import org.apache.flink.connector.kafka.testutils.TestKafkaContainer;
+import org.apache.flink.core.execution.SavepointFormatType;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.test.junit5.InjectClusterClient;
+import org.apache.flink.test.junit5.InjectMiniCluster;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.testutils.junit.SharedObjectsExtension;
+import org.apache.flink.testutils.junit.SharedReference;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ListTransactionsOptions;
+import org.apache.kafka.clients.admin.TransactionDescription;
+import org.apache.kafka.clients.admin.TransactionListing;
+import org.apache.kafka.clients.admin.TransactionState;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createKafkaContainer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+class KafkaTransactionManagerITCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaTransactionManagerITCase.class);
+    private static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
+
+    @Nested
+    class AbortAndCommitTests {
+
+        @Container
+        final TestKafkaContainer kafkaContainer =
+                createKafkaContainer(KafkaTransactionManagerITCase.class)
+                        .withNetwork(Network.newNetwork())
+                        .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);
+
+        @Test
+        void testAbortSpecificTransactionOnly() {
+            // given
+            final String topic = "test-abort-isolation";
+            final String transactionIdPrefix = "testAbortTarget-";
+
+            // Two ongoing transactions
+            // Target - the one we want to abort
+            final String targetTxId = transactionIdPrefix + "target";
+            final String targetData = "data-to-abort";
+            createLingeringTransaction(topic, targetTxId, targetData);
+
+            // Neighbor - must remain unaffected
+            final String neighborTxId = transactionIdPrefix + "neighbor";
+            final String neighborData = "data-keep-alive";
+            createLingeringTransaction(topic, neighborTxId, neighborData);
+
+            // Verify Initial State
+            try (KafkaAdminAssert adminAssert = KafkaAdminAssert.assertThat(kafkaContainer)) {
+                // Verify no other transactions were created
+                adminAssert
+                        .transactions()
+                        .extractingIds()
+                        .containsExactlyInAnyOrder(targetTxId, neighborTxId);
+
+                adminAssert
+                        .transactions()
+                        .extractingStates()
+                        .containsEntry(targetTxId, TransactionState.ONGOING)
+                        .containsEntry(neighborTxId, TransactionState.ONGOING);
+            }
+            assertThat(consumeRecords(topic, "read_committed")).isEmpty();
+
+            // when
+            KafkaTransactionManager tool = new KafkaTransactionManager();
+            tool.abortTransaction(kafkaContainer.getBootstrapServers(), targetTxId);
+
+            // then
+            try (KafkaAdminAssert adminAssert = KafkaAdminAssert.assertThat(kafkaContainer)) {
+                // COMPLETE_ABORT is transient and may transition to EMPTY.
+                adminAssert
+                        .transactions()
+                        .extractingStates()
+                        .extractingByKey(targetTxId)
+                        .isIn(TransactionState.COMPLETE_ABORT, TransactionState.EMPTY);
+
+                adminAssert
+                        .transactions()
+                        .extractingStates()
+                        .containsEntry(neighborTxId, TransactionState.ONGOING);
+
+                // Verify we didn't create any unrelated transactions during abort
+                adminAssert
+                        .transactions()
+                        .extractingIds()
+                        .containsExactlyInAnyOrder(targetTxId, neighborTxId);
+            }
+
+            // Committed Consumer should see NOTHING (Target aborted, Neighbor still open)
+            assertThat(consumeRecords(topic, "read_committed")).isEmpty();
+
+            // Uncommitted Consumer should see everything (aborted messages exist in log, just
+            // marked aborted)
+            assertThat(consumeRecords(topic, "read_uncommitted"))
+                    .contains(targetData, neighborData);
+        }
+
+        @Test
+        void testCommitSpecificTransactionOnly() {
+            // given
+            final String topic = "test-commit-isolation";
+            final String transactionIdPrefix = "testCommitTarget-";
+
+            // Two ongoing transactions on the SAME topic
+            // Target - the one we want to commit
+            final String targetTxId = transactionIdPrefix + "target";
+            final String targetData = "data-target";
+            final long[] targetMetadata = createLingeringTransaction(topic, targetTxId, targetData);
+            final long targetProducerId = targetMetadata[0];
+            final short targetEpoch = (short) targetMetadata[1];
+
+            // Neighbor - must remain unaffected
+            final String neighborTxId = transactionIdPrefix + "neighbor";
+            final String neighborData = "data-neighbor";
+            createLingeringTransaction(topic, neighborTxId, neighborData);
+
+            // Verify Initial State
+            try (KafkaAdminAssert adminAssert = KafkaAdminAssert.assertThat(kafkaContainer)) {
+                // Verify no other transactions were created
+                adminAssert
+                        .transactions()
+                        .extractingIds()
+                        .containsExactlyInAnyOrder(targetTxId, neighborTxId);
+
+                adminAssert
+                        .transactions()
+                        .extractingStates()
+                        .containsEntry(targetTxId, TransactionState.ONGOING)
+                        .containsEntry(neighborTxId, TransactionState.ONGOING);
+            }
+            assertThat(consumeRecords(topic, "read_committed")).isEmpty();
+            assertThat(consumeRecords(topic, "read_uncommitted"))
+                    .contains(targetData, neighborData);
+
+            // when
+            KafkaTransactionManager kafkaTransactionManager = new KafkaTransactionManager();
+            kafkaTransactionManager.commitTransaction(
+                    kafkaContainer.getBootstrapServers(),
+                    targetTxId,
+                    targetProducerId,
+                    targetEpoch);
+
+            // then
+            try (KafkaAdminAssert adminAssert = KafkaAdminAssert.assertThat(kafkaContainer)) {
+                adminAssert
+                        .transactions()
+                        .extractingStates()
+                        .extractingByKey(targetTxId)
+                        .isIn(TransactionState.PREPARE_COMMIT, TransactionState.COMPLETE_COMMIT);
+
+                adminAssert
+                        .transactions()
+                        .extractingStates()
+                        .containsEntry(neighborTxId, TransactionState.ONGOING);
+
+                // Verify no other transactions were created
+                adminAssert
+                        .transactions()
+                        .extractingIds()
+                        .containsExactlyInAnyOrder(targetTxId, neighborTxId);
+            }
+
+            // Target Data should now be visible in read_committed
+            assertThat(consumeRecords(topic, "read_committed")).contains(targetData);
+
+            // Neighbor Data should STILL be invisible in read_committed
+            assertThat(consumeRecords(topic, "read_committed")).doesNotContain(neighborData);
+        }
+
+        @Test
+        void testCommitWithWrongProducerIdFails() {
+            // given
+            final String topic = "test-commit-wrong-pid";
+            final String transactionalId = "testWrongPid-target";
+            final long invalidProducerId = 999999L;
+            createLingeringTransaction(topic, transactionalId, "data");
+
+            KafkaTransactionManager manager = new KafkaTransactionManager();
+
+            // when/then
+            assertThatThrownBy(
+                            () ->
+                                    manager.commitTransaction(
+                                            kafkaContainer.getBootstrapServers(),
+                                            transactionalId,
+                                            invalidProducerId,
+                                            (short) 0))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Failed to commit transaction");
+        }
+
+        private long[] createLingeringTransaction(
+                String topic, String transactionalId, String data) {
+            final Properties props = new Properties();
+            props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+            props.put(
+                    ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+            props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+            props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+            props.put(
+                    ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+            // We rely on FlinkKafkaInternalProducer's specific close behavior (Duration.ZERO)
+            // to leave the transaction hanging on the broker without sending an abort signal.
+            try (FlinkKafkaInternalProducer<String, String> producer =
+                    new FlinkKafkaInternalProducer<>(props, transactionalId)) {
+                producer.initTransactions();
+                producer.beginTransaction();
+                producer.send(new ProducerRecord<>(topic, data));
+                producer.flush();
+
+                long pid = producer.getProducerId();
+                short epoch = producer.getEpoch();
+                return new long[] {pid, epoch};
+            }
+        }
+
+        private List<String> consumeRecords(String topic, String isolationLevel) {
+            Properties props = new Properties();
+            props.put(
+                    ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+            props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group-" + UUID.randomUUID());
+            props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+            boolean committed = "read_committed".equals(isolationLevel);
+            return KafkaUtil.drainAllRecordsFromTopic(topic, props, committed).stream()
+                    .map(r -> new String(r.value()))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class SavepointRecoveryTests {
+
+        @Container
+        private final TestKafkaContainer kafkaContainer =
+                createKafkaContainer(KafkaTransactionManagerITCase.class)
+                        .withNetwork(Network.newNetwork())
+                        .withNetworkAliases(INTER_CONTAINER_KAFKA_ALIAS);
+
+        @RegisterExtension
+        final MiniClusterExtension miniClusterExtension =
+                new MiniClusterExtension(
+                        new MiniClusterResourceConfiguration.Builder()
+                                .setNumberTaskManagers(1)
+                                .setNumberSlotsPerTaskManager(1)
+                                .setConfiguration(new Configuration())
+                                .build());
+
+        @RegisterExtension
+        final SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
+
+        @TempDir Path tempDir;
+
+        @Test
+        void testCommitLingeringTransactionAfterSavepointWithoutSinkCommit(
+                @InjectMiniCluster MiniCluster miniCluster,
+                @InjectClusterClient ClusterClient<?> clusterClient)
+                throws Exception {
+            // given
+            final String topic = UUID.randomUUID().toString();
+            createTestTopic(topic);
+
+            final StreamExecutionEnvironment env =
+                    StreamExecutionEnvironment.getExecutionEnvironment(createConfiguration(1));
+            env.enableCheckpointing(
+                    1_000_000); // some high value only to allow savepoint triggering
+
+            final DataStream<Long> source = createSource(env, 100);
+            SharedReference<Set<Long>> checkpointedRecords =
+                    sharedObjects.add(new ConcurrentSkipListSet<>());
+
+            final String kafkaSinkUid = "kafka-sink-operator-uid";
+            final String transactionalIdPrefix = "kafka-sink";
+
+            final KafkaSink<Long> kafkaSink =
+                    KafkaSink.<Long>builder()
+                            .setBootstrapServers(kafkaContainer.getBootstrapServers())
+                            .setDeliveryGuarantee(DeliveryGuarantee.EXACTLY_ONCE)
+                            .setRecordSerializer(
+                                    KafkaRecordSerializationSchema.builder()
+                                            .setTopic(topic)
+                                            .setValueSerializationSchema(new RecordSerializer())
+                                            .build())
+                            .setTransactionalIdPrefix(transactionalIdPrefix)
+                            .build();
+
+            source.map(new RecordFetcher(checkpointedRecords))
+                    .sinkTo(NoCommitKafkaSinkWrapper.wrap(kafkaSink))
+                    .uid(kafkaSinkUid);
+
+            StreamGraph streamGraph = env.getStreamGraph();
+            JobGraph jobGraph = streamGraph.getJobGraph();
+
+            JobID jobId = clusterClient.submitJob(jobGraph).get();
+            CommonTestUtils.waitForAllTaskRunning(miniCluster, jobId, true);
+
+            Path flinkInternalSavepointTargetDirRestored =
+                    tempDir.resolve("native-savepoint-restored");
+            Files.createDirectories(flinkInternalSavepointTargetDirRestored);
+            CompletableFuture<String> savepointFutureRestored =
+                    clusterClient.stopWithSavepoint(
+                            jobGraph.getJobID(),
+                            false,
+                            flinkInternalSavepointTargetDirRestored.toAbsolutePath().toString(),
+                            SavepointFormatType.NATIVE);
+            // Wait for savepoint completion
+            String savepointPathStringRestored = savepointFutureRestored.get();
+
+            List<TransactionListing> transactions =
+                    listTransactionsForPrefix(transactionalIdPrefix);
+
+            // Find the ONGOING transaction (the transactional ID format is
+            // prefix-subtask-offset)
+            List<TransactionListing> ongoingTransactions =
+                    transactions.stream()
+                            .filter(t -> t.state() == TransactionState.ONGOING)
+                            .collect(Collectors.toList());
+            assertThat(ongoingTransactions).hasSize(1);
+            String transactionalId = ongoingTransactions.get(0).transactionalId();
+
+            List<Long> collectedRecords = deserializeValues(drainAllRecordsFromTopic(topic, true));
+            // NoCommitKafkaSink should leave all transactions not committed hence collected
+            // records should be empty
+            assertThat(collectedRecords).isEmpty();
+
+            // when
+            TransactionDescription description = describeTransaction(transactionalId);
+            KafkaTransactionManager kafkaTransactionManager = new KafkaTransactionManager();
+            kafkaTransactionManager.commitTransaction(
+                    kafkaContainer.getBootstrapServers(),
+                    transactionalId,
+                    description.producerId(),
+                    (short) description.producerEpoch());
+
+            // then
+            // after committing transactions via the cleanup process, we should finally see the
+            // expected records
+            collectedRecords = deserializeValues(drainAllRecordsFromTopic(topic, true));
+            assertThat(collectedRecords)
+                    .containsExactlyInAnyOrderElementsOf(checkpointedRecords.get());
+            assertThat(describeTransaction(transactionalId).state())
+                    .isEqualTo(TransactionState.COMPLETE_COMMIT);
+        }
+
+        private void createTestTopic(String topic) throws Exception {
+            Properties adminProps = new Properties();
+            adminProps.put("bootstrap.servers", kafkaContainer.getBootstrapServers());
+            try (Admin admin = Admin.create(adminProps)) {
+                admin.createTopics(
+                                Collections.singletonList(
+                                        new org.apache.kafka.clients.admin.NewTopic(
+                                                topic, 1, (short) 1)))
+                        .all()
+                        .get();
+            }
+        }
+
+        private TransactionDescription describeTransaction(String transactionalId)
+                throws Exception {
+            Properties props = new Properties();
+            props.put(
+                    ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+
+            try (Admin admin = Admin.create(props)) {
+                TransactionDescription description =
+                        admin.describeTransactions(List.of(transactionalId))
+                                .all()
+                                .get()
+                                .get(transactionalId);
+
+                LOG.info("Transaction {} state is: {}", transactionalId, description.state());
+                return description;
+            }
+        }
+
+        private List<ConsumerRecord<byte[], byte[]>> drainAllRecordsFromTopic(
+                String topic, boolean committed) {
+            Properties properties = new Properties();
+            properties.put("bootstrap.servers", kafkaContainer.getBootstrapServers());
+            properties.put("group.id", UUID.randomUUID().toString());
+            properties.put("enable.auto.commit", false);
+            properties.put("auto.offset.reset", "earliest");
+            return KafkaUtil.drainAllRecordsFromTopic(topic, properties, committed);
+        }
+
+        private List<TransactionListing> listTransactionsForPrefix(String prefix) throws Exception {
+            Properties adminProps = new Properties();
+            adminProps.put("bootstrap.servers", kafkaContainer.getBootstrapServers());
+
+            try (Admin admin = Admin.create(adminProps)) {
+                KafkaFuture<Collection<TransactionListing>> transactionsFuture =
+                        admin.listTransactions(new ListTransactionsOptions()).all();
+                Collection<TransactionListing> transactions = transactionsFuture.get();
+                return transactions.stream()
+                        .filter(t -> t.transactionalId().contains(prefix))
+                        .collect(Collectors.toList());
+            }
+        }
+
+        private Configuration createConfiguration(int parallelism) {
+            final Configuration config = new Configuration();
+            config.set(CoreOptions.DEFAULT_PARALLELISM, parallelism);
+            return config;
+        }
+
+        private DataStream<Long> createSource(StreamExecutionEnvironment env, int count) {
+            return env.fromSource(
+                    new DataGeneratorSource<>(
+                            value -> value,
+                            count,
+                            RateLimiterStrategy.noOp(),
+                            BasicTypeInfo.LONG_TYPE_INFO),
+                    WatermarkStrategy.noWatermarks(),
+                    "Generator Source");
+        }
+
+        private List<Long> deserializeValues(List<ConsumerRecord<byte[], byte[]>> records) {
+            return records.stream()
+                    .map(
+                            record -> {
+                                final ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+                                final byte[] value = record.value();
+                                buffer.put(value, 0, value.length);
+                                buffer.flip();
+                                return buffer.getLong();
+                            })
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private static class RecordSerializer implements SerializationSchema<Long> {
+
+        @Override
+        public byte[] serialize(Long element) {
+            final ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+            buffer.putLong(element);
+            return buffer.array();
+        }
+    }
+
+    /**
+     * Fetches records that have been successfully checkpointed. It relies on final checkpoints and
+     * subsumption to ultimately, emit all records that have been checkpointed.
+     *
+     * <p>Note that the current implementation only works by operating on a set because on failure,
+     * we may end up with duplicate records being added to the {@link #checkpointedRecords}.
+     *
+     * <p>The fetcher uses three states to manage the records:
+     *
+     * <ol>
+     *   <li>{@link #recordsSinceLastCheckpoint} is used to buffer records between checkpoints.
+     *   <li>{@link #snapshottedRecords} is used to store the records that have been checkpointed.
+     *   <li>{@link #checkpointedRecords} is used to store snapshottedRecords where the checkpoint
+     *       has been acknowledged.
+     * </ol>
+     *
+     * <p>Records are promoted from data structure to the next (e.g. removed from the lower level).
+     */
+    private static class RecordFetcher
+            implements MapFunction<Long, Long>, CheckpointedFunction, CheckpointListener {
+        private final SharedReference<Set<Long>> checkpointedRecords;
+        private final List<Long> recordsSinceLastCheckpoint = new ArrayList<>();
+        private static final ListStateDescriptor<Long> STATE_DESCRIPTOR =
+                new ListStateDescriptor<>("committed-records", BasicTypeInfo.LONG_TYPE_INFO);
+        private ListState<Long> snapshottedRecords;
+
+        private RecordFetcher(SharedReference<Set<Long>> checkpointedRecords) {
+            this.checkpointedRecords = checkpointedRecords;
+        }
+
+        @Override
+        public Long map(Long value) {
+            recordsSinceLastCheckpoint.add(value);
+            return value;
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) throws Exception {
+            // sync with shared object, this is guaranteed to sync eventually because of final
+            // checkpoint
+            ArrayList<Long> committedRecords = new ArrayList<>();
+            snapshottedRecords.get().forEach(committedRecords::add);
+            checkpointedRecords.get().addAll(committedRecords);
+        }
+
+        @Override
+        public void snapshotState(FunctionSnapshotContext context) throws Exception {
+            LOG.info(
+                    "snapshotState {} @ {}", recordsSinceLastCheckpoint, context.getCheckpointId());
+            snapshottedRecords.addAll(recordsSinceLastCheckpoint);
+            recordsSinceLastCheckpoint.clear();
+        }
+
+        @Override
+        public void initializeState(FunctionInitializationContext context) throws Exception {
+            snapshottedRecords = context.getOperatorStateStore().getListState(STATE_DESCRIPTOR);
+        }
+    }
+
+    /**
+     * A Facade (Wrapper) around KafkaSink that intercepts the Committer to prevent actual commits.
+     */
+    private static class NoCommitKafkaSinkWrapper<IN>
+            implements TwoPhaseCommittingStatefulSink<IN, KafkaWriterState, KafkaCommittable> {
+
+        private final KafkaSink<IN> kafkaSink;
+
+        private NoCommitKafkaSinkWrapper(KafkaSink<IN> kafkaSink) {
+            this.kafkaSink = kafkaSink;
+        }
+
+        static <IN> NoCommitKafkaSinkWrapper<IN> wrap(KafkaSink<IN> sink) {
+            return new NoCommitKafkaSinkWrapper<>(sink);
+        }
+
+        @Override
+        public Committer<KafkaCommittable> createCommitter(CommitterInitContext context) {
+            return new NoCommitCommitter(kafkaSink.createCommitter(context));
+        }
+
+        @Override
+        public SimpleVersionedSerializer<KafkaCommittable> getCommittableSerializer() {
+            return kafkaSink.getCommittableSerializer();
+        }
+
+        @Override
+        public PrecommittingStatefulSinkWriter<IN, KafkaWriterState, KafkaCommittable> createWriter(
+                WriterInitContext context) throws IOException {
+            return kafkaSink.createWriter(context);
+        }
+
+        @Override
+        public PrecommittingStatefulSinkWriter<IN, KafkaWriterState, KafkaCommittable>
+                restoreWriter(
+                        WriterInitContext context, Collection<KafkaWriterState> recoveredState)
+                        throws IOException {
+            return kafkaSink.restoreWriter(context, recoveredState);
+        }
+
+        @Override
+        public SimpleVersionedSerializer<KafkaWriterState> getWriterStateSerializer() {
+            return kafkaSink.getWriterStateSerializer();
+        }
+
+        /** Inner Committer that delegates everything except the commit() method. */
+        private static class NoCommitCommitter implements Committer<KafkaCommittable> {
+            private final Committer<KafkaCommittable> committerDelegate;
+
+            NoCommitCommitter(Committer<KafkaCommittable> committerDelegate) {
+                this.committerDelegate = committerDelegate;
+            }
+
+            @Override
+            public void commit(Collection<CommitRequest<KafkaCommittable>> collection)
+                    throws IOException, InterruptedException {
+                // noop - ignore and do not commit
+            }
+
+            @Override
+            public void close() throws Exception {
+                committerDelegate.close();
+            }
+        }
+    }
+}

--- a/flink-connector-kafka-transaction-tool/src/test/java/org/apache/flink/connector/kafka/tool/KafkaTransactionManagerTest.java
+++ b/flink-connector-kafka-transaction-tool/src/test/java/org/apache/flink/connector/kafka/tool/KafkaTransactionManagerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.tool;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link KafkaTransactionManager} input validation and error handling. */
+class KafkaTransactionManagerTest {
+
+    private final KafkaTransactionManager manager = new KafkaTransactionManager();
+
+    @Test
+    void testAbortWithNullBootstrapServers() {
+        assertThatThrownBy(() -> manager.abortTransaction(null, "tx-1"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("Bootstrap servers cannot be null");
+    }
+
+    @Test
+    void testAbortWithEmptyBootstrapServers() {
+        assertThatThrownBy(() -> manager.abortTransaction("", "tx-1"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Bootstrap servers cannot be empty");
+    }
+
+    @Test
+    void testAbortWithNullTransactionalId() {
+        assertThatThrownBy(() -> manager.abortTransaction("localhost:9092", null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("Transactional ID cannot be null");
+    }
+
+    @Test
+    void testAbortWithEmptyTransactionalId() {
+        assertThatThrownBy(() -> manager.abortTransaction("localhost:9092", ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Transactional ID cannot be empty");
+    }
+
+    @Test
+    void testCommitWithNegativeProducerId() {
+        assertThatThrownBy(() -> manager.commitTransaction("localhost:9092", "tx-1", -1, (short) 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Producer ID must be non-negative");
+    }
+
+    @Test
+    void testCommitWithNegativeEpoch() {
+        assertThatThrownBy(
+                        () -> manager.commitTransaction("localhost:9092", "tx-1", 100, (short) -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Epoch must be non-negative");
+    }
+}

--- a/flink-connector-kafka-transaction-tool/src/test/java/org/apache/flink/connector/kafka/tool/KafkaTransactionToolTest.java
+++ b/flink-connector-kafka-transaction-tool/src/test/java/org/apache/flink/connector/kafka/tool/KafkaTransactionToolTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.tool;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link KafkaTransactionTool} CLI argument parsing. */
+class KafkaTransactionToolTest {
+
+    @Test
+    void testHelpReturnsZero() {
+        assertThat(KafkaTransactionTool.run(new String[] {"--help"})).isEqualTo(0);
+    }
+
+    @Test
+    void testEmptyArgsReturnsZero() {
+        assertThat(KafkaTransactionTool.run(new String[] {})).isEqualTo(0);
+    }
+
+    @Test
+    void testMissingRequiredArgsReturnsOne() {
+        assertThat(KafkaTransactionTool.run(new String[] {"--action", "abort"})).isEqualTo(1);
+    }
+
+    @Test
+    void testUnknownActionReturnsTwo() {
+        assertThat(
+                        KafkaTransactionTool.run(
+                                new String[] {
+                                    "--action", "unknown",
+                                    "--bootstrap-servers", "localhost:9092",
+                                    "--transactional-id", "tx-1"
+                                }))
+                .isEqualTo(2);
+    }
+
+    @Test
+    void testCommitWithoutProducerIdReturnsTwo() {
+        assertThat(
+                        KafkaTransactionTool.run(
+                                new String[] {
+                                    "--action", "commit",
+                                    "--bootstrap-servers", "localhost:9092",
+                                    "--transactional-id", "tx-1",
+                                    "--epoch", "5"
+                                }))
+                .isEqualTo(2);
+    }
+
+    @Test
+    void testCommitWithoutEpochReturnsTwo() {
+        assertThat(
+                        KafkaTransactionTool.run(
+                                new String[] {
+                                    "--action", "commit",
+                                    "--bootstrap-servers", "localhost:9092",
+                                    "--transactional-id", "tx-1",
+                                    "--producer-id", "100"
+                                }))
+                .isEqualTo(2);
+    }
+
+    @Test
+    void testNonNumericProducerIdReturnsTwo() {
+        assertThat(
+                        KafkaTransactionTool.run(
+                                new String[] {
+                                    "--action", "commit",
+                                    "--bootstrap-servers", "localhost:9092",
+                                    "--transactional-id", "tx-1",
+                                    "--producer-id", "abc",
+                                    "--epoch", "5"
+                                }))
+                .isEqualTo(2);
+    }
+
+    @Test
+    void testEpochOverflowReturnsTwo() {
+        assertThat(
+                        KafkaTransactionTool.run(
+                                new String[] {
+                                    "--action", "commit",
+                                    "--bootstrap-servers", "localhost:9092",
+                                    "--transactional-id", "tx-1",
+                                    "--producer-id", "100",
+                                    "--epoch", "50000"
+                                }))
+                .isEqualTo(2);
+    }
+
+    @Test
+    void testNonNumericEpochReturnsTwo() {
+        assertThat(
+                        KafkaTransactionTool.run(
+                                new String[] {
+                                    "--action", "commit",
+                                    "--bootstrap-servers", "localhost:9092",
+                                    "--transactional-id", "tx-1",
+                                    "--producer-id", "100",
+                                    "--epoch", "xyz"
+                                }))
+                .isEqualTo(2);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@ under the License.
 
 	<modules>
 		<module>flink-connector-kafka</module>
+		<module>flink-connector-kafka-transaction-tool</module>
 		<module>flink-sql-connector-kafka</module>
 		<module>flink-connector-kafka-e2e-tests</module>
 		<module>flink-python</module>


### PR DESCRIPTION
## What is the purpose of the change

A standalone CLI tool (`KafkaTransactionTool`) that allows operators to manually abort or commit lingering Kafka transactions left behind when a Flink job with exactly-once Kafka sink stops unexpectedly (crash, kill, cancellation) and is not restarted.

Open transactions block downstream consumers using `read_committed` isolation (stuck LSO) and can lead to data loss - the data is checkpointed in Flink but never committed to Kafka, and will be lost when the transaction times out and is aborted by the broker.

The tool provides two operations:
- **Abort**: Fences the transactional producer via `initTransactions()`, causing the broker to abort the open transaction.
- **Commit**: Resumes the transaction using the exact producerId and epoch (stored in Flink checkpoint state via `KafkaCommittable`) and commits it.

## Brief change log

- Add `KafkaTransactionManager` - core logic for abort/commit operations
- Add `KafkaTransactionTool` - CLI entry point using commons-cli
- Package CLI as uber-jar via maven-shade-plugin

## Verifying this change

This change includes integration tests (`KafkaTransactionManagerITCase`) that:
- Create lingering transactions, abort them, and verify state
- Create lingering transactions, commit them with correct producerId/epoch, and verify committed records are readable
- Verify transaction handling during savepoint-based job lifecycle

Unit tests (`KafkaTransactionManagerTest`, `KafkaTransactionToolTest`) cover input validation and CLI argument parsing.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): yes (new submodule)
- The public API: no
- Anything that could affect deployment: no

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? JavaDoc + CLI `--help` output