### PR TITLE
[FLINK-39728] Fix pauseOrResumeSplits race with unassigned partitions

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -240,14 +240,29 @@ public class KafkaPartitionSplitReader
     public void pauseOrResumeSplits(
             Collection<KafkaPartitionSplit> splitsToPause,
             Collection<KafkaPartitionSplit> splitsToResume) {
-        consumer.resume(
-                splitsToResume.stream()
-                        .map(KafkaPartitionSplit::getTopicPartition)
-                        .collect(Collectors.toList()));
-        consumer.pause(
-                splitsToPause.stream()
-                        .map(KafkaPartitionSplit::getTopicPartition)
-                        .collect(Collectors.toList()));
+        // Filter against current assignment to avoid IllegalStateException when a partition
+        // was concurrently unassigned by fetch() or removeEmptySplits().
+        Set<TopicPartition> assigned = consumer.assignment();
+        List<TopicPartition> toResume = new ArrayList<>();
+        for (KafkaPartitionSplit split : splitsToResume) {
+            TopicPartition tp = split.getTopicPartition();
+            if (assigned.contains(tp)) {
+                toResume.add(tp);
+            } else {
+                LOG.warn("Skipping resume for unassigned partition {}", tp);
+            }
+        }
+        List<TopicPartition> toPause = new ArrayList<>();
+        for (KafkaPartitionSplit split : splitsToPause) {
+            TopicPartition tp = split.getTopicPartition();
+            if (assigned.contains(tp)) {
+                toPause.add(tp);
+            } else {
+                LOG.warn("Skipping pause for unassigned partition {}", tp);
+            }
+        }
+        consumer.resume(toResume);
+        consumer.pause(toPause);
     }
 
     // ---------------

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -354,6 +354,29 @@ public class KafkaPartitionSplitReaderTest {
         assertThat(properties.containsKey(ConsumerConfig.CLIENT_RACK_CONFIG)).isFalse();
     }
 
+    @Test
+    void testPauseOrResumeSplitsWithUnassignedPartition() {
+        KafkaPartitionSplitReader reader = createReader();
+        // Create a split for a partition that is NOT assigned to the consumer.
+        // Without the fix, this would throw IllegalStateException:
+        // "No current assignment for partition".
+        TopicPartition unassignedPartition = new TopicPartition(TOPIC1, 0);
+        KafkaPartitionSplit unassignedSplit =
+                new KafkaPartitionSplit(unassignedPartition, KafkaPartitionSplit.EARLIEST_OFFSET);
+
+        // Verify the partition is indeed not assigned
+        assertThat(reader.consumer().assignment()).doesNotContain(unassignedPartition);
+
+        // This should be a no-op, not throw an exception
+        reader.pauseOrResumeSplits(
+                Collections.singletonList(unassignedSplit), Collections.emptyList());
+        reader.pauseOrResumeSplits(
+                Collections.emptyList(), Collections.singletonList(unassignedSplit));
+        reader.pauseOrResumeSplits(
+                Collections.singletonList(unassignedSplit),
+                Collections.singletonList(unassignedSplit));
+    }
+
     // ------------------
 
     private void assignSplitsAndFetchUntilFinish(KafkaPartitionSplitReader reader, int readerId)


### PR DESCRIPTION
When `pauseOrResumeSplits` is add to the mailbox thread, the set of splits it operates on reflects the mailbox thread's view *at start time*. 

By the time the SplitFetcher executes the action, a split may have already finished and been unassigned.

This can happen when the split-finished event has not yet propagated far enough to abort an in-flight alignment check on the `SourceOperator`. Calling `pause()` or `resume()` on a partition that is no longer in `consumer.assignment()` then throws `IllegalStateException`.

Generated-by: Claude Opus 4.6 (Anthropic)