### PR TITLE
[FLINK-39941][tests] Drop Python 3.8 from the flink-python tox envlist

### DIFF
--- a/flink-python/tox.ini
+++ b/flink-python/tox.ini
@@ -21,7 +21,7 @@
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions.
 # new environments will be excluded by default unless explicitly added to envlist.
-envlist = {py38, py39, py310}-cython
+envlist = {py39, py310}-cython
 
 [testenv]
 whitelist_externals = /bin/bash


### PR DESCRIPTION
The weekly CI Python test job fails on the v4.0 branch in the py38-cython tox environment (Python 3.8):
https://github.com/apache/flink-connector-kafka/actions/runs/27484280508/job/81237466038 

This is toolchain drift, not a connector code change. The tox Python environments bootstrap pip unpinned (is not fixed). Modern pip no longer supports Python 3.8, even its own code uses a Python 3.10+ feature, so pip crashes on import under Python 3.8 and cannot install apache-flink.

This PR is a DRAFT. Work is in progress. Potentially there is another option to not drop testing with 3.8 (because Flink 2.0.2 still supports it).