### PR TITLE
[FLINK-39979] DynamicKafkaSource should mark reader idle when metadata removal leaves a subtask with no active subreaders

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
@@ -102,6 +102,7 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
     private int availabilityHelperSize;
     private boolean isActivelyConsumingSplits;
     private boolean isNoMoreSplits;
+    private boolean dynamicOutputIdle;
     private AtomicBoolean restartingReaders;
     private ReaderOutput<T> latestReaderOutput;
 
@@ -127,6 +128,7 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
                 new MultipleFuturesAvailabilityHelper(this.availabilityHelperSize = 0);
         this.isNoMoreSplits = false;
         this.isActivelyConsumingSplits = false;
+        this.dynamicOutputIdle = false;
         this.restartingReaders = new AtomicBoolean();
         this.clustersProperties = new HashMap<>();
         this.pendingSplitOutputReleases = new HashSet<>();
@@ -148,6 +150,7 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
     public InputStatus pollNext(ReaderOutput<T> readerOutput) throws Exception {
         latestReaderOutput = readerOutput;
         releasePendingSplitOutputs(readerOutput);
+        maybeUpdateNoSubReaderOutputIdleness(readerOutput);
 
         // at startup, do not return end of input if metadata event has not been received
         if (clusterReaderMap.isEmpty()) {
@@ -678,6 +681,16 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
         retainedSplits.removeIf(
                 split -> split.isRetained() && !split.isRetained(currentTimeMillis));
         pendingSplits.removeIf(split -> split.isRetained() && !split.isRetained(currentTimeMillis));
+    }
+
+    private void maybeUpdateNoSubReaderOutputIdleness(ReaderOutput<T> readerOutput) {
+        if (clusterReaderMap.isEmpty() && isActivelyConsumingSplits && !dynamicOutputIdle) {
+            readerOutput.markIdle();
+            dynamicOutputIdle = true;
+        } else if (!clusterReaderMap.isEmpty() && dynamicOutputIdle) {
+            readerOutput.markActive();
+            dynamicOutputIdle = false;
+        }
     }
 
     static Configuration toConfiguration(Properties props) {

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
@@ -595,6 +595,12 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
                         this.availabilityHelperSize = clusterReaderMap.size());
         syncAvailabilityHelperWithReaders();
 
+        if (clusterReaderMap.isEmpty()) {
+            restartingReaders.set(false);
+            cachedPreviousFuture.complete(null);
+            return;
+        }
+
         // We cannot immediately complete the previous future here. We must complete it only when
         // the new readers have finished handling the split assignment. Completing the future too
         // early can cause WakeupException (implicitly woken up by invocation to pollNext()) if the

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
@@ -150,7 +150,7 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
     public InputStatus pollNext(ReaderOutput<T> readerOutput) throws Exception {
         latestReaderOutput = readerOutput;
         releasePendingSplitOutputs(readerOutput);
-        maybeUpdateNoSubReaderOutputIdleness(readerOutput);
+        maybeUpdateNoActiveSplitOutputIdleness(readerOutput);
 
         // at startup, do not return end of input if metadata event has not been received
         if (clusterReaderMap.isEmpty()) {
@@ -595,7 +595,7 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
                         this.availabilityHelperSize = clusterReaderMap.size());
         syncAvailabilityHelperWithReaders();
 
-        if (clusterReaderMap.isEmpty()) {
+        if (getNumberOfActiveSplits() == 0) {
             restartingReaders.set(false);
             cachedPreviousFuture.complete(null);
             return;
@@ -689,11 +689,18 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
         pendingSplits.removeIf(split -> split.isRetained() && !split.isRetained(currentTimeMillis));
     }
 
-    private void maybeUpdateNoSubReaderOutputIdleness(ReaderOutput<T> readerOutput) {
-        if (clusterReaderMap.isEmpty() && isActivelyConsumingSplits && !dynamicOutputIdle) {
+    private int getNumberOfActiveSplits() {
+        return clusterReaderMap.values().stream()
+                .mapToInt(KafkaSourceReader::getNumberOfCurrentlyAssignedSplits)
+                .sum();
+    }
+
+    private void maybeUpdateNoActiveSplitOutputIdleness(ReaderOutput<T> readerOutput) {
+        boolean hasActiveSplits = getNumberOfActiveSplits() > 0;
+        if (!hasActiveSplits && isActivelyConsumingSplits && !dynamicOutputIdle) {
             readerOutput.markIdle();
             dynamicOutputIdle = true;
-        } else if (!clusterReaderMap.isEmpty() && dynamicOutputIdle) {
+        } else if (hasActiveSplits && dynamicOutputIdle) {
             readerOutput.markActive();
             dynamicOutputIdle = false;
         }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
@@ -45,10 +45,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Tests idleness transitions for {@link DynamicKafkaSourceReader}. */
 class DynamicKafkaSourceReaderIdlenessTest {
     private static final String TOPIC = "topic";
+    private static final String REMAINING_TOPIC = "remaining-topic";
     private static final String KAFKA_CLUSTER_ID = "cluster-1";
 
     @Test
-    void testMetadataRemovalMarksReaderIdleWhenAllSubReadersRemoved() throws Exception {
+    void testMetadataRemovalMarksReaderIdleWhenAllActiveSplitsRemoved() throws Exception {
         TestingReaderContext context = new TestingReaderContext();
         try (DynamicKafkaSourceReader<byte[]> reader =
                 new DynamicKafkaSourceReader<>(
@@ -70,34 +71,35 @@ class DynamicKafkaSourceReaderIdlenessTest {
             CompletableFuture<Void> availabilityFuture = reader.isAvailable();
             assertThat(availabilityFuture).isNotDone();
 
-            reader.handleSourceEvents(getEmptyMetadataUpdateEvent());
+            reader.handleSourceEvents(getMetadataUpdateEvent(REMAINING_TOPIC));
+            assertThat(reader.getAvailabilityHelperSize()).isEqualTo(1);
             assertThat(availabilityFuture).isDone();
 
             TrackingReaderOutputWithIdleness<byte[]> readerOutput =
                     new TrackingReaderOutputWithIdleness<>();
             assertThat(reader.pollNext(readerOutput)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+            assertThat(reader.pollNext(readerOutput)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
             assertThat(readerOutput.releasedSplitIds()).containsExactly(split.splitId());
             assertThat(readerOutput.idleCount()).isEqualTo(1);
+            assertThat(readerOutput.activeCount()).isZero();
             assertThat(readerOutput.isIdle()).isTrue();
         }
     }
 
     private static MetadataUpdateEvent getMetadataUpdateEvent() {
+        return getMetadataUpdateEvent(TOPIC);
+    }
+
+    private static MetadataUpdateEvent getMetadataUpdateEvent(String topic) {
         Properties clusterProperties = new Properties();
         clusterProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         ClusterMetadata clusterMetadata =
-                new ClusterMetadata(Collections.singleton(TOPIC), clusterProperties);
+                new ClusterMetadata(Collections.singleton(topic), clusterProperties);
         return new MetadataUpdateEvent(
                 Collections.singleton(
                         new KafkaStream(
                                 TOPIC,
                                 Collections.singletonMap(KAFKA_CLUSTER_ID, clusterMetadata))));
-    }
-
-    private static MetadataUpdateEvent getEmptyMetadataUpdateEvent() {
-        return new MetadataUpdateEvent(
-                Collections.singleton(
-                        new KafkaStream(TOPIC, Collections.<String, ClusterMetadata>emptyMap())));
     }
 
     private static Properties getRequiredProperties() {
@@ -113,6 +115,7 @@ class DynamicKafkaSourceReaderIdlenessTest {
 
     private static class TrackingReaderOutputWithIdleness<E> extends TestingReaderOutput<E> {
         private int idleCount;
+        private int activeCount;
         private boolean idle;
         private final List<String> releasedSplitIds = new ArrayList<>();
 
@@ -126,12 +129,22 @@ class DynamicKafkaSourceReaderIdlenessTest {
         }
 
         @Override
+        public void markActive() {
+            activeCount++;
+            idle = false;
+        }
+
+        @Override
         public void releaseOutputForSplit(String splitId) {
             releasedSplitIds.add(splitId);
         }
 
         private int idleCount() {
             return idleCount;
+        }
+
+        private int activeCount() {
+            return activeCount;
         }
 
         private boolean isIdle() {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.dynamic.source.reader;
+
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.connector.kafka.dynamic.metadata.ClusterMetadata;
+import org.apache.flink.connector.kafka.dynamic.metadata.KafkaStream;
+import org.apache.flink.connector.kafka.dynamic.source.MetadataUpdateEvent;
+import org.apache.flink.connector.kafka.dynamic.source.split.DynamicKafkaSourceSplit;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
+import org.apache.flink.core.io.InputStatus;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests idleness transitions for {@link DynamicKafkaSourceReader}. */
+class DynamicKafkaSourceReaderIdlenessTest {
+    private static final String TOPIC = "topic";
+    private static final String KAFKA_CLUSTER_ID = "cluster-1";
+
+    @Test
+    void testMetadataRemovalMarksReaderIdleWhenAllSubReadersRemoved() throws Exception {
+        TestingReaderContext context = new TestingReaderContext();
+        try (DynamicKafkaSourceReader<byte[]> reader =
+                new DynamicKafkaSourceReader<>(
+                        context,
+                        KafkaRecordDeserializationSchema.valueOnly(ByteArrayDeserializer.class),
+                        getRequiredProperties())) {
+            reader.start();
+            reader.handleSourceEvents(getMetadataUpdateEvent());
+
+            DynamicKafkaSourceSplit split =
+                    new DynamicKafkaSourceSplit(
+                            KAFKA_CLUSTER_ID,
+                            new KafkaPartitionSplit(
+                                    new TopicPartition(TOPIC, 0),
+                                    0L,
+                                    KafkaPartitionSplit.NO_STOPPING_OFFSET));
+            reader.addSplits(Collections.singletonList(split));
+
+            reader.handleSourceEvents(getEmptyMetadataUpdateEvent());
+
+            TrackingReaderOutputWithIdleness<byte[]> readerOutput =
+                    new TrackingReaderOutputWithIdleness<>();
+            assertThat(reader.pollNext(readerOutput)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+            assertThat(readerOutput.releasedSplitIds()).containsExactly(split.splitId());
+            assertThat(readerOutput.idleCount()).isEqualTo(1);
+            assertThat(readerOutput.isIdle()).isTrue();
+        }
+    }
+
+    private static MetadataUpdateEvent getMetadataUpdateEvent() {
+        Properties clusterProperties = new Properties();
+        clusterProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        ClusterMetadata clusterMetadata =
+                new ClusterMetadata(Collections.singleton(TOPIC), clusterProperties);
+        return new MetadataUpdateEvent(
+                Collections.singleton(
+                        new KafkaStream(
+                                TOPIC,
+                                Collections.singletonMap(KAFKA_CLUSTER_ID, clusterMetadata))));
+    }
+
+    private static MetadataUpdateEvent getEmptyMetadataUpdateEvent() {
+        return new MetadataUpdateEvent(
+                Collections.singleton(
+                        new KafkaStream(TOPIC, Collections.<String, ClusterMetadata>emptyMap())));
+    }
+
+    private static Properties getRequiredProperties() {
+        Properties properties = new Properties();
+        properties.setProperty(
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                ByteArrayDeserializer.class.getName());
+        properties.setProperty(
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                ByteArrayDeserializer.class.getName());
+        return properties;
+    }
+
+    private static class TrackingReaderOutputWithIdleness<E> extends TestingReaderOutput<E> {
+        private int idleCount;
+        private boolean idle;
+        private final List<String> releasedSplitIds = new ArrayList<>();
+
+        @Override
+        public void emitWatermark(Watermark watermark) {}
+
+        @Override
+        public void markIdle() {
+            idleCount++;
+            idle = true;
+        }
+
+        @Override
+        public void releaseOutputForSplit(String splitId) {
+            releasedSplitIds.add(splitId);
+        }
+
+        private int idleCount() {
+            return idleCount;
+        }
+
+        private boolean isIdle() {
+            return idle;
+        }
+
+        private List<String> releasedSplitIds() {
+            return releasedSplitIds;
+        }
+    }
+}

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -66,7 +67,11 @@ class DynamicKafkaSourceReaderIdlenessTest {
                                     KafkaPartitionSplit.NO_STOPPING_OFFSET));
             reader.addSplits(Collections.singletonList(split));
 
+            CompletableFuture<Void> availabilityFuture = reader.isAvailable();
+            assertThat(availabilityFuture).isNotDone();
+
             reader.handleSourceEvents(getEmptyMetadataUpdateEvent());
+            assertThat(availabilityFuture).isDone();
 
             TrackingReaderOutputWithIdleness<byte[]> readerOutput =
                     new TrackingReaderOutputWithIdleness<>();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderTest.java
@@ -81,6 +81,12 @@ public class DynamicKafkaSourceReaderTest extends SourceReaderTestBase<DynamicKa
         private final List<String> releasedSplitIds = new ArrayList<>();
 
         @Override
+        public void markIdle() {}
+
+        @Override
+        public void markActive() {}
+
+        @Override
         public void releaseOutputForSplit(String splitId) {
             releasedSplitIds.add(splitId);
         }
@@ -249,7 +255,7 @@ public class DynamicKafkaSourceReaderTest extends SourceReaderTestBase<DynamicKa
     void testNoSubReadersInputStatus() throws Exception {
         try (DynamicKafkaSourceReader<Integer> reader =
                 (DynamicKafkaSourceReader<Integer>) createReader()) {
-            TestingReaderOutput<Integer> readerOutput = new TestingReaderOutput<>();
+            TrackingReaderOutput<Integer> readerOutput = new TrackingReaderOutput<>();
             InputStatus inputStatus = reader.pollNext(readerOutput);
             assertEquals(
                     InputStatus.NOTHING_AVAILABLE,


### PR DESCRIPTION
## What is the purpose of the change

`DynamicKafkaSource` can remain active after a metadata update removes the last active Kafka cluster/split from a reader subtask. Since no sub-reader remains to report idleness, downstream watermark progress can stall.

When the reader is already waiting on `isAvailable()`, resetting availability to zero sub-readers also leaves the cached availability future incomplete, so `pollNext()` is not invoked to release pending split outputs or mark the output idle.


## Brief change log

- Treat an actively consuming dynamic reader with zero active sub-readers as idle, and mark it active again when sub-readers return.
- Complete the previous availability future when metadata removal leaves the reader with zero active sub-readers.
- Add no-Docker regression coverage for removing the last active cluster/split while waiting on `isAvailable()`, completing availability, releasing the split output, and marking the reader idle.

## Verifying this change

- `mvn -f flink-connector-kafka/pom.xml -Dtest=DynamicKafkaSourceReaderIdlenessTest test`

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): yes
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (OpenAI Codex)

Generated-by: OpenAI Codex