### PR TITLE
[hotfix] Fix reader idleness test output

### DIFF
--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderTest.java
@@ -342,7 +342,7 @@ public class DynamicKafkaSourceReaderTest extends SourceReaderTestBase<DynamicKa
     void testNotifyNoMoreSplits() throws Exception {
         TestingReaderContext context = new TestingReaderContext();
         try (DynamicKafkaSourceReader<Integer> reader = createReaderWithoutStart(context)) {
-            TestingReaderOutput<Integer> readerOutput = new TestingReaderOutput<>();
+            TrackingReaderOutput<Integer> readerOutput = new TrackingReaderOutput<>();
             reader.start();
 
             // Splits assigned


### PR DESCRIPTION
## Summary

Fix the CI regression introduced by two commits merged before, whose CI individually succeeded but has a test class mismatch

`DynamicKafkaSourceReaderTest.testNotifyNoMoreSplits` still used `TestingReaderOutput`, whose `markIdle()` throws `UnsupportedOperationException`. The reader now marks its output idle after consuming its final active splits.

## Changes

- Use the existing `TrackingReaderOutput` fixture in `testNotifyNoMoreSplits`.
- Preserve the test’s existing end-of-input and emitted-record assertions.

## Validation

- `mvn -f flink-connector-kafka/pom.xml -DskipTests test` — passed
- `git diff --check upstream/main...HEAD` — passed
- `mvn -f flink-connector-kafka/pom.xml -Dtest=DynamicKafkaSourceReaderTest#testNotifyNoMoreSplits test` — compilation, checkstyle, and spotless passed; runtime blocked because this machine has no valid Docker environment for Kafka Testcontainers

## Notes

The failing Actions job reported:

`DynamicKafkaSourceReaderTest.testNotifyNoMoreSplits:364 » UnsupportedOperation`

The pushed branch already triggered [fork CI run 28252248219](https://github.com/bowenli86/flink-connector-kafka/actions/runs/28252248219), currently running. I paused monitoring so you can inspect/create the PR first. Send me the actual PR URL afterward and I’ll resume babysitting CI.
