### PR TITLE
[FLINK-40139][Connectors/Kafka] Add default JUnit test timeout to fail hung tests fast

### DIFF
--- a/flink-connector-kafka/src/test/resources/junit-platform.properties
+++ b/flink-connector-kafka/src/test/resources/junit-platform.properties
@@ -1,0 +1,22 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+
+# Fail hung test methods after 15 minutes instead of consuming the CI job's
+# global timeout. Individual tests can override this with @Timeout.
+junit.jupiter.execution.timeout.testable.method.default = 15 m
+junit.jupiter.execution.timeout.mode = disabled_on_debug


### PR DESCRIPTION
## What is the purpose of the change

A hung test consumes the CI job's whole test-step budget: the step timeout (50 minutes for `push_pr.yml` through the shared `ci.yml` default, 45 minutes in `weekly.yml`) kills the job, no stack trace is produced, and every test scheduled after it is lost. A per-method timeout turns that into one failed test with the stuck thread's stack trace, while the rest of the suite runs and reports.

## Brief change log

- Add `flink-connector-kafka/src/test/resources/junit-platform.properties` with `junit.jupiter.execution.timeout.testable.method.default = 15 m`. The timeout applies to `@Test` and `@TestTemplate` methods only; lifecycle methods such as container startup in `@BeforeAll` are unaffected.
- Set `junit.jupiter.execution.timeout.mode = disabled_on_debug` so a debugger session is not interrupted.
- A test can still override the default with `@Timeout`.

The file is a test resource of `flink-connector-kafka` only. The module's test jar has an explicit include list that leaves it out, so `flink-sql-connector-kafka` and the end-to-end modules are unchanged.

## Verifying this change

The 15-minute default is checked against the latest build on `main`, [run 34476453743](https://github.com/apache/flink-connector-kafka/actions/runs/34476453743) at 48ddbf1f (Flink 2.2.1 on JDK 11, 17, and 21):

| | JDK 11 | JDK 17 | JDK 21 |
|---|---|---|---|
| Job wall time | 27 min | 26 min | 25 min |
| `flink-connector-kafka`, `default-test` execution | 438 tests | 438 tests | 438 tests |
| `flink-connector-kafka`, `integration-tests` execution | 325 tests, 1 skipped | 325 tests, 1 skipped | 325 tests, 1 skipped |
| `KafkaSinkITCase` class total (slowest class) | 714 s | 712 s | 711 s |
| `SourceTopicIntegrityITCase` class total | 112 s | 115 s | 119 s |
| `DynamicKafkaSourceITTest` class total | 113 s | 108 s | 106 s |
| `KafkaTableITCase` class total | 108 s | 107 s | 104 s |

The CI console reports durations per class, not per method, so the class total is the bound: no method runs longer than its class, and the slowest class finishes in under 12 minutes on every JDK. Every other class in the module finishes in under 120 seconds. The slowest class is within 1% across the three JDKs, so the JDK does not move the margin.

15 minutes is also below both step timeouts, so the per-method timeout fires first and the diagnostic is produced.

## Does this pull request potentially affect one of the following parts

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Fable 5)
