### PR TITLE
[FLINK-39979][Connectors/Kafka] Mark DynamicKafkaSource reader idle when metadata removes all active clusters

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
@@ -102,6 +102,7 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
     private int availabilityHelperSize;
     private boolean isActivelyConsumingSplits;
     private boolean isNoMoreSplits;
+    private boolean dynamicOutputIdle;
     private AtomicBoolean restartingReaders;
     private ReaderOutput<T> latestReaderOutput;
 
@@ -127,6 +128,7 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
                 new MultipleFuturesAvailabilityHelper(this.availabilityHelperSize = 0);
         this.isNoMoreSplits = false;
         this.isActivelyConsumingSplits = false;
+        this.dynamicOutputIdle = false;
         this.restartingReaders = new AtomicBoolean();
         this.clustersProperties = new HashMap<>();
         this.pendingSplitOutputReleases = new HashSet<>();
@@ -148,6 +150,7 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
     public InputStatus pollNext(ReaderOutput<T> readerOutput) throws Exception {
         latestReaderOutput = readerOutput;
         releasePendingSplitOutputs(readerOutput);
+        maybeUpdateNoSubReaderOutputIdleness(readerOutput);
 
         // at startup, do not return end of input if metadata event has not been received
         if (clusterReaderMap.isEmpty()) {
@@ -678,6 +681,16 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
         retainedSplits.removeIf(
                 split -> split.isRetained() && !split.isRetained(currentTimeMillis));
         pendingSplits.removeIf(split -> split.isRetained() && !split.isRetained(currentTimeMillis));
+    }
+
+    private void maybeUpdateNoSubReaderOutputIdleness(ReaderOutput<T> readerOutput) {
+        if (clusterReaderMap.isEmpty() && isActivelyConsumingSplits && !dynamicOutputIdle) {
+            readerOutput.markIdle();
+            dynamicOutputIdle = true;
+        } else if (!clusterReaderMap.isEmpty() && dynamicOutputIdle) {
+            readerOutput.markActive();
+            dynamicOutputIdle = false;
+        }
     }
 
     static Configuration toConfiguration(Properties props) {

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
@@ -595,6 +595,12 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
                         this.availabilityHelperSize = clusterReaderMap.size());
         syncAvailabilityHelperWithReaders();
 
+        if (clusterReaderMap.isEmpty()) {
+            restartingReaders.set(false);
+            cachedPreviousFuture.complete(null);
+            return;
+        }
+
         // We cannot immediately complete the previous future here. We must complete it only when
         // the new readers have finished handling the split assignment. Completing the future too
         // early can cause WakeupException (implicitly woken up by invocation to pollNext()) if the

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.dynamic.source.reader;
+
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.connector.kafka.dynamic.metadata.ClusterMetadata;
+import org.apache.flink.connector.kafka.dynamic.metadata.KafkaStream;
+import org.apache.flink.connector.kafka.dynamic.source.MetadataUpdateEvent;
+import org.apache.flink.connector.kafka.dynamic.source.split.DynamicKafkaSourceSplit;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
+import org.apache.flink.core.io.InputStatus;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests idleness transitions for {@link DynamicKafkaSourceReader}. */
+class DynamicKafkaSourceReaderIdlenessTest {
+    private static final String TOPIC = "topic";
+    private static final String KAFKA_CLUSTER_ID = "cluster-1";
+
+    @Test
+    void testMetadataRemovalMarksReaderIdleWhenAllSubReadersRemoved() throws Exception {
+        TestingReaderContext context = new TestingReaderContext();
+        try (DynamicKafkaSourceReader<byte[]> reader =
+                new DynamicKafkaSourceReader<>(
+                        context,
+                        KafkaRecordDeserializationSchema.valueOnly(ByteArrayDeserializer.class),
+                        getRequiredProperties())) {
+            reader.start();
+            reader.handleSourceEvents(getMetadataUpdateEvent());
+
+            DynamicKafkaSourceSplit split =
+                    new DynamicKafkaSourceSplit(
+                            KAFKA_CLUSTER_ID,
+                            new KafkaPartitionSplit(
+                                    new TopicPartition(TOPIC, 0),
+                                    0L,
+                                    KafkaPartitionSplit.NO_STOPPING_OFFSET));
+            reader.addSplits(Collections.singletonList(split));
+
+            reader.handleSourceEvents(getEmptyMetadataUpdateEvent());
+
+            TrackingReaderOutputWithIdleness<byte[]> readerOutput =
+                    new TrackingReaderOutputWithIdleness<>();
+            assertThat(reader.pollNext(readerOutput)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+            assertThat(readerOutput.releasedSplitIds()).containsExactly(split.splitId());
+            assertThat(readerOutput.idleCount()).isEqualTo(1);
+            assertThat(readerOutput.isIdle()).isTrue();
+        }
+    }
+
+    private static MetadataUpdateEvent getMetadataUpdateEvent() {
+        Properties clusterProperties = new Properties();
+        clusterProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        ClusterMetadata clusterMetadata =
+                new ClusterMetadata(Collections.singleton(TOPIC), clusterProperties);
+        return new MetadataUpdateEvent(
+                Collections.singleton(
+                        new KafkaStream(
+                                TOPIC,
+                                Collections.singletonMap(KAFKA_CLUSTER_ID, clusterMetadata))));
+    }
+
+    private static MetadataUpdateEvent getEmptyMetadataUpdateEvent() {
+        return new MetadataUpdateEvent(
+                Collections.singleton(
+                        new KafkaStream(TOPIC, Collections.<String, ClusterMetadata>emptyMap())));
+    }
+
+    private static Properties getRequiredProperties() {
+        Properties properties = new Properties();
+        properties.setProperty(
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                ByteArrayDeserializer.class.getName());
+        properties.setProperty(
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                ByteArrayDeserializer.class.getName());
+        return properties;
+    }
+
+    private static class TrackingReaderOutputWithIdleness<E> extends TestingReaderOutput<E> {
+        private int idleCount;
+        private boolean idle;
+        private final List<String> releasedSplitIds = new ArrayList<>();
+
+        @Override
+        public void emitWatermark(Watermark watermark) {}
+
+        @Override
+        public void markIdle() {
+            idleCount++;
+            idle = true;
+        }
+
+        @Override
+        public void releaseOutputForSplit(String splitId) {
+            releasedSplitIds.add(splitId);
+        }
+
+        private int idleCount() {
+            return idleCount;
+        }
+
+        private boolean isIdle() {
+            return idle;
+        }
+
+        private List<String> releasedSplitIds() {
+            return releasedSplitIds;
+        }
+    }
+}

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -66,7 +67,11 @@ class DynamicKafkaSourceReaderIdlenessTest {
                                     KafkaPartitionSplit.NO_STOPPING_OFFSET));
             reader.addSplits(Collections.singletonList(split));
 
+            CompletableFuture<Void> availabilityFuture = reader.isAvailable();
+            assertThat(availabilityFuture).isNotDone();
+
             reader.handleSourceEvents(getEmptyMetadataUpdateEvent());
+            assertThat(availabilityFuture).isDone();
 
             TrackingReaderOutputWithIdleness<byte[]> readerOutput =
                     new TrackingReaderOutputWithIdleness<>();


### PR DESCRIPTION
## What is the purpose of the change

`DynamicKafkaSource` can remain active after a metadata update removes the last active Kafka cluster/split from a reader subtask. Since no sub-reader remains to report idleness, downstream watermark progress can stall.

This is based on openai/flink-connector-kafka#73 and adapted for Apache main.

## Brief change log

- Treat an actively consuming dynamic reader with zero active sub-readers as idle, and mark it active again when sub-readers return.
- Complete the previous availability future when resetting availability to zero sub-readers.
- Add no-Docker regression coverage for removing the last active cluster/split, releasing the split output, and completing the availability transition.

## Verifying this change

- `mvn -f flink-connector-kafka/pom.xml -Dtest=DynamicKafkaSourceReaderIdlenessTest test`
