### PR TITLE
[FLINK-39980] Implement split rebalance/reassignment support in DynamicKafkaSource after metadata changes

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,7 +28,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: &flink_versions [ 2.2.1, 2.1.2 ]
+        flink: &flink_versions [ 2.2.1 ]
         jdk: &jdk_versions [ '11, 17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,7 +28,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: &flink_versions [ 2.2.1 ]
+        flink: &flink_versions [ 2.3.0, 2.2.1 ]
         jdk: &jdk_versions [ '11, 17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,7 +28,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: &flink_versions [ 2.3.0, 2.2.1 ]
+        flink: &flink_versions [ 2.2.1 ]
         jdk: &jdk_versions [ '11, 17, 21' ]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:

--- a/docs/content.zh/docs/connectors/datastream/dynamic-kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/dynamic-kafka.md
@@ -197,9 +197,9 @@ Dynamic Kafka Source 支持两种 split 分配模式：
 在 `global` 模式下，均衡策略是**前向增量（forward-only）**的：新发现 split 会尽量保证后续分配均衡，
 但不会仅为重平衡主动迁移已分配且仍在消费的 active split。
 
-如果因为缩容/移除导致 global 分配出现倾斜，enumerator 不会自行重排已在运行的 split。
-如需对已有 ownership 做重平衡，可通过并行度变化后的恢复流程（例如 savepoint/checkpoint + rescale restore），
-让 Flink Runtime 对 source reader 的 operator state 进行重分区。
+如果因为缩容/移除导致 global 分配出现倾斜，恢复流程会将恢复出的 active split
+重新分配到可用 reader，无需改变并行度。仅为保留 offset 而保存的已移除 split
+不会参与 active 重平衡，在重新激活或过期前仍保留在原 reader 上。
 
 {{< tabs "DynamicKafkaSourceEnumeratorMode" >}}
 {{< tab "Java" >}}

--- a/docs/content/docs/connectors/datastream/dynamic-kafka.md
+++ b/docs/content/docs/connectors/datastream/dynamic-kafka.md
@@ -168,10 +168,10 @@ In `global` mode, balancing is **forward-looking**: newly discovered splits are 
 future distribution balanced, while already assigned active splits are not proactively migrated only
 for rebalancing.
 
-If global assignment becomes skewed due to shrink/removal, the enumerator does not rebalance already
-active splits by itself. To rebalance existing ownership, use a restore with parallelism change
-(for example, savepoint/checkpoint restore after rescale), so Flink runtime repartitions source
-reader operator state.
+If global assignment becomes skewed due to shrink/removal, a recovery redistributes the restored
+active splits across the available readers. A parallelism change is not required. Removed splits
+kept only for offset retention are excluded from this active rebalance and stay with their previous
+reader until they are reactivated or expire.
 
 {{< tabs "DynamicKafkaSourceEnumeratorMode" >}}
 {{< tab "Java" >}}

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/DynamicKafkaSource.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/DynamicKafkaSource.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SupportsSplitReassignmentOnRecovery;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.connector.kafka.dynamic.metadata.KafkaMetadataService;
 import org.apache.flink.connector.kafka.dynamic.source.enumerator.DynamicKafkaSourceEnumState;
@@ -78,6 +79,7 @@ import java.util.Properties;
 @Experimental
 public class DynamicKafkaSource<T>
         implements Source<T, DynamicKafkaSourceSplit, DynamicKafkaSourceEnumState>,
+                SupportsSplitReassignmentOnRecovery,
                 ResultTypeQueryable<T> {
 
     private final KafkaStreamSubscriber kafkaStreamSubscriber;

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumerator.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumerator.java
@@ -21,9 +21,11 @@ package org.apache.flink.connector.kafka.dynamic.source.enumerator;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ReaderInfo;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.connector.kafka.dynamic.metadata.ClusterMetadata;
 import org.apache.flink.connector.kafka.dynamic.metadata.KafkaMetadataService;
 import org.apache.flink.connector.kafka.dynamic.metadata.KafkaStream;
@@ -111,6 +113,9 @@ public class DynamicKafkaSourceEnumerator
     private Map<String, DynamicKafkaSourceEnumState.RetainedClusterState>
             retainedClusterEnumeratorStates;
     private boolean firstDiscoveryComplete;
+    private boolean initialReaderRegistrationPending;
+    private final Map<Integer, List<DynamicKafkaSourceSplit>> pendingReportedSplitsByReader;
+    private final Set<Integer> pendingMetadataUpdateReaders;
 
     public DynamicKafkaSourceEnumerator(
             KafkaStreamSubscriber kafkaStreamSubscriber,
@@ -212,6 +217,10 @@ public class DynamicKafkaSourceEnumerator
                                         runnable, "dynamic-kafka-enumerator-closing-worker"));
         this.asynchronousEnumeratorCloseFailure = new AtomicReference<>();
         this.splitAssignmentStrategy = createSplitAssignmentStrategy(properties);
+        this.initialReaderRegistrationPending =
+                hasRestoredEnumeratorState(dynamicKafkaSourceEnumState);
+        this.pendingReportedSplitsByReader = new HashMap<>();
+        this.pendingMetadataUpdateReaders = new HashSet<>();
 
         if (!dynamicKafkaSourceEnumState.getClusterEnumeratorStates().isEmpty()) {
             logger.info("Dynamic Kafka source restored from checkpointed enumerator state");
@@ -446,6 +455,7 @@ public class DynamicKafkaSourceEnumerator
 
         // don't do anything if no change
         if (latestClusterTopicsMap.equals(newClustersTopicsMap)) {
+            tryCompletePendingReaderRegistration();
             return;
         }
 
@@ -522,6 +532,7 @@ public class DynamicKafkaSourceEnumerator
 
         splitAssignmentStrategy.onMetadataRefresh(activeSplitIds);
         startAllEnumerators();
+        tryCompletePendingReaderRegistration();
     }
 
     private Set<KafkaStream> handleFetchSubscribedStreamsError(
@@ -546,10 +557,13 @@ public class DynamicKafkaSourceEnumerator
 
     /** NOTE: Must run on coordinator thread. */
     private void sendMetadataUpdateEventToAvailableReaders() {
+        if (shouldDeferMetadataUpdateEvents()) {
+            pendingMetadataUpdateReaders.addAll(enumContext.registeredReaders().keySet());
+            return;
+        }
+
         for (int readerId : enumContext.registeredReaders().keySet()) {
-            MetadataUpdateEvent metadataUpdateEvent = new MetadataUpdateEvent(latestKafkaStreams);
-            logger.debug("sending metadata update to reader {}: {}", readerId, metadataUpdateEvent);
-            enumContext.sendEventToSourceReader(readerId, metadataUpdateEvent);
+            sendMetadataUpdateEvent(readerId);
         }
     }
 
@@ -713,7 +727,12 @@ public class DynamicKafkaSourceEnumerator
     public void addSplitsBack(List<DynamicKafkaSourceSplit> splits, int subtaskId) {
         logger.debug("Adding splits back for {}", subtaskId);
         splitAssignmentStrategy.onSplitsBack(splits, subtaskId);
+        addSplitsBackToClusterEnumerators(splits, subtaskId, false);
+        handleNoMoreSplits();
+    }
 
+    private void addSplitsBackToClusterEnumerators(
+            List<DynamicKafkaSourceSplit> splits, int subtaskId, boolean failOnInactiveCluster) {
         // separate splits by cluster
         Map<String, List<KafkaPartitionSplit>> kafkaPartitionSplits = new HashMap<>();
         for (DynamicKafkaSourceSplit split : splits) {
@@ -728,6 +747,12 @@ public class DynamicKafkaSourceEnumerator
                 clusterEnumeratorMap
                         .get(kafkaClusterId)
                         .addSplitsBack(kafkaPartitionSplits.get(kafkaClusterId), subtaskId);
+            } else if (failOnInactiveCluster) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Cannot reassign split for active cluster %s because its"
+                                        + " enumerator is unavailable",
+                                kafkaClusterId));
             } else {
                 logger.warn(
                         "Split refers to inactive cluster {} with current clusters being {}",
@@ -735,20 +760,195 @@ public class DynamicKafkaSourceEnumerator
                         clusterEnumeratorMap.keySet());
             }
         }
