### PR TITLE
[FLINK-39699][BP v4.0][tests] Stabilize flaky tests in KafkaSinkITCase and KafkaWriterFaultToleranceITCase

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,7 +28,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [ 2.0.0 ]
+        flink: [ 2.0.2 ]
         jdk: [ '11, 17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
@@ -37,7 +37,7 @@ jobs:
   python_test:
     strategy:
       matrix:
-        flink: [ 2.0.0 ]
+        flink: [ 2.0.2 ]
         jdk: [ '11, 17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -33,7 +33,7 @@ jobs:
           flink: 2.1-SNAPSHOT,
           branch: main
         }, {
-          flink: 2.0.0,
+          flink: 2.0.2,
           branch: main
         }, {
           flink: 1.19.1,

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
@@ -55,7 +55,6 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
-import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -120,6 +119,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -140,6 +140,8 @@ public class KafkaSinkITCase extends TestLogger {
     private static final Network NETWORK = Network.newNetwork();
     private static final int ZK_TIMEOUT_MILLIS = 30000;
     private static final short TOPIC_REPLICATION_FACTOR = 1;
+    private static final long CHECKPOINT_PATH_LOOKUP_TIMEOUT_SECONDS = 10;
+    private static final long CHECKPOINT_PATH_LOOKUP_POLL_INTERVAL_MILLIS = 200;
     private static AdminClient admin;
 
     private String topic;
@@ -329,11 +331,7 @@ public class KafkaSinkITCase extends TestLogger {
         } catch (Exception e) {
             assertThat(e).hasStackTraceContaining("Exceeded checkpoint tolerable failure");
         }
-        final Optional<String> completedCheckpoint =
-                CommonTestUtils.getLatestCompletedCheckpointPath(firstJobId, miniCluster);
-
-        assertThat(completedCheckpoint).isPresent();
-        config.set(SAVEPOINT_PATH, completedCheckpoint.get());
+        config.set(SAVEPOINT_PATH, waitForCompletedCheckpointPath(miniCluster, firstJobId));
 
         // Run a second job which aborts all lingering transactions and new consumer should
         // immediately see the newly written records
@@ -426,7 +424,7 @@ public class KafkaSinkITCase extends TestLogger {
                         "firstPrefix",
                         clusterClient);
 
-        config.set(SAVEPOINT_PATH, getCheckpointPath(miniCluster, firstJobId));
+        config.set(SAVEPOINT_PATH, waitForCompletedCheckpointPath(miniCluster, firstJobId));
         config.set(CoreOptions.DEFAULT_PARALLELISM, newParallelsm);
 
         // Run a second job which aborts all lingering transactions and new consumer should
@@ -441,7 +439,7 @@ public class KafkaSinkITCase extends TestLogger {
                         "secondPrefix",
                         clusterClient);
 
-        config.set(SAVEPOINT_PATH, getCheckpointPath(miniCluster, secondJobId));
+        config.set(SAVEPOINT_PATH, waitForCompletedCheckpointPath(miniCluster, secondJobId));
         config.set(CoreOptions.DEFAULT_PARALLELISM, oldParallelism);
 
         SharedReference<AtomicBoolean> failed = sharedObjects.add(new AtomicBoolean(true));
@@ -459,12 +457,27 @@ public class KafkaSinkITCase extends TestLogger {
         assertThat(committedRecords).containsExactlyInAnyOrderElementsOf(checkpointedRecords.get());
     }
 
-    private String getCheckpointPath(MiniCluster miniCluster, JobID secondJobId)
-            throws InterruptedException, ExecutionException, FlinkJobNotFoundException {
-        final Optional<String> completedCheckpoint =
-                CommonTestUtils.getLatestCompletedCheckpointPath(secondJobId, miniCluster);
-
-        assertThat(completedCheckpoint).isPresent();
+    private String waitForCompletedCheckpointPath(MiniCluster miniCluster, JobID jobId)
+            throws Exception {
+        // The CompletedCheckpointStats can briefly lag behind requestJobResult() returning,
+        // so poll with a bounded timeout instead of asserting on the first miss.
+        final long deadline =
+                System.nanoTime()
+                        + TimeUnit.SECONDS.toNanos(CHECKPOINT_PATH_LOOKUP_TIMEOUT_SECONDS);
+        Optional<String> completedCheckpoint = Optional.empty();
+        while (System.nanoTime() < deadline) {
+            completedCheckpoint =
+                    CommonTestUtils.getLatestCompletedCheckpointPath(jobId, miniCluster);
+            if (completedCheckpoint.isPresent()) {
+                return completedCheckpoint.get();
+            }
+            Thread.sleep(CHECKPOINT_PATH_LOOKUP_POLL_INTERVAL_MILLIS);
+        }
+        assertThat(completedCheckpoint)
+                .as(
+                        "Job %s did not expose a completed checkpoint within %ds",
+                        jobId, CHECKPOINT_PATH_LOOKUP_TIMEOUT_SECONDS)
+                .isPresent();
         return completedCheckpoint.get();
     }
 
@@ -499,7 +512,7 @@ public class KafkaSinkITCase extends TestLogger {
                         clusterClient);
 
         // Run a second job which switching to POOLING
-        config.set(SAVEPOINT_PATH, getCheckpointPath(miniCluster, firstJobId));
+        config.set(SAVEPOINT_PATH, waitForCompletedCheckpointPath(miniCluster, firstJobId));
         config.set(CoreOptions.DEFAULT_PARALLELISM, 5);
         JobID secondJobId2 =
                 executeWithMapper(
@@ -512,7 +525,7 @@ public class KafkaSinkITCase extends TestLogger {
                         clusterClient);
 
         // Run a third job with downscaling
-        config.set(SAVEPOINT_PATH, getCheckpointPath(miniCluster, secondJobId2));
+        config.set(SAVEPOINT_PATH, waitForCompletedCheckpointPath(miniCluster, secondJobId2));
         config.set(CoreOptions.DEFAULT_PARALLELISM, 3);
         JobID thirdJobId =
                 executeWithMapper(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
@@ -61,10 +61,12 @@ public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
                         new SinkInitContext(metricGroup, timeService, null))) {
 
             writer.write(1, SINK_WRITER_CONTEXT);
+            writer.getCurrentProducer().flush();
 
             KAFKA_CONTAINER.stop();
 
             try {
+                writer.write(1, SINK_WRITER_CONTEXT);
                 writer.getCurrentProducer().flush();
                 assertThatCode(() -> writer.write(1, SINK_WRITER_CONTEXT))
                         .rootCause()
@@ -84,9 +86,11 @@ public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
                         DeliveryGuarantee.AT_LEAST_ONCE,
                         new SinkInitContext(metricGroup, timeService, null))) {
             writer.write(1, SINK_WRITER_CONTEXT);
+            writer.flush(false);
 
             KAFKA_CONTAINER.stop();
             try {
+                writer.write(1, SINK_WRITER_CONTEXT);
                 assertThatCode(() -> writer.flush(false))
                         .rootCause()
                         .isInstanceOfAny(NetworkException.class, TimeoutException.class);
@@ -106,10 +110,12 @@ public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
                         new SinkInitContext(metricGroup, timeService, null));
 
         writer.write(1, SINK_WRITER_CONTEXT);
+        writer.getCurrentProducer().flush();
 
         KAFKA_CONTAINER.stop();
 
         try {
+            writer.write(1, SINK_WRITER_CONTEXT);
             writer.getCurrentProducer().flush();
             // closing producer resource throws exception first
             assertThatCode(() -> writer.close())


### PR DESCRIPTION
Backport of [FLINK-39699] (PR #254) from `main` to `v4.0`.

## Why

Both `KafkaSinkITCase` and `KafkaWriterFaultToleranceITCase` are recurring failures in the Weekly Flink Connector Kafka CI on `v4.0` (Flink 2.0.1). FLINK-39699 stabilized both on `main` but was never backported.

## What

Two of the three FLINK-39699 commits, both of which cherry-pick cleanly onto `v4.0`:

- **Wait for completed checkpoint stats in KafkaSinkITCase** (`2d441987`) — fixes the intermittent `containsExactlyInAnyOrderElementsOf` assertion failure (e.g. `testAbortTransactionsAfterScaleInBeforeFirstCheckpoint`) by waiting for a completed checkpoint before asserting on committed records.
- **Stabilize KafkaWriterFaultToleranceITCase exception-on-unavailable tests** (`887d5941`) — drains a warm-up record before stopping the broker so the operation under test reliably surfaces the expected `NetworkException`/`TimeoutException` instead of an "actual not to be null" failure.

The third FLINK-39699 commit (`443c0f32`, partition-assignment wait) is intentionally **omitted**: it depends on the `createNewTopicAndWaitForPartitionAssignment` helper introduced separately by FLINK-39234, which is not on `v4.0`. The two commits here already cover both observed weekly failures.

## Verification

- `mvn clean test-compile -pl flink-connector-kafka` succeeds on `v4.0`.
- `spotless:check` passes.
- The integration tests were not run against the live flaky scenario (Docker-based, flaky by nature); efficacy is best confirmed across weekly CI cycles.

Generated-by: Claude Code (Opus 4.8)


---

## Also includes a CI hotfix

`[hotfix] Bump CI Flink version to 2.0.2` is bundled here because the `v4.0` CI was already red for an unrelated reason: `flink-2.0.0` binaries have been dropped from `dlcdn.apache.org`, so the workflow download step failed with an empty archive on every PR to this branch. The commit bumps the `push_pr.yml` and `weekly.yml` matrices from `2.0.0` to `2.0.2` (latest 2.0.x on the CDN). `pom.xml` `<flink.version>` is intentionally left unchanged.
