### PR TITLE
[FLINK-39193][Kafka Connector] Fix Kafka client compatibility for committed offset lookup

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -32,10 +32,10 @@ import org.apache.flink.util.FlinkRuntimeException;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
-import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsSpec;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
@@ -685,23 +685,11 @@ public class KafkaSourceEnumerator
 
         @Override
         public Map<TopicPartition, Long> committedOffsets(Collection<TopicPartition> partitions) {
-            ListConsumerGroupOffsetsSpec offsetsSpec =
-                    new ListConsumerGroupOffsetsSpec().topicPartitions(partitions);
             try {
                 return adminClient
-                        .listConsumerGroupOffsets(Collections.singletonMap(groupId, offsetsSpec))
+                        .listConsumerGroupOffsets(groupId)
                         .partitionsToOffsetAndMetadata()
-                        .thenApply(
-                                result -> {
-                                    Map<TopicPartition, Long> offsets = new HashMap<>();
-                                    result.forEach(
-                                            (tp, oam) -> {
-                                                if (oam != null) {
-                                                    offsets.put(tp, oam.offset());
-                                                }
-                                            });
-                                    return offsets;
-                                })
+                        .thenApply(result -> filterCommittedOffsets(partitions, result))
                         .get();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -714,6 +702,20 @@ public class KafkaSourceEnumerator
                                 + " due to",
                         e);
             }
+        }
+
+        @VisibleForTesting
+        static Map<TopicPartition, Long> filterCommittedOffsets(
+                Collection<TopicPartition> partitions,
+                Map<TopicPartition, OffsetAndMetadata> committedOffsets) {
+            Map<TopicPartition, Long> offsets = new HashMap<>();
+            for (TopicPartition partition : partitions) {
+                OffsetAndMetadata offsetAndMetadata = committedOffsets.get(partition);
+                if (offsetAndMetadata != null) {
+                    offsets.put(partition, offsetAndMetadata.offset());
+                }
+            }
+            return offsets;
         }
 
         /**

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/PartitionOffsetsRetrieverImplTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/PartitionOffsetsRetrieverImplTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.enumerator;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+class PartitionOffsetsRetrieverImplTest {
+
+    @Test
+    void filtersCommittedOffsetsToRequestedPartitionsWithNonNullOffsets() {
+        TopicPartition requestedWithOffset = new TopicPartition("topic", 0);
+        TopicPartition requestedWithNullOffset = new TopicPartition("topic", 1);
+        TopicPartition requestedWithoutOffset = new TopicPartition("topic", 2);
+        TopicPartition unrequestedWithOffset = new TopicPartition("topic", 3);
+
+        Map<TopicPartition, OffsetAndMetadata> committedOffsets = new HashMap<>();
+        committedOffsets.put(requestedWithOffset, new OffsetAndMetadata(42L));
+        committedOffsets.put(requestedWithNullOffset, null);
+        committedOffsets.put(unrequestedWithOffset, new OffsetAndMetadata(123L));
+
+        Map<TopicPartition, Long> filteredOffsets =
+                KafkaSourceEnumerator.PartitionOffsetsRetrieverImpl.filterCommittedOffsets(
+                        Arrays.asList(
+                                requestedWithOffset,
+                                requestedWithNullOffset,
+                                requestedWithoutOffset),
+                        committedOffsets);
+
+        assertThat(filteredOffsets).containsOnly(entry(requestedWithOffset, 42L));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

FLINK-39193 reports a `NoClassDefFoundError` for `org/apache/kafka/clients/admin/ListConsumerGroupOffsetsSpec` when an incomplete specific-offset map causes the Kafka source to look up committed offsets.

The committed-offset lookup started referencing `ListConsumerGroupOffsetsSpec` when the connector upgraded to Kafka 4.0. That class and the map-based `listConsumerGroupOffsets(...)` overload are not available in Kafka clients before 3.3, so a runtime classpath containing an older Kafka client can fail before the lookup is executed.

This PR now fixes that library compatibility issue without changing offset-initialization semantics.

## Brief change log

- Use the long-standing `AdminClient#listConsumerGroupOffsets(String)` overload instead of directly referencing `ListConsumerGroupOffsetsSpec`.
- Filter the returned consumer-group offsets to the partitions requested by the initializer.
- Ignore missing or null committed offsets, preserving the existing fallback behavior.
- Add a focused unit test for requested-partition filtering.
- Restore the existing specified-offset behavior: missing specified offsets still prefer committed offsets before applying the configured reset strategy.

The stable overload retrieves all committed offsets for the consumer group and filters them client-side. This is a deliberate compatibility trade-off that avoids reflection and keeps the production code linkable with older Kafka client runtimes.

## Verifying this change

- Verified with actual `kafka-clients` JARs that:
  - `ListConsumerGroupOffsetsSpec` is absent through 3.2.3 and present from 3.3.0.
  - `AdminClient#listConsumerGroupOffsets(String)` and `ListConsumerGroupOffsetsResult#partitionsToOffsetAndMetadata()` remain linkable across representative Kafka client versions from 2.1.1 through 4.2.x.
- Reproduced the original `NoClassDefFoundError` by compiling the map/spec call against Kafka 4.2.0 and running it with Kafka 2.3.1.
- Confirmed the stable string-overload probe links with representative Kafka client versions from 2.1.1 through 4.2.0.
- Focused regression test:
  - `mvn -pl flink-connector-kafka -Dtest=PartitionOffsetsRetrieverImplTest -DfailIfNoTests=false test`
  - `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`
  - Checkstyle: 0 violations
  - Spotless: 0 files need changes
- Confirmed the compiled `PartitionOffsetsRetrieverImpl` bytecode no longer references `ListConsumerGroupOffsetsSpec`.

Docker-backed Kafka integration tests were not run locally because this environment has no Docker daemon.

## AI Assistance

This pull request was prepared with AI assistance under human-directed scope for FLINK-39193. The root-cause analysis, compatibility matrix, code changes, focused tests, and final submission were reviewed and directed by the contributor.
