### PR TITLE
[FLINK-38790] Update to Flink 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@ under the License.
 
 		<!-- Main Dependencies -->
 		<confluent.version>7.9.2</confluent.version>
-		<flink.version>2.1.0</flink.version>
+		<flink.version>2.2.0</flink.version>
 		<kafka.version>4.2.0</kafka.version>
 
 		<!-- Other Dependencies -->


### PR DESCRIPTION
This PR updates the Flink version to 2.2.0.

No mentionable change needed on the connector side.