### PR TITLE
[FLINK-40094][Connectors/Kafka] Mark removed DynamicKafkaSource split outputs idle before release

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
@@ -395,7 +395,7 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
         if (latestReaderOutput == null) {
             pendingSplitOutputReleases.add(splitId);
         } else {
-            latestReaderOutput.releaseOutputForSplit(splitId);
+            markSplitIdleAndReleaseOutput(latestReaderOutput, splitId);
         }
     }
 
@@ -405,9 +405,16 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
         }
 
         for (String splitId : pendingSplitOutputReleases) {
-            readerOutput.releaseOutputForSplit(splitId);
+            markSplitIdleAndReleaseOutput(readerOutput, splitId);
         }
         pendingSplitOutputReleases.clear();
+    }
+
+    private void markSplitIdleAndReleaseOutput(ReaderOutput<T> readerOutput, String splitId) {
+        // Unregistering a split output does not recompute Flink's split-local watermark or
+        // idleness. Mark it idle first so a removed split cannot keep the source output active.
+        readerOutput.createOutputForSplit(splitId).markIdle();
+        readerOutput.releaseOutputForSplit(splitId);
     }
 
     private static boolean isSplitForActiveClusters(

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
@@ -389,6 +389,12 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
                 notifyNoMoreSplits();
             }
         }
+
+        // Releasing the last split output can expose the runtime output as idle immediately. Keep
+        // the reader-level state in sync so a replacement split is reactivated before polling it.
+        if (latestReaderOutput != null) {
+            maybeUpdateNoActiveSplitOutputIdleness(latestReaderOutput);
+        }
     }
 
     private void releaseOrDeferSplitOutput(String splitId) {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.core.io.InputStatus;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -63,13 +64,7 @@ class DynamicKafkaSourceReaderIdlenessTest {
             reader.start();
             reader.handleSourceEvents(getMetadataUpdateEvent());
 
-            DynamicKafkaSourceSplit split =
-                    new DynamicKafkaSourceSplit(
-                            KAFKA_CLUSTER_ID,
-                            new KafkaPartitionSplit(
-                                    new TopicPartition(TOPIC, 0),
-                                    0L,
-                                    KafkaPartitionSplit.NO_STOPPING_OFFSET));
+            DynamicKafkaSourceSplit split = getSplit(TOPIC);
             reader.addSplits(Collections.singletonList(split));
 
             CompletableFuture<Void> availabilityFuture = reader.isAvailable();
@@ -95,6 +90,39 @@ class DynamicKafkaSourceReaderIdlenessTest {
         }
     }
 
+    @Test
+    void testSplitReassignmentBeforeIdlePollReactivatesReaderOutput() throws Exception {
+        TestingReaderContext context = new TestingReaderContext();
+        try (DynamicKafkaSourceReader<byte[]> reader =
+                new DynamicKafkaSourceReader<>(
+                        context,
+                        KafkaRecordDeserializationSchema.valueOnly(ByteArrayDeserializer.class),
+                        getRequiredProperties())) {
+            reader.start();
+            reader.handleSourceEvents(getMetadataUpdateEvent());
+
+            DynamicKafkaSourceSplit removedSplit = getSplit(TOPIC);
+            reader.addSplits(Collections.singletonList(removedSplit));
+
+            TrackingReaderOutputWithIdleness<byte[]> readerOutput =
+                    new TrackingReaderOutputWithIdleness<>();
+            assertThat(reader.pollNext(readerOutput)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+
+            reader.handleSourceEvents(getMetadataUpdateEvent(REMAINING_TOPIC));
+            assertThat(readerOutput.isIdle()).isTrue();
+
+            reader.addSplits(Collections.singletonList(getSplit(REMAINING_TOPIC)));
+            assertThat(reader.pollNext(readerOutput)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+
+            assertThat(readerOutput.splitOutputEvents())
+                    .containsExactly(
+                            "idle:" + removedSplit.splitId(), "release:" + removedSplit.splitId());
+            assertThat(readerOutput.idleCount()).isEqualTo(1);
+            assertThat(readerOutput.activeCount()).isEqualTo(1);
+            assertThat(readerOutput.isIdle()).isFalse();
+        }
+    }
+
     private static MetadataUpdateEvent getMetadataUpdateEvent() {
         return getMetadataUpdateEvent(TOPIC);
     }
@@ -109,6 +137,13 @@ class DynamicKafkaSourceReaderIdlenessTest {
                         new KafkaStream(
                                 TOPIC,
                                 Collections.singletonMap(KAFKA_CLUSTER_ID, clusterMetadata))));
+    }
+
+    private static DynamicKafkaSourceSplit getSplit(String topic) {
+        return new DynamicKafkaSourceSplit(
+                KAFKA_CLUSTER_ID,
+                new KafkaPartitionSplit(
+                        new TopicPartition(topic, 0), 0L, KafkaPartitionSplit.NO_STOPPING_OFFSET));
     }
 
     private static Properties getRequiredProperties() {
@@ -143,6 +178,8 @@ class DynamicKafkaSourceReaderIdlenessTest {
                 @Override
                 public void markIdle() {
                     splitOutputEvents.add("idle:" + splitId);
+                    // Model the split-output multiplexer publishing aggregate idleness.
+                    idle = true;
                 }
 
                 @Override

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderIdlenessTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.kafka.dynamic.source.reader;
 
 import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.kafka.dynamic.metadata.ClusterMetadata;
 import org.apache.flink.connector.kafka.dynamic.metadata.KafkaStream;
 import org.apache.flink.connector.kafka.dynamic.source.MetadataUpdateEvent;
@@ -32,7 +33,8 @@ import org.apache.flink.core.io.InputStatus;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,8 +50,10 @@ class DynamicKafkaSourceReaderIdlenessTest {
     private static final String REMAINING_TOPIC = "remaining-topic";
     private static final String KAFKA_CLUSTER_ID = "cluster-1";
 
-    @Test
-    void testMetadataRemovalMarksReaderIdleWhenAllActiveSplitsRemoved() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testMetadataRemovalMarksReaderAndSplitOutputIdle(boolean outputAvailableBeforeRemoval)
+            throws Exception {
         TestingReaderContext context = new TestingReaderContext();
         try (DynamicKafkaSourceReader<byte[]> reader =
                 new DynamicKafkaSourceReader<>(
@@ -71,15 +75,20 @@ class DynamicKafkaSourceReaderIdlenessTest {
             CompletableFuture<Void> availabilityFuture = reader.isAvailable();
             assertThat(availabilityFuture).isNotDone();
 
+            TrackingReaderOutputWithIdleness<byte[]> readerOutput =
+                    new TrackingReaderOutputWithIdleness<>();
+            if (outputAvailableBeforeRemoval) {
+                assertThat(reader.pollNext(readerOutput)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+            }
+
             reader.handleSourceEvents(getMetadataUpdateEvent(REMAINING_TOPIC));
             assertThat(reader.getAvailabilityHelperSize()).isEqualTo(1);
             assertThat(availabilityFuture).isDone();
 
-            TrackingReaderOutputWithIdleness<byte[]> readerOutput =
-                    new TrackingReaderOutputWithIdleness<>();
             assertThat(reader.pollNext(readerOutput)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
             assertThat(reader.pollNext(readerOutput)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
-            assertThat(readerOutput.releasedSplitIds()).containsExactly(split.splitId());
+            assertThat(readerOutput.splitOutputEvents())
+                    .containsExactly("idle:" + split.splitId(), "release:" + split.splitId());
             assertThat(readerOutput.idleCount()).isEqualTo(1);
             assertThat(readerOutput.activeCount()).isZero();
             assertThat(readerOutput.isIdle()).isTrue();
@@ -117,7 +126,29 @@ class DynamicKafkaSourceReaderIdlenessTest {
         private int idleCount;
         private int activeCount;
         private boolean idle;
-        private final List<String> releasedSplitIds = new ArrayList<>();
+        private final List<String> splitOutputEvents = new ArrayList<>();
+
+        @Override
+        public SourceOutput<E> createOutputForSplit(String splitId) {
+            return new SourceOutput<E>() {
+                @Override
+                public void collect(E record) {}
+
+                @Override
+                public void collect(E record, long timestamp) {}
+
+                @Override
+                public void emitWatermark(Watermark watermark) {}
+
+                @Override
+                public void markIdle() {
+                    splitOutputEvents.add("idle:" + splitId);
+                }
+
+                @Override
+                public void markActive() {}
+            };
+        }
 
         @Override
         public void emitWatermark(Watermark watermark) {}
@@ -136,7 +167,7 @@ class DynamicKafkaSourceReaderIdlenessTest {
 
         @Override
         public void releaseOutputForSplit(String splitId) {
-            releasedSplitIds.add(splitId);
+            splitOutputEvents.add("release:" + splitId);
         }
 
         private int idleCount() {
@@ -151,8 +182,8 @@ class DynamicKafkaSourceReaderIdlenessTest {
             return idle;
         }
 
-        private List<String> releasedSplitIds() {
-            return releasedSplitIds;
+        private List<String> splitOutputEvents() {
+            return splitOutputEvents;
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This implements [FLINK-40094](https://issues.apache.org/jira/browse/FLINK-40094) as the mandatory correctness follow-up to [FLINK-39979](https://issues.apache.org/jira/browse/FLINK-39979) and [#276](https://github.com/apache/flink-connector-kafka/pull/276).

#276 correctly marks the `DynamicKafkaSource` reader's main output idle when metadata removal leaves a source subtask without active subreaders. Flink also maintains split-local outputs for source watermark aggregation, however, and directly calling `releaseOutputForSplit` does not recompute or publish their aggregate watermark/idleness. A removed split that was active can therefore leave the subtask output active and pin the downstream watermark even after the main reader output becomes idle.

This change marks each removed split output idle immediately before releasing it. That forces Flink to publish the updated aggregate state before the split-local output is unregistered.

## Brief change log

- Mark removed split outputs idle before both immediate and deferred release.
- Synchronize the reader-level idle state so a replacement split is reactivated before polling.
- Add no-Docker regression coverage for immediate/deferred release, `idle` then `release`
  ordering, and split reassignment before the next poll.

## Verifying this change

- `mvn -pl flink-connector-kafka -Dtest=DynamicKafkaSourceReaderIdlenessTest -DskipITs -Drat.skip=true test`
- `mvn -pl flink-connector-kafka -Drat.skip=true clean test`

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (OpenAI Codex)

Generated-by: OpenAI Codex
