### PR TITLE
[FLINK-39320] Include Kafka record metadata in deserialization error message

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaRecordEmitter.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaRecordEmitter.java
@@ -53,7 +53,13 @@ public class KafkaRecordEmitter<T>
             deserializationSchema.deserialize(consumerRecord, sourceOutputWrapper);
             splitState.setCurrentOffset(consumerRecord.offset() + 1);
         } catch (Exception e) {
-            throw new IOException("Failed to deserialize consumer record due to", e);
+            throw new IOException(
+                    String.format(
+                            "Failed to deserialize consumer record from topic=%s, partition=%d, offset=%d due to",
+                            consumerRecord.topic(),
+                            consumerRecord.partition(),
+                            consumerRecord.offset()),
+                    e);
         }
     }
 


### PR DESCRIPTION
When deserialization fails in `KafkaRecordEmitter`, the error message doesn't include which Kafka record caused the failure:

```
Failed to deserialize consumer record due to
```

In production environments with many topics and partitions, this makes root-cause analysis difficult. Engineers have to add custom logging and redeploy to locate the problematic record.

This change adds topic, partition, and offset to the exception message:

```
Failed to deserialize consumer record from topic=my-topic, partition=117, offset=448550177 due to
```

JIRA: https://issues.apache.org/jira/browse/FLINK-39320