-
-        handleNoMoreSplits();
     }
 
     /** NOTE: this happens at startup and failover. */
     @Override
     public void addReader(int subtaskId) {
         logger.debug("Adding reader {}", subtaskId);
-        splitAssignmentStrategy.onReaderAdded(subtaskId);
+        ReaderInfo readerInfo = enumContext.registeredReaders().get(subtaskId);
+        if (readerInfo != null) {
+            List<DynamicKafkaSourceSplit> reportedSplits =
+                    readerInfo.getReportedSplitsOnRegistration();
+            if (!reportedSplits.isEmpty()) {
+                pendingReportedSplitsByReader.put(subtaskId, new ArrayList<>(reportedSplits));
+            }
+        }
 
-        // assign pending splits from the sub enumerator
+        if (tryCompletePendingReaderRegistration()) {
+            return;
+        }
+
+        addReaderToClusterEnumerators(subtaskId);
+        handleNoMoreSplits();
+    }
+
+    private boolean tryCompletePendingReaderRegistration() {
+        boolean hasPendingRecovery =
+                initialReaderRegistrationPending || !pendingReportedSplitsByReader.isEmpty();
+        if (!hasPendingRecovery) {
+            return false;
+        }
+        if (!firstDiscoveryComplete || !allReadersRegistered()) {
+            return true;
+        }
+
+        if (initialReaderRegistrationPending) {
+            initialReaderRegistrationPending = false;
+        }
+        if (!pendingReportedSplitsByReader.isEmpty()) {
+            reassignReportedSplits();
+        } else {
+            flushPendingSplitAssignmentsForRegisteredReaders();
+        }
+        handleNoMoreSplits();
+        flushPendingMetadataUpdateEvents();
+        return true;
+    }
+
+    private boolean allReadersRegistered() {
+        return enumContext.registeredReaders().size() == enumContext.currentParallelism();
+    }
+
+    private void addReaderToClusterEnumerators(int subtaskId) {
+        splitAssignmentStrategy.onReaderAdded(subtaskId);
         clusterEnumeratorMap.forEach(
                 (cluster, subEnumerator) -> subEnumerator.addReader(subtaskId));
-        handleNoMoreSplits();
+    }
+
+    private void flushPendingSplitAssignmentsForRegisteredReaders() {
+        List<Integer> registeredReaders = new ArrayList<>(enumContext.registeredReaders().keySet());
+        Collections.sort(registeredReaders);
+        for (int readerId : registeredReaders) {
+            addReaderToClusterEnumerators(readerId);
+        }
+    }
+
+    private void reassignReportedSplits() {
+        Map<String, ReportedSplit> activeReportedSplits = new TreeMap<>();
+        Map<Integer, List<DynamicKafkaSourceSplit>> retainedSplitsByReader = new TreeMap<>();
+        long currentTimeMillis = System.currentTimeMillis();
+
+        for (Entry<Integer, List<DynamicKafkaSourceSplit>> readerSplits :
+                new TreeMap<>(pendingReportedSplitsByReader).entrySet()) {
+            int readerId = readerSplits.getKey();
+            for (DynamicKafkaSourceSplit split : readerSplits.getValue()) {
+                if (isSplitActive(split)) {
+                    DynamicKafkaSourceSplit activeSplit = split.clearRetention();
+                    ReportedSplit previous =
+                            activeReportedSplits.putIfAbsent(
+                                    activeSplit.splitId(),
+                                    new ReportedSplit(activeSplit, readerId));
+                    if (previous != null) {
+                        throw new IllegalStateException(
+                                String.format(
+                                        "Split %s was reported by both reader %d and reader %d",
+                                        activeSplit.splitId(), previous.readerId, readerId));
+                    }
+                } else {
+                    DynamicKafkaSourceSplit retainedSplit =
+                            getRetainedReportedSplit(split, currentTimeMillis);
+                    if (retainedSplit != null) {
+                        retainedSplitsByReader
+                                .computeIfAbsent(readerId, ignored -> new ArrayList<>())
+                                .add(retainedSplit);
+                    } else {
+                        logger.info("Dropping inactive reported split on recovery: {}", split);
+                    }
+                }
+            }
+        }
+
+        List<DynamicKafkaSourceSplit> activeSplits =
+                activeReportedSplits.values().stream()
+                        .map(reportedSplit -> reportedSplit.split)
+                        .collect(Collectors.toList());
+        splitAssignmentStrategy.onRecoveredSplits(activeSplits, enumContext.currentParallelism());
+
+        for (ReportedSplit reportedSplit : activeReportedSplits.values()) {
+            addSplitsBackToClusterEnumerators(
+                    Collections.singletonList(reportedSplit.split), reportedSplit.readerId, true);
+        }
+
+        flushPendingSplitAssignmentsForRegisteredReaders();
+
+        if (!retainedSplitsByReader.isEmpty()) {
+            enumContext.assignSplits(new SplitsAssignment<>(retainedSplitsByReader));
+        }
+        pendingReportedSplitsByReader.clear();
+    }
+
+    private boolean shouldDeferMetadataUpdateEvents() {
+        return initialReaderRegistrationPending
+                || (!pendingReportedSplitsByReader.isEmpty() && !allReadersRegistered());
+    }
+
+    private void flushPendingMetadataUpdateEvents() {
+        List<Integer> readers = new ArrayList<>(pendingMetadataUpdateReaders);
+        Collections.sort(readers);
+        pendingMetadataUpdateReaders.clear();
+        for (int readerId : readers) {
+            if (enumContext.registeredReaders().containsKey(readerId)) {
+                sendMetadataUpdateEvent(readerId);
+            }
+        }
+    }
+
+    private void sendMetadataUpdateEvent(int readerId) {
+        MetadataUpdateEvent metadataUpdateEvent = new MetadataUpdateEvent(latestKafkaStreams);
+        logger.debug("sending metadata update to reader {}: {}", readerId, metadataUpdateEvent);
+        enumContext.sendEventToSourceReader(readerId, metadataUpdateEvent);
+    }
+
+    private boolean isSplitActive(DynamicKafkaSourceSplit split) {
+        for (KafkaStream kafkaStream : latestKafkaStreams) {
+            ClusterMetadata clusterMetadata =
+                    kafkaStream.getClusterMetadataMap().get(split.getKafkaClusterId());
+            if (clusterMetadata != null
+                    && clusterMetadata
+                            .getTopics()
+                            .contains(split.getKafkaPartitionSplit().getTopic())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Nullable
+    private DynamicKafkaSourceSplit getRetainedReportedSplit(
+            DynamicKafkaSourceSplit split, long currentTimeMillis) {
+        if (split.isRetained()) {
+            return split.isRetained(currentTimeMillis) ? split : null;
+        }
+        if (removedClusterStateRetentionMs > 0 && !isClusterActive(split.getKafkaClusterId())) {
+            return split.retainUntil(currentTimeMillis + removedClusterStateRetentionMs);
+        }
+        return null;
+    }
+
+    private boolean isClusterActive(String kafkaClusterId) {
+        for (KafkaStream kafkaStream : latestKafkaStreams) {
+            if (kafkaStream.getClusterMetadataMap().containsKey(kafkaClusterId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasRestoredEnumeratorState(
+            DynamicKafkaSourceEnumState dynamicKafkaSourceEnumState) {
+        return !dynamicKafkaSourceEnumState.getClusterEnumeratorStates().isEmpty()
+                || !dynamicKafkaSourceEnumState.getRetainedClusterEnumeratorStates().isEmpty();
+    }
+
+    private static class ReportedSplit {
+        private final DynamicKafkaSourceSplit split;
+        private final int readerId;
+
+        private ReportedSplit(DynamicKafkaSourceSplit split, int readerId) {
+            this.split = split;
+            this.readerId = readerId;
+        }
     }
 
     /**
@@ -842,10 +1042,11 @@ public class DynamicKafkaSourceEnumerator
                 "Received invalid source event: " + sourceEvent);
 
         if (enumContext.registeredReaders().containsKey(subtaskId)) {
-            MetadataUpdateEvent metadataUpdateEvent = new MetadataUpdateEvent(latestKafkaStreams);
-            logger.debug(
-                    "sending metadata update to reader {}: {}", subtaskId, metadataUpdateEvent);
-            enumContext.sendEventToSourceReader(subtaskId, metadataUpdateEvent);
+            if (shouldDeferMetadataUpdateEvents()) {
+                pendingMetadataUpdateReaders.add(subtaskId);
+            } else {
+                sendMetadataUpdateEvent(subtaskId);
+            }
         } else {
             logger.warn("Got get metadata update but subtask was unavailable");
         }
@@ -917,6 +1118,9 @@ public class DynamicKafkaSourceEnumerator
         default void onSplitsBack(List<DynamicKafkaSourceSplit> splits, int subtaskId) {}
 
         default void onMetadataRefresh(Set<String> activeSplitIds) {}
+
+        default void onRecoveredSplits(
+                List<DynamicKafkaSourceSplit> splits, int currentParallelism) {}
     }
 
     private static class PerClusterSplitAssignmentStrategy implements SplitAssignmentStrategy {
@@ -957,6 +1161,12 @@ public class DynamicKafkaSourceEnumerator
         @Override
         public void onMetadataRefresh(Set<String> activeSplitIds) {
             splitOwnerAssigner.onMetadataRefresh(activeSplitIds);
+        }
+
+        @Override
+        public void onRecoveredSplits(
+                List<DynamicKafkaSourceSplit> splits, int currentParallelism) {
+            splitOwnerAssigner.onRecoveredSplits(splits, currentParallelism);
         }
 
         private int assignSplitOwner(

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumerator.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumerator.java
@@ -453,7 +453,7 @@ public class DynamicKafkaSourceEnumerator
             }
         }
 
-        // don't do anything if no change
+        // An unchanged refresh can still unblock deferred recovery registration.
         if (latestClusterTopicsMap.equals(newClustersTopicsMap)) {
             tryCompletePendingReaderRegistration();
             return;

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/GlobalSplitOwnerAssigner.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/GlobalSplitOwnerAssigner.java
@@ -34,6 +34,7 @@ final class GlobalSplitOwnerAssigner {
 
     private final Set<String> knownActiveSplitIds = new HashSet<>();
     private final Map<String, Integer> preferredOwnerBySplitId = new HashMap<>();
+    private final Map<String, Integer> recoveryOwnerBySplitId = new HashMap<>();
 
     void onMetadataRefresh(Set<String> activeSplitIds) {
         knownActiveSplitIds.clear();
@@ -48,8 +49,29 @@ final class GlobalSplitOwnerAssigner {
         }
     }
 
+    void onRecoveredSplits(List<DynamicKafkaSourceSplit> splits, int numReaders) {
+        Preconditions.checkArgument(numReaders > 0, "numReaders must be > 0");
+
+        recoveryOwnerBySplitId.clear();
+        for (DynamicKafkaSourceSplit split : splits) {
+            knownActiveSplitIds.remove(split.splitId());
+            preferredOwnerBySplitId.remove(split.splitId());
+        }
+
+        for (DynamicKafkaSourceSplit split : splits) {
+            int targetReader = Math.floorMod(knownActiveSplitIds.size(), numReaders);
+            knownActiveSplitIds.add(split.splitId());
+            recoveryOwnerBySplitId.put(split.splitId(), targetReader);
+        }
+    }
+
     int assignSplitOwner(String splitId, int numReaders) {
         Preconditions.checkArgument(numReaders > 0, "numReaders must be > 0");
+
+        Integer recoveryOwner = recoveryOwnerBySplitId.remove(splitId);
+        if (recoveryOwner != null) {
+            return recoveryOwner;
+        }
 
         Integer preferredOwner = preferredOwnerBySplitId.remove(splitId);
         if (preferredOwner != null && preferredOwner >= 0 && preferredOwner < numReaders) {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorRecoveryTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorRecoveryTest.java
@@ -1,0 +1,358 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.dynamic.source.enumerator;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.ReaderInfo;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.api.connector.source.SupportsSplitReassignmentOnRecovery;
+import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
+import org.apache.flink.connector.kafka.dynamic.metadata.ClusterMetadata;
+import org.apache.flink.connector.kafka.dynamic.metadata.KafkaMetadataService;
+import org.apache.flink.connector.kafka.dynamic.metadata.KafkaStream;
+import org.apache.flink.connector.kafka.dynamic.source.DynamicKafkaSource;
+import org.apache.flink.connector.kafka.dynamic.source.DynamicKafkaSourceOptions;
+import org.apache.flink.connector.kafka.dynamic.source.GetMetadataUpdateEvent;
+import org.apache.flink.connector.kafka.dynamic.source.MetadataUpdateEvent;
+import org.apache.flink.connector.kafka.dynamic.source.enumerator.subscriber.KafkaStreamSetSubscriber;
+import org.apache.flink.connector.kafka.dynamic.source.split.DynamicKafkaSourceSplit;
+import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
+import org.apache.flink.connector.kafka.source.enumerator.KafkaSourceEnumState;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.NoStoppingOffsetsInitializer;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.connector.kafka.testutils.MockKafkaMetadataService;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.function.BiConsumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Recovery tests for {@link DynamicKafkaSourceEnumerator}. */
+public class DynamicKafkaSourceEnumeratorRecoveryTest {
+
+    @Test
+    public void testReassignsReportedActiveSplitsAfterMetadataShrink() throws Throwable {
+        int parallelism = 4;
+        String streamId = "stream";
+        String clusterId = "cluster-0";
+        String activeTopic = "active-topic";
+        String removedTopic = "removed-topic";
+
+        List<DynamicKafkaSourceSplit> activeSplits = createSplits(clusterId, activeTopic, 10);
+        List<DynamicKafkaSourceSplit> reportedSplits = new ArrayList<>(activeSplits);
+        reportedSplits.addAll(createSplits(clusterId, removedTopic, 2));
+
+        KafkaStream restoredKafkaStream =
+                createKafkaStream(streamId, clusterId, Set.of(activeTopic, removedTopic));
+        KafkaStream currentKafkaStream = createKafkaStream(streamId, clusterId, activeTopic);
+        DynamicKafkaSourceEnumState restoredState =
+                createRestoredState(restoredKafkaStream, clusterId, reportedSplits);
+        Properties properties = createGlobalModeProperties();
+
+        try (MockSplitEnumeratorContext<DynamicKafkaSourceSplit> context =
+                        new MockSplitEnumeratorContext<>(parallelism);
+                DynamicKafkaSourceEnumerator enumerator =
+                        createEnumerator(
+                                streamId,
+                                new MockKafkaMetadataService(
+                                        Collections.singleton(currentKafkaStream)),
+                                context,
+                                properties,
+                                restoredState)) {
+            enumerator.start();
+            for (int reader = 0; reader < parallelism; reader++) {
+                List<DynamicKafkaSourceSplit> readerReportedSplits =
+                        reader == 0 ? reportedSplits : Collections.emptyList();
+                context.registerReader(
+                        ReaderInfo.createReaderInfo(
+                                reader, "location-" + reader, readerReportedSplits));
+                enumerator.addReader(reader);
+            }
+
+            assertThat(context.getSplitsAssignmentSequence()).isEmpty();
+            context.runNextOneTimeCallable();
+
+            Map<Integer, Integer> assignmentCounts = new HashMap<>();
+            Set<String> assignedSplitIds = new HashSet<>();
+            int totalAssignments = 0;
+            for (int reader = 0; reader < parallelism; reader++) {
+                assignmentCounts.put(reader, 0);
+            }
+            for (SplitsAssignment<DynamicKafkaSourceSplit> assignment :
+                    context.getSplitsAssignmentSequence()) {
+                for (Map.Entry<Integer, List<DynamicKafkaSourceSplit>> entry :
+                        assignment.assignment().entrySet()) {
+                    assignmentCounts.merge(entry.getKey(), entry.getValue().size(), Integer::sum);
+                    totalAssignments += entry.getValue().size();
+                    for (DynamicKafkaSourceSplit split : entry.getValue()) {
+                        assertThat(split.getKafkaPartitionSplit().getTopic())
+                                .isEqualTo(activeTopic);
+                        assignedSplitIds.add(split.splitId());
+                    }
+                }
+            }
+
+            assertThat(totalAssignments).isEqualTo(activeSplits.size());
+            assertThat(assignedSplitIds).hasSize(activeSplits.size());
+            assertThat(assignmentCounts.values()).containsExactlyInAnyOrder(3, 3, 2, 2);
+        }
+    }
+
+    @Test
+    public void testReturnsRetainedSplitsBeforeSendingDeferredMetadata() throws Throwable {
+        int parallelism = 2;
+        String streamId = "stream";
+        String activeClusterId = "active-cluster";
+        String activeTopic = "active-topic";
+        DynamicKafkaSourceSplit activeSplit = createSplits(activeClusterId, activeTopic, 1).get(0);
+        DynamicKafkaSourceSplit removedSplit =
+                createSplits("removed-cluster", "removed-topic", 1).get(0);
+
+        KafkaStream kafkaStream = createKafkaStream(streamId, activeClusterId, activeTopic);
+        DynamicKafkaSourceEnumState restoredState =
+                createRestoredState(
+                        kafkaStream, activeClusterId, Collections.singletonList(activeSplit));
+        Properties properties = createGlobalModeProperties();
+        properties.setProperty(
+                DynamicKafkaSourceOptions.STREAM_METADATA_REMOVED_CLUSTER_RETENTION_MS.key(),
+                "60000");
+
+        try (MockSplitEnumeratorContext<DynamicKafkaSourceSplit> context =
+                        new MockSplitEnumeratorContext<>(parallelism);
+                DynamicKafkaSourceEnumerator enumerator =
+                        createEnumerator(
+                                streamId,
+                                new MockKafkaMetadataService(Collections.singleton(kafkaStream)),
+                                context,
+                                properties,
+                                restoredState)) {
+            enumerator.start();
+            context.registerReader(
+                    ReaderInfo.createReaderInfo(
+                            0, "location-0", List.of(activeSplit, removedSplit)));
+            enumerator.addReader(0);
+            enumerator.handleSourceEvent(0, new GetMetadataUpdateEvent());
+
+            assertThat(context.getSentSourceEvent().getOrDefault(0, Collections.emptyList()))
+                    .isEmpty();
+
+            context.registerReader(
+                    ReaderInfo.createReaderInfo(1, "location-1", Collections.emptyList()));
+            enumerator.addReader(1);
+            assertThat(context.getSplitsAssignmentSequence()).isEmpty();
+
+            context.runNextOneTimeCallable();
+
+            List<DynamicKafkaSourceSplit> assignedSplits =
+                    context.getSplitsAssignmentSequence().stream()
+                            .flatMap(
+                                    assignment ->
+                                            assignment.assignment().values().stream()
+                                                    .flatMap(List::stream))
+                            .collect(java.util.stream.Collectors.toList());
+            DynamicKafkaSourceSplit retainedSplit =
+                    assignedSplits.stream()
+                            .filter(split -> split.splitId().equals(removedSplit.splitId()))
+                            .findFirst()
+                            .orElseThrow(AssertionError::new);
+            assertThat(retainedSplit.isRetained()).isTrue();
+            assertThat(context.getSentSourceEvent().get(0))
+                    .hasSize(1)
+                    .allMatch(MetadataUpdateEvent.class::isInstance);
+        }
+    }
+
+    @Test
+    public void testReassignsReportedSplitsWithPerClusterOwnerSelection() throws Throwable {
+        int parallelism = 2;
+        String streamId = "stream";
+        String clusterId = "cluster-0";
+        String topic = "topic";
+        List<DynamicKafkaSourceSplit> splits = createSplits(clusterId, topic, 4);
+        KafkaStream kafkaStream = createKafkaStream(streamId, clusterId, topic);
+
+        try (MockSplitEnumeratorContext<DynamicKafkaSourceSplit> context =
+                        new MockSplitEnumeratorContext<>(parallelism);
+                DynamicKafkaSourceEnumerator enumerator =
+                        createEnumerator(
+                                streamId,
+                                new MockKafkaMetadataService(Collections.singleton(kafkaStream)),
+                                context,
+                                createBaseProperties(),
+                                createRestoredState(kafkaStream, clusterId, splits))) {
+            enumerator.start();
+            context.registerReader(ReaderInfo.createReaderInfo(0, "location-0", splits));
+            enumerator.addReader(0);
+            context.registerReader(
+                    ReaderInfo.createReaderInfo(1, "location-1", Collections.emptyList()));
+            enumerator.addReader(1);
+            context.runNextOneTimeCallable();
+
+            Map<Integer, Integer> assignmentCounts = new HashMap<>();
+            for (SplitsAssignment<DynamicKafkaSourceSplit> assignment :
+                    context.getSplitsAssignmentSequence()) {
+                for (Map.Entry<Integer, List<DynamicKafkaSourceSplit>> entry :
+                        assignment.assignment().entrySet()) {
+                    assignmentCounts.merge(entry.getKey(), entry.getValue().size(), Integer::sum);
+                }
+            }
+            assertThat(assignmentCounts).containsEntry(0, 2).containsEntry(1, 2);
+        }
+    }
+
+    @Test
+    public void testSourceOptsIntoSplitReassignmentOnRecovery() {
+        assertThat(
+                        SupportsSplitReassignmentOnRecovery.class.isAssignableFrom(
+                                DynamicKafkaSource.class))
+                .isTrue();
+    }
+
+    private static DynamicKafkaSourceEnumState createRestoredState(
+            KafkaStream kafkaStream, String clusterId, List<DynamicKafkaSourceSplit> activeSplits) {
+        return new DynamicKafkaSourceEnumState(
+                Collections.singleton(kafkaStream),
+                Collections.singletonMap(
+                        clusterId,
+                        new KafkaSourceEnumState(
+                                unwrapSplits(activeSplits), Collections.emptyList(), true)));
+    }
+
+    private static Properties createGlobalModeProperties() {
+        Properties properties = createBaseProperties();
+        properties.setProperty(
+                DynamicKafkaSourceOptions.STREAM_ENUMERATOR_MODE.key(),
+                DynamicKafkaSourceOptions.EnumeratorMode.GLOBAL.name().toLowerCase());
+        return properties;
+    }
+
+    private static Properties createBaseProperties() {
+        Properties properties = new Properties();
+        properties.setProperty(KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(), "0");
+        properties.setProperty(
+                DynamicKafkaSourceOptions.STREAM_METADATA_DISCOVERY_INTERVAL_MS.key(), "0");
+        return properties;
+    }
+
+    private static DynamicKafkaSourceEnumerator createEnumerator(
+            String streamId,
+            KafkaMetadataService metadataService,
+            SplitEnumeratorContext<DynamicKafkaSourceSplit> context,
+            Properties properties,
+            DynamicKafkaSourceEnumState restoredState) {
+        return new DynamicKafkaSourceEnumerator(
+                new KafkaStreamSetSubscriber(Collections.singleton(streamId)),
+                metadataService,
+                context,
+                OffsetsInitializer.earliest(),
+                new NoStoppingOffsetsInitializer(),
+                properties,
+                Boundedness.CONTINUOUS_UNBOUNDED,
+                restoredState,
+                new NoOpKafkaEnumContextProxyFactory());
+    }
+
+    private static KafkaStream createKafkaStream(
+            String streamId, String clusterId, String activeTopic) {
+        return createKafkaStream(streamId, clusterId, Collections.singleton(activeTopic));
+    }
+
+    private static KafkaStream createKafkaStream(
+            String streamId, String clusterId, Set<String> activeTopics) {
+        Properties clusterProperties = new Properties();
+        clusterProperties.setProperty(
+                CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        return new KafkaStream(
+                streamId,
+                Collections.singletonMap(
+                        clusterId, new ClusterMetadata(activeTopics, clusterProperties)));
+    }
+
+    private static List<DynamicKafkaSourceSplit> createSplits(
+            String clusterId, String topic, int count) {
+        List<DynamicKafkaSourceSplit> splits = new ArrayList<>();
+        for (int partition = 0; partition < count; partition++) {
+            splits.add(
+                    new DynamicKafkaSourceSplit(
+                            clusterId,
+                            new KafkaPartitionSplit(
+                                    new TopicPartition(topic, partition),
+                                    KafkaPartitionSplit.EARLIEST_OFFSET)));
+        }
+        return splits;
+    }
+
+    private static List<KafkaPartitionSplit> unwrapSplits(
+            List<DynamicKafkaSourceSplit> dynamicSplits) {
+        List<KafkaPartitionSplit> splits = new ArrayList<>();
+        for (DynamicKafkaSourceSplit split : dynamicSplits) {
+            splits.add(split.getKafkaPartitionSplit());
+        }
+        return splits;
+    }
+
+    private static class NoOpKafkaEnumContextProxyFactory
+            implements StoppableKafkaEnumContextProxy.StoppableKafkaEnumContextProxyFactory {
+
+        @Override
+        public StoppableKafkaEnumContextProxy create(
+                SplitEnumeratorContext<DynamicKafkaSourceSplit> enumContext,
+                String kafkaClusterId,
+                KafkaMetadataService kafkaMetadataService,
+                Runnable signalNoMoreSplitsCallback) {
+            return new NoOpKafkaEnumContextProxy(
+                    kafkaClusterId, kafkaMetadataService, enumContext, signalNoMoreSplitsCallback);
+        }
+    }
+
+    private static class NoOpKafkaEnumContextProxy extends StoppableKafkaEnumContextProxy {
+
+        private NoOpKafkaEnumContextProxy(
+                String kafkaClusterId,
+                KafkaMetadataService kafkaMetadataService,
+                SplitEnumeratorContext<DynamicKafkaSourceSplit> enumContext,
+                Runnable signalNoMoreSplitsCallback) {
+            super(kafkaClusterId, kafkaMetadataService, enumContext, signalNoMoreSplitsCallback);
+        }
+
+        @Override
+        public <T> void callAsync(Callable<T> callable, BiConsumer<T, Throwable> handler) {}
+
+        @Override
+        public <T> void callAsync(
+                Callable<T> callable,
+                BiConsumer<T, Throwable> handler,
+                long initialDelay,
+                long period) {}
+    }
+}

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorTest.java
@@ -1005,7 +1005,12 @@ public class DynamicKafkaSourceEnumeratorTest {
                                 serializedRestoredState,
                                 new TestKafkaEnumContextProxyFactory())) {
             enumerator.start();
-            mockRegisterReaderAndSendReaderStartupEvent(context, enumerator, 0);
+            // Recovery metadata updates are deferred until all restored readers register and the
+            // first metadata discovery completes.
+            for (int reader = 0; reader < NUM_SUBTASKS; reader++) {
+                mockRegisterReaderAndSendReaderStartupEvent(context, enumerator, reader);
+            }
+            runAllOneTimeCallables(context);
 
             MetadataUpdateEvent metadataUpdateEvent = getLatestMetadataUpdateEvent(context, 0);
             KafkaStream updatedStream =

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@ under the License.
 
 		<!-- Main Dependencies -->
 		<confluent.version>7.9.2</confluent.version>
-		<flink.version>2.1.2</flink.version>
+		<flink.version>2.2.1</flink.version>
 		<kafka.version>4.2.0</kafka.version>
 
 		<!-- Other Dependencies -->


### PR DESCRIPTION
## What is the purpose of the change

`DynamicKafkaSource` keeps the split ownership inherited from reader state after metadata
removes clusters or topics. In global mode, the remaining active splits can therefore stay skewed
across subtasks even when the number of active partitions is at least the source parallelism.

Flink 2.2.1 provides `SupportsSplitReassignmentOnRecovery` so a source can report restored reader
splits to its enumerator before assigning them. This change adopts that contract and lets
`DynamicKafkaSourceEnumerator` redistribute the active restored split set during recovery.

## Brief change log

- Make `DynamicKafkaSource` implement `SupportsSplitReassignmentOnRecovery`.
- Buffer reader-reported restored splits until all readers are registered and the first current
  metadata refresh has been applied.
- Requeue active reported splits through the existing Kafka sub-enumerators; global mode assigns
  deterministic round-robin recovery owners, while per-cluster mode keeps its existing owner
  selection semantics.
- Exclude removed topic splits from active rebalance, preserve retained removed-cluster offsets on
  their prior reader, and defer metadata events until recovery assignments are queued.
- Compile against Flink 2.2.1 because the split-reassignment marker interface and reported-splits
  reader API are unavailable in Flink 2.1.2.
- Document the global-mode recovery behavior and add no-Docker recovery regressions.

## Verifying this change

- `./mvnw -pl flink-connector-kafka -Dtest=DynamicKafkaSourceEnumeratorRecoveryTest,GlobalSplitOwnerAssignerTest test`
- `./mvnw -pl flink-connector-kafka -Dflink.version=2.3.0 -Dtest=DynamicKafkaSourceEnumeratorRecoveryTest test`
- `./mvnw -pl flink-connector-kafka -DskipTests verify`

The existing Docker-backed `DynamicKafkaSourceEnumeratorTest` was not runnable locally because
Testcontainers could not find a Docker environment.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): yes, default Flink dependency 2.1.2 -> 2.2.1
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes, the source
  opts into the public evolving split-reassignment contract
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing,
  Kubernetes/Yarn, ZooKeeper: yes, source recovery
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? Dynamic Kafka Source documentation

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (OpenAI Codex)

Generated-by: OpenAI Codex