### PR TITLE
[hotfix] Bump flink.version to 2.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@ under the License.
 
 		<!-- Main Dependencies -->
 		<confluent.version>7.9.2</confluent.version>
-		<flink.version>2.1.0</flink.version>
+		<flink.version>2.1.2</flink.version>
 		<kafka.version>4.2.0</kafka.version>
 
 		<!-- Other Dependencies -->


### PR DESCRIPTION
## Summary

Bumps `flink.version` from 2.1.0 to 2.1.2 in the root `pom.xml`. Patch-level Flink bump within the same minor; picks up the bug-fixes and dep updates from the 2.1.x line. No API changes expected on the connector side.

## Test plan

- [x] `mvn clean test-compile` on `flink-connector-kafka` passes against Flink 2.1.2.
- [ ] CI green.