### PR TITLE
[FLINK-38919][docs] Document PyFlink per-cluster offsets

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/dynamic-kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/dynamic-kafka.md
@@ -139,6 +139,23 @@ DynamicKafkaSource<String> source =
         .build();
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+metadata_service = SingleClusterTopicMetadataService(
+    "cluster-a",
+    {"bootstrap.servers": "localhost:9092"},
+    starting_offsets_initializer=KafkaOffsetsInitializer.earliest(),
+    stopping_offsets_initializer=KafkaOffsetsInitializer.latest())
+
+source = DynamicKafkaSource.builder() \
+    .set_kafka_metadata_service(metadata_service) \
+    .set_stream_ids({"input-stream"}) \
+    .set_starting_offsets(KafkaOffsetsInitializer.latest()) \
+    .set_bounded(KafkaOffsetsInitializer.latest()) \
+    .set_value_only_deserializer(SimpleStringSchema()) \
+    .build()
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 ### Watermark 对齐

--- a/docs/content.zh/docs/connectors/datastream/dynamic-kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/dynamic-kafka.md
@@ -141,11 +141,20 @@ DynamicKafkaSource<String> source =
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
+starting_offsets = KafkaOffsetsInitializer.offsets({
+    KafkaTopicPartition("input-stream", 0): 100,
+    KafkaTopicPartition("input-stream", 1): 200,
+})
+stopping_offsets = KafkaOffsetsInitializer.offsets({
+    KafkaTopicPartition("input-stream", 0): 1000,
+    KafkaTopicPartition("input-stream", 1): 2000,
+})
+
 metadata_service = SingleClusterTopicMetadataService(
     "cluster-a",
     {"bootstrap.servers": "localhost:9092"},
-    starting_offsets_initializer=KafkaOffsetsInitializer.earliest(),
-    stopping_offsets_initializer=KafkaOffsetsInitializer.latest())
+    starting_offsets_initializer=starting_offsets,
+    stopping_offsets_initializer=stopping_offsets)
 
 source = DynamicKafkaSource.builder() \
     .set_kafka_metadata_service(metadata_service) \

--- a/docs/content.zh/docs/connectors/datastream/dynamic-kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/dynamic-kafka.md
@@ -145,22 +145,16 @@ starting_offsets = KafkaOffsetsInitializer.offsets({
     KafkaTopicPartition("input-stream", 0): 100,
     KafkaTopicPartition("input-stream", 1): 200,
 })
-stopping_offsets = KafkaOffsetsInitializer.offsets({
-    KafkaTopicPartition("input-stream", 0): 1000,
-    KafkaTopicPartition("input-stream", 1): 2000,
-})
 
 metadata_service = SingleClusterTopicMetadataService(
     "cluster-a",
     {"bootstrap.servers": "localhost:9092"},
-    starting_offsets_initializer=starting_offsets,
-    stopping_offsets_initializer=stopping_offsets)
+    starting_offsets_initializer=starting_offsets)
 
 source = DynamicKafkaSource.builder() \
     .set_kafka_metadata_service(metadata_service) \
     .set_stream_ids({"input-stream"}) \
     .set_starting_offsets(KafkaOffsetsInitializer.latest()) \
-    .set_bounded(KafkaOffsetsInitializer.latest()) \
     .set_value_only_deserializer(SimpleStringSchema()) \
     .build()
 ```

--- a/docs/content/docs/connectors/datastream/dynamic-kafka.md
+++ b/docs/content/docs/connectors/datastream/dynamic-kafka.md
@@ -142,6 +142,23 @@ DynamicKafkaSource<String> source =
         .build();
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+metadata_service = SingleClusterTopicMetadataService(
+    "cluster-a",
+    {"bootstrap.servers": "localhost:9092"},
+    starting_offsets_initializer=KafkaOffsetsInitializer.earliest(),
+    stopping_offsets_initializer=KafkaOffsetsInitializer.latest())
+
+source = DynamicKafkaSource.builder() \
+    .set_kafka_metadata_service(metadata_service) \
+    .set_stream_ids({"input-stream"}) \
+    .set_starting_offsets(KafkaOffsetsInitializer.latest()) \
+    .set_bounded(KafkaOffsetsInitializer.latest()) \
+    .set_value_only_deserializer(SimpleStringSchema()) \
+    .build()
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 ### Split Assignment Mode

--- a/docs/content/docs/connectors/datastream/dynamic-kafka.md
+++ b/docs/content/docs/connectors/datastream/dynamic-kafka.md
@@ -148,22 +148,16 @@ starting_offsets = KafkaOffsetsInitializer.offsets({
     KafkaTopicPartition("input-stream", 0): 100,
     KafkaTopicPartition("input-stream", 1): 200,
 })
-stopping_offsets = KafkaOffsetsInitializer.offsets({
-    KafkaTopicPartition("input-stream", 0): 1000,
-    KafkaTopicPartition("input-stream", 1): 2000,
-})
 
 metadata_service = SingleClusterTopicMetadataService(
     "cluster-a",
     {"bootstrap.servers": "localhost:9092"},
-    starting_offsets_initializer=starting_offsets,
-    stopping_offsets_initializer=stopping_offsets)
+    starting_offsets_initializer=starting_offsets)
 
 source = DynamicKafkaSource.builder() \
     .set_kafka_metadata_service(metadata_service) \
     .set_stream_ids({"input-stream"}) \
     .set_starting_offsets(KafkaOffsetsInitializer.latest()) \
-    .set_bounded(KafkaOffsetsInitializer.latest()) \
     .set_value_only_deserializer(SimpleStringSchema()) \
     .build()
 ```

--- a/docs/content/docs/connectors/datastream/dynamic-kafka.md
+++ b/docs/content/docs/connectors/datastream/dynamic-kafka.md
@@ -144,11 +144,20 @@ DynamicKafkaSource<String> source =
 {{< /tab >}}
 {{< tab "Python" >}}
 ```python
+starting_offsets = KafkaOffsetsInitializer.offsets({
+    KafkaTopicPartition("input-stream", 0): 100,
+    KafkaTopicPartition("input-stream", 1): 200,
+})
+stopping_offsets = KafkaOffsetsInitializer.offsets({
+    KafkaTopicPartition("input-stream", 0): 1000,
+    KafkaTopicPartition("input-stream", 1): 2000,
+})
+
 metadata_service = SingleClusterTopicMetadataService(
     "cluster-a",
     {"bootstrap.servers": "localhost:9092"},
-    starting_offsets_initializer=KafkaOffsetsInitializer.earliest(),
-    stopping_offsets_initializer=KafkaOffsetsInitializer.latest())
+    starting_offsets_initializer=starting_offsets,
+    stopping_offsets_initializer=stopping_offsets)
 
 source = DynamicKafkaSource.builder() \
     .set_kafka_metadata_service(metadata_service) \


### PR DESCRIPTION


## Summary

Documents the PyFlink per-cluster starting offset initializer API for DynamicKafkaSource, following the merged FLINK-38918 implementation https://github.com/apache/flink/pull/28512 in apache/flink repo

## Changes

- Added a Python tab to the Dynamic Kafka offsets example using `SingleClusterTopicMetadataService` with per-cluster starting and stopping offset initializers.
- Demonstrated a per-cluster starting offset overriding the global builder default and used `set_bounded(...)` so stopping offsets apply.
- Mirrored the example in the Chinese documentation tree.

## Validation

- `git diff --check upstream/main...HEAD` — passed
- `./mvnw -N apache-rat:check` — passed

## Notes

No repository-local Markdown/Hugo docs build target exists; no production code changed.