### PR TITLE
[FLINK-39193][Kafka Connector] Use reset strategy for missing specified offsets

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializer.java
@@ -160,6 +160,7 @@ public interface OffsetsInitializer extends Serializable {
 
     /**
      * Get an {@link OffsetsInitializer} which initializes the offsets to the specified offsets.
+     * Partitions without specified offsets will be initialized to their earliest offsets.
      *
      * @param offsets the specified offsets for each partition.
      * @return an {@link OffsetsInitializer} which initializes the offsets to the specified offsets.
@@ -171,11 +172,11 @@ public interface OffsetsInitializer extends Serializable {
     /**
      * Get an {@link OffsetsInitializer} which initializes the offsets to the specified offsets. Use
      * the given {@link OffsetResetStrategy} to initialize the offsets in case the specified offset
-     * is out of range.
+     * is out of range, or in case a partition does not have a specified offset.
      *
      * @param offsets the specified offsets for each partition.
      * @param offsetResetStrategy the {@link OffsetResetStrategy} to use when the specified offset
-     *     is out of range.
+     *     is out of range or missing.
      * @return an {@link OffsetsInitializer} which initializes the offsets to the specified offsets.
      */
     static OffsetsInitializer offsets(

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializer.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializer.java
@@ -38,8 +38,8 @@ import static org.apache.flink.util.Preconditions.checkState;
  * An implementation of {@link OffsetsInitializer} which initializes the offsets of the partition
  * according to the user specified offsets.
  *
- * <p>Use specified offsets for specified partitions while use commit offsets or offsetResetStrategy
- * for unspecified partitions. Specified partition's offset should be less than its latest offset,
+ * <p>Use specified offsets for specified partitions while using the offsetResetStrategy for
+ * unspecified partitions. Specified partition's offset should be less than its latest offset,
  * otherwise it will start from the offsetResetStrategy. The default value of offsetResetStrategy is
  * earliest.
  *
@@ -61,32 +61,27 @@ class SpecifiedOffsetsInitializer implements OffsetsInitializer, OffsetsInitiali
             Collection<TopicPartition> partitions,
             PartitionOffsetsRetriever partitionOffsetsRetriever) {
         Map<TopicPartition, Long> offsets = new HashMap<>();
-        List<TopicPartition> toLookup = new ArrayList<>();
+        List<TopicPartition> unspecifiedPartitions = new ArrayList<>();
         for (TopicPartition tp : partitions) {
             Long offset = initialOffsets.get(tp);
             if (offset == null) {
-                toLookup.add(tp);
+                unspecifiedPartitions.add(tp);
             } else {
                 offsets.put(tp, offset);
             }
         }
-        if (!toLookup.isEmpty()) {
-            // First check the committed offsets.
-            Map<TopicPartition, Long> committedOffsets =
-                    partitionOffsetsRetriever.committedOffsets(toLookup);
-            offsets.putAll(committedOffsets);
-            toLookup.removeAll(committedOffsets.keySet());
-
+        if (!unspecifiedPartitions.isEmpty()) {
             switch (offsetResetStrategy) {
                 case EARLIEST:
-                    offsets.putAll(partitionOffsetsRetriever.beginningOffsets(toLookup));
+                    offsets.putAll(
+                            partitionOffsetsRetriever.beginningOffsets(unspecifiedPartitions));
                     break;
                 case LATEST:
-                    offsets.putAll(partitionOffsetsRetriever.endOffsets(toLookup));
+                    offsets.putAll(partitionOffsetsRetriever.endOffsets(unspecifiedPartitions));
                     break;
                 default:
                     throw new IllegalStateException(
-                            "Cannot find initial offsets for partitions: " + toLookup);
+                            "Cannot find initial offsets for partitions: " + unspecifiedPartitions);
             }
         }
         return offsets;

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/OffsetsInitializerTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.connector.kafka.source.enumerator.KafkaSourceEnumerator;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
 import org.apache.flink.connector.kafka.testutils.KafkaSourceTestEnv;
 
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.AfterAll;
@@ -132,27 +131,23 @@ class OffsetsInitializerTest {
     void testSpecificOffsetsInitializer() {
         Map<TopicPartition, Long> specifiedOffsets = new HashMap<>();
         List<TopicPartition> partitions = KafkaSourceTestEnv.getPartitionsForTopic(TOPIC);
-        Map<TopicPartition, OffsetAndMetadata> committedOffsets =
-                KafkaSourceTestEnv.getCommittedOffsets(partitions);
         partitions.forEach(tp -> specifiedOffsets.put(tp, (long) tp.partition()));
         // Remove the specified offsets for partition 0.
-        TopicPartition partitionSetToCommitted = new TopicPartition(TOPIC, 0);
-        specifiedOffsets.remove(partitionSetToCommitted);
+        TopicPartition partitionSetToEarliest = new TopicPartition(TOPIC, 0);
+        specifiedOffsets.remove(partitionSetToEarliest);
         OffsetsInitializer initializer = OffsetsInitializer.offsets(specifiedOffsets);
 
         assertThat(initializer.getAutoOffsetResetStrategy())
                 .isEqualTo(OffsetResetStrategy.EARLIEST);
-        // The partition without committed offset should fallback to offset reset strategy.
-        TopicPartition partitionSetToEarliest = new TopicPartition(TOPIC2, 0);
-        partitions.add(partitionSetToEarliest);
+        // The partitions without specified offsets should fallback to offset reset strategy.
+        TopicPartition partitionWithoutSpecifiedOffset = new TopicPartition(TOPIC2, 0);
+        partitions.add(partitionWithoutSpecifiedOffset);
 
         Map<TopicPartition, Long> offsets = initializer.getPartitionOffsets(partitions, retriever);
         for (TopicPartition tp : partitions) {
             Long offset = offsets.get(tp);
             long expectedOffset;
-            if (tp.equals(partitionSetToCommitted)) {
-                expectedOffset = committedOffsets.get(tp).offset();
-            } else if (tp.equals(partitionSetToEarliest)) {
+            if (tp.equals(partitionSetToEarliest) || tp.equals(partitionWithoutSpecifiedOffset)) {
                 expectedOffset = 0L;
             } else {
                 expectedOffset = specifiedOffsets.get(tp);

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializerTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/initializer/SpecifiedOffsetsInitializerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator.initializer;
+
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link SpecifiedOffsetsInitializer}. */
+class SpecifiedOffsetsInitializerTest {
+
+    @Test
+    void incompleteSpecificOffsetsUsesResetStrategyWithoutCommittedOffsetLookup() {
+        TopicPartition specifiedPartition = new TopicPartition("topic", 0);
+        TopicPartition unspecifiedPartition = new TopicPartition("topic", 1);
+        OffsetsInitializer initializer =
+                OffsetsInitializer.offsets(Map.of(specifiedPartition, 111L));
+
+        Map<TopicPartition, Long> offsets =
+                initializer.getPartitionOffsets(
+                        List.of(specifiedPartition, unspecifiedPartition),
+                        new OffsetsInitializer.PartitionOffsetsRetriever() {
+                            @Override
+                            public Map<TopicPartition, Long> committedOffsets(
+                                    Collection<TopicPartition> partitions) {
+                                throw new AssertionError(
+                                        "Committed offsets should not be used for incomplete specific offsets");
+                            }
+
+                            @Override
+                            public Map<TopicPartition, Long> endOffsets(
+                                    Collection<TopicPartition> partitions) {
+                                throw new AssertionError("Latest offsets should not be used");
+                            }
+
+                            @Override
+                            public Map<TopicPartition, Long> beginningOffsets(
+                                    Collection<TopicPartition> partitions) {
+                                assertThat(partitions).containsExactly(unspecifiedPartition);
+                                return Map.of(unspecifiedPartition, 0L);
+                            }
+
+                            @Override
+                            public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(
+                                    Map<TopicPartition, Long> timestampsToSearch) {
+                                throw new AssertionError("Timestamp offsets should not be used");
+                            }
+                        });
+
+        assertThat(offsets)
+                .containsEntry(specifiedPartition, 111L)
+                .containsEntry(unspecifiedPartition, 0L)
+                .hasSize(2);
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `SpecifiedOffsetsInitializer` so partitions missing from a non-empty specific-offset map use the configured `OffsetResetStrategy` instead of querying committed offsets first.
- Clarify the Java `OffsetsInitializer.offsets(...)` documentation for missing specified offsets.
- Add a focused regression test proving incomplete specific-offset maps do not call `committedOffsets(...)`.

## Root Cause

`SpecifiedOffsetsInitializer#getPartitionOffsets` treated partitions not present in the caller-provided specific-offset map as candidates for committed-offset lookup before falling back to the reset strategy. For callers that provide a specific-offset map without relying on committed offsets, this can fail when the Kafka source cannot query committed offsets (for example because the consumer group/commit path is unavailable), even though the configured reset strategy should be enough to initialize the missing partitions.

## Changes

- For unspecified partitions, apply `EARLIEST`, `LATEST`, or `NONE` directly via the configured reset strategy.
- Update the existing offset initializer expectation from committed-offset fallback to reset-strategy fallback.
- Add `SpecifiedOffsetsInitializerTest#incompleteSpecificOffsetsUsesResetStrategyWithoutCommittedOffsetLookup`.

## Validation

- `mvn -pl flink-connector-kafka -Dtest=SpecifiedOffsetsInitializerTest#incompleteSpecificOffsetsUsesResetStrategyWithoutCommittedOffsetLookup -DfailIfNoTests=false test`
  - Verified RED before the fix: failed because `committedOffsets(...)` was called.
  - Verified GREEN after the fix: `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`.
- `mvn -pl flink-connector-kafka -DskipTests test`
  - `You have 0 Checkstyle violations`.
  - `Spotless.Java ... 0 needs changes`.
  - `BUILD SUCCESS`.

Note: I did not claim full module tests locally. A Docker-backed existing `OffsetsInitializerTest` baseline attempt was blocked by a missing valid Docker environment, so I kept validation to the focused unit regression plus module compile/checkstyle/spotless.

## AI Assistance

This pull request was prepared with AI assistance under human-directed scope for FLINK-39193.
