### PR TITLE
[FLINK-38790] Update CI to Flink 2.2, adjust code

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,7 +28,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: &flink_versions [ 2.0.1, 2.1.1 ]
+        flink: &flink_versions [ 2.2.0, 2.1.1 ]
         jdk: &jdk_versions [ '11, 17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -33,7 +33,7 @@ jobs:
           flink: 2.2-SNAPSHOT,
           branch: main
         }, {
-          flink: 2.1.1,
+          flink: 2.1-SNAPSHOT,
           branch: main
         }, {
           flink: 2.0.1,

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/ExactlyOnceKafkaWriter.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/ExactlyOnceKafkaWriter.java
@@ -268,6 +268,7 @@ class ExactlyOnceKafkaWriter<IN> extends KafkaWriter<IN> {
 
     @Override
     public void close() throws Exception {
+        markClosed();
         closeAll(
                 this::abortCurrentProducer,
                 () -> closeAll(producerPool),

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
@@ -199,7 +199,7 @@ class KafkaWriter<IN>
 
     @Override
     public void close() throws Exception {
-        closed = true;
+        markClosed();
         LOG.debug("Closing writer with {}", currentProducer);
         closeAll(currentProducer);
         checkState(
@@ -208,6 +208,10 @@ class KafkaWriter<IN>
 
         // Rethrow exception for the case in which close is called before writer() and flush().
         checkAsyncException();
+    }
+
+    protected void markClosed() {
+        closed = true;
     }
 
     @VisibleForTesting

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/ExactlyOnceKafkaWriterTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/ExactlyOnceKafkaWriterTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.sink;
+
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.connector.kafka.sink.internal.FlinkKafkaInternalProducer;
+import org.apache.flink.connector.kafka.sink.internal.TransactionAbortStrategyImpl;
+import org.apache.flink.connector.kafka.sink.internal.TransactionNamingStrategyImpl;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.apache.flink.metrics.testutils.MetricListener;
+import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.TransactionAbortedException;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+
+/** Tests for {@link ExactlyOnceKafkaWriter}. */
+@ExtendWith(TestLoggerExtension.class)
+class ExactlyOnceKafkaWriterTest {
+
+    @Test
+    void testCloseIgnoresAbortTriggeredAsyncError() {
+        final SinkWriterMetricGroup metricGroup = createSinkWriterMetricGroup();
+        final Counter numRecordsOutErrors = metricGroup.getNumRecordsOutErrorsCounter();
+        final ExactlyOnceKafkaWriter<Integer> writer = createWriter(metricGroup);
+        writer.currentProducer =
+                new MockProducer(
+                        writer.deliveryCallback,
+                        new TransactionAbortedException("Transaction aborted during close"));
+
+        assertThatCode(writer::close).doesNotThrowAnyException();
+        assertThat(numRecordsOutErrors.getCount()).isEqualTo(0L);
+    }
+
+    @Test
+    void testClosePropagatesAsyncErrorReportedBeforeClose() {
+        final ExactlyOnceKafkaWriter<Integer> writer = createWriter(createSinkWriterMetricGroup());
+        writer.currentProducer = new MockProducer(writer.deliveryCallback, null);
+        writer.deliveryCallback.onCompletion(
+                null, new ProducerFencedException("Producer fenced before close"));
+
+        assertThatCode(writer::close).hasRootCauseExactlyInstanceOf(ProducerFencedException.class);
+    }
+
+    private static ExactlyOnceKafkaWriter<Integer> createWriter(SinkWriterMetricGroup metricGroup) {
+        return new ExactlyOnceKafkaWriter<>(
+                DeliveryGuarantee.EXACTLY_ONCE,
+                getKafkaClientConfiguration(),
+                "test-prefix",
+                new KafkaWriterTestBase.SinkInitContext(
+                        metricGroup, new KafkaWriterTestBase.TriggerTimeService(), null),
+                (element, context, timestamp) -> new ProducerRecord<>("topic", new byte[0]),
+                null,
+                TransactionAbortStrategyImpl.PROBING,
+                TransactionNamingStrategyImpl.INCREMENTING,
+                List.of());
+    }
+
+    private static SinkWriterMetricGroup createSinkWriterMetricGroup() {
+        return InternalSinkWriterMetricGroup.wrap(
+                new KafkaWriterTestBase.DummyOperatorMetricGroup(
+                        new MetricListener().getMetricGroup()));
+    }
+
+    private static Properties getKafkaClientConfiguration() {
+        Properties properties = new Properties();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1234");
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+
+        return properties;
+    }
+
+    private static class MockProducer extends FlinkKafkaInternalProducer<byte[], byte[]> {
+
+        private final Callback callback;
+        @Nullable private final RuntimeException abortException;
+
+        private MockProducer(Callback callback, @Nullable RuntimeException abortException) {
+            super(getKafkaClientConfiguration());
+            this.callback = callback;
+            this.abortException = abortException;
+        }
+
+        @Override
+        public boolean hasRecordsInTransaction() {
+            return abortException != null;
+        }
+
+        @Override
+        public void abortTransaction() {
+            callback.onCompletion(null, abortException);
+        }
+    }
+}


### PR DESCRIPTION
With Flink 2.2 `ExactlyOnceKafkaWriter.close()` aborted the transaction before the writer was marked closed, so `TransactionAbortedExceptions` from in-flight sends were recorded as real async producer failures and rethrown during cleanup. This could kill the MiniCluster TaskManager and leave the job restarting without slots.

The applied fix marks the writer closed before `closeAll` gets called. Shutdown related callbacks get ignored, but any prev async exceptions still surface properly. Added a regression test that validates the changed logic only suppresses shutdown-induced abort errors, not real async producer failures recorded before close, so the logic flow stays the same.

---
Also updated the `main` branch version to `SNAPSHOT` in `weekly.yml`, cause `main` refers to the unreleased latest state of the connector, so IMO it makes more sense to test against the latest unreleased core version state we plan to support with the upcoming connector relese.