### PR TITLE
[FLINK-39608] Change KafkaDatasetFacet to extend DatasetConfigFacet to fix classloader issues

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/lineage/DefaultKafkaDatasetFacet.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/lineage/DefaultKafkaDatasetFacet.java
@@ -22,6 +22,9 @@ package org.apache.flink.connector.kafka.lineage;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.connector.kafka.source.KafkaPropertiesUtil;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
@@ -80,5 +83,19 @@ public class DefaultKafkaDatasetFacet implements KafkaDatasetFacet {
     @Override
     public String name() {
         return KAFKA_FACET_NAME;
+    }
+
+    @Override
+    public Map<String, String> config() {
+        if (properties == null) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> config = new HashMap<>();
+        for (String key : properties.stringPropertyNames()) {
+            config.put(key, properties.getProperty(key));
+        }
+
+        return config;
     }
 }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/lineage/KafkaDatasetFacet.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/lineage/KafkaDatasetFacet.java
@@ -20,13 +20,13 @@
 package org.apache.flink.connector.kafka.lineage;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+import org.apache.flink.streaming.api.lineage.DatasetConfigFacet;
 
 import java.util.Properties;
 
 /** Facet definition to contain all Kafka specific information on Kafka sources and sinks. */
 @PublicEvolving
-public interface KafkaDatasetFacet extends LineageDatasetFacet {
+public interface KafkaDatasetFacet extends DatasetConfigFacet {
     Properties getProperties();
 
     KafkaDatasetIdentifier getTopicIdentifier();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkTest.java
@@ -32,6 +32,8 @@ import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamNode;
+import org.apache.flink.streaming.api.lineage.DatasetConfigFacet;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
 import org.apache.flink.streaming.api.lineage.LineageVertex;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -106,17 +108,21 @@ public class KafkaSinkTest {
         assertThat(lineageVertex.datasets().get(0).namespace()).isEqualTo("kafka://host1");
         assertThat(lineageVertex.datasets().get(0).name()).isEqualTo("topic1");
 
-        assertThat(
-                        lineageVertex
-                                .datasets()
-                                .get(0)
-                                .facets()
-                                .get(DefaultKafkaDatasetFacet.KAFKA_FACET_NAME))
+        LineageDatasetFacet lineageDatasetFacet =
+                lineageVertex
+                        .datasets()
+                        .get(0)
+                        .facets()
+                        .get(DefaultKafkaDatasetFacet.KAFKA_FACET_NAME);
+        assertThat(lineageDatasetFacet)
                 .hasFieldOrPropertyWithValue("properties", kafkaProperties)
                 .hasFieldOrPropertyWithValue(
                         "topicIdentifier",
                         DefaultKafkaDatasetIdentifier.ofTopics(
                                 Collections.singletonList("topic1")));
+
+        assertThat(((DatasetConfigFacet) lineageDatasetFacet).config())
+                .containsEntry("bootstrap.servers", "host1;host2");
 
         assertThat(
                         lineageVertex

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceTest.java
@@ -161,6 +161,7 @@ public class KafkaSourceTest {
                         dataset.facets().get(DefaultKafkaDatasetFacet.KAFKA_FACET_NAME);
 
         assertThat(kafkaFacet.getProperties()).containsEntry("bootstrap.servers", "host1;host2");
+        assertThat(kafkaFacet.config()).containsEntry("bootstrap.servers", "host1;host2");
 
         assertThat(dataset.facets()).containsKey(DefaultTypeDatasetFacet.TYPE_FACET_NAME);
         assertThat(dataset.facets().get(DefaultTypeDatasetFacet.TYPE_FACET_NAME))


### PR DESCRIPTION
Currently OpenLineage event emitter relies on availability of custom Kafka facet in the classpath.
https://github.com/OpenLineage/OpenLineage/blob/main/integration/flink/flink2/src/main/java/io/openlineage/flink/util/KafkaDatasetFacetUtil.java#L25

This fails when Kafka connector is being loaded as part of user jar and openlineage library loaded as part of Flink distribution. 
Openlineage emitters gets loaded in ApplicationClassLoader , whereas the Kafka connector 
libs gets loaded into FlinkUserClassLoader.

In order to fix this, we make Kafka connector emit facet that is an instance of `org.apache.flink.streaming.api.lineage.DatasetConfigFacet`. Openlineage libs can then rely on the existence of facet by name and pull configs by casting to DatasetConfigFacet. This will avoid depending on Kafka connector classes to be in same class loader as lineage emitter libs.