### PR TITLE
[FLINK-39693] Bump jackson, log4j, assertj to address CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,11 +66,11 @@ under the License.
 		<commons-lang3.version>3.18.0</commons-lang3.version>
 		<httpcore.version>4.4.16</httpcore.version>
 		<httpclient.version>4.5.14</httpclient.version>
-		<jackson-bom.version>2.18.2</jackson-bom.version>
+		<jackson-bom.version>2.18.6</jackson-bom.version>
 		<javassist.version>3.30.2-GA</javassist.version>
 		<jsr305.version>1.3.9</jsr305.version>
 		<kryo.version>5.6.2</kryo.version>
-		<log4j.version>2.25.0</log4j.version>
+		<log4j.version>2.25.4</log4j.version>
 		<objenesis.version>3.4</objenesis.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<scala-library.version>${scala.binary.version}.20</scala-library.version>
@@ -81,7 +81,7 @@ under the License.
 
 		<!-- Test Dependencies -->
 		<archunit.version>1.4.1</archunit.version>
-		<assertj.version>3.27.3</assertj.version>
+		<assertj.version>3.27.7</assertj.version>
 		<docker-java-api.version>3.5.2</docker-java-api.version>
 		<guava.version>33.4.8-jre</guava.version>
 		<hamcrest.version>1.3</hamcrest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ under the License.
 		<commons-lang3.version>3.18.0</commons-lang3.version>
 		<httpcore.version>4.4.16</httpcore.version>
 		<httpclient.version>4.5.14</httpclient.version>
-		<jackson-bom.version>2.18.6</jackson-bom.version>
+		<jackson-bom.version>2.21.3</jackson-bom.version>
 		<javassist.version>3.30.2-GA</javassist.version>
 		<jsr305.version>1.3.9</jsr305.version>
 		<kryo.version>5.6.2</kryo.version>


### PR DESCRIPTION
## Summary

Bumps three dependency versions declared in the root `pom.xml`:

| Dep | From | To | Scope |
|---|---|---|---|
| `jackson-bom` | 2.18.2 | 2.21.3 | compile (ships in connector jar) |
| `log4j` | 2.25.0 | 2.25.4 | test |
| `assertj` | 3.27.3 | 3.27.7 | test |

`jackson-bom` aligns with what Flink master pins, so the connector and Flink stay on the same Jackson minor going forward. `log4j` and `assertj` are test-scope hygiene bumps.

## Test plan

- [x] `mvn clean test-compile` on `flink-connector-kafka` passes with the new versions.
- [ ] CI green.