### PR TITLE
[hotfix] fix depenedency version of kafka connector in documentation

### DIFF
--- a/docs/data/kafka.yml
+++ b/docs/data/kafka.yml
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+version: 5.0.0
+flink_compatibility: ["2.1","2.2"]
+variants:
+  - maven: flink-connector-kafka
+    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka/$full_version/flink-sql-connector-kafka-$full_version.jar


### PR DESCRIPTION
Hi @ferenc-csaky,

I have observed that there is a missing kafka.yml file in v5.0 release due to which there is some misleading information in the documentation of Flink as shown in the image: 
<img width="911" height="338" alt="flinkdocumentationissue" src="https://github.com/user-attachments/assets/37a4cb34-f263-4500-ac14-45b71474f299" />
 
Please verify this change.
