### PR TITLE
[FLINK-39703][tests] Fix flaky KafkaWriterFaultToleranceITCase

### DIFF
--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
@@ -86,9 +86,11 @@ public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
                         DeliveryGuarantee.AT_LEAST_ONCE,
                         new SinkInitContext(metricGroup, timeService, null))) {
             writer.write(1, SINK_WRITER_CONTEXT);
+            writer.flush(false);
 
             KAFKA_CONTAINER.stop();
             try {
+                writer.write(1, SINK_WRITER_CONTEXT);
                 assertThatCode(() -> writer.flush(false))
                         .rootCause()
                         .isInstanceOfAny(NetworkException.class, TimeoutException.class);


### PR DESCRIPTION
testFlushExceptionWhenKafkaUnavailable is flaky because of a race condition between the Kafka producer's send pipeline and the Kafka container being stopped.