### PR TITLE
[FLINK-36434][Connectors/Kafka] Create the KafkaConsumer lazily on the split fetcher thread

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -66,12 +66,27 @@ public class KafkaPartitionSplitReader
     private static final Logger LOG = LoggerFactory.getLogger(KafkaPartitionSplitReader.class);
     private static final long POLL_TIMEOUT = 10000L;
 
-    private final KafkaConsumer<byte[], byte[]> consumer;
+    private final Properties consumerProps;
     private final Map<TopicPartition, Long> stoppingOffsets;
     private final String groupId;
     private final int subtaskId;
 
     private final KafkaSourceReaderMetrics kafkaSourceReaderMetrics;
+
+    /** Guards lazy creation of {@link #consumer} and the {@link #pendingWakeup} flag. */
+    private final Object consumerLock = new Object();
+
+    /**
+     * The Kafka consumer. Created lazily on the first thread that actually uses it — the split
+     * fetcher thread — rather than on the thread constructing this reader (the source-reader or
+     * checkpoint thread). {@link KafkaConsumer} is not thread-safe, so it must live on the thread
+     * that uses it (FLINK-36434). Access outside {@link #ensureConsumer()} / {@link #wakeUp()} is
+     * only safe after a call to {@link #ensureConsumer()} on the same thread.
+     */
+    @Nullable private volatile KafkaConsumer<byte[], byte[]> consumer;
+
+    /** Set when {@link #wakeUp()} is called before the consumer exists; guarded by the lock. */
+    private boolean pendingWakeup;
 
     // Tracking empty splits that has not been added to finished splits in fetch()
     private final Set<String> emptySplits = new HashSet<>();
@@ -94,17 +109,56 @@ public class KafkaPartitionSplitReader
         consumerProps.putAll(props);
         consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, createConsumerClientId(props));
         setConsumerClientRack(consumerProps, rackIdSupplier);
-        this.consumer = new KafkaConsumer<>(consumerProps);
+        this.consumerProps = consumerProps;
         this.stoppingOffsets = new HashMap<>();
         this.groupId = consumerProps.getProperty(ConsumerConfig.GROUP_ID_CONFIG);
+    }
 
-        // Metric registration
-        maybeRegisterKafkaConsumerMetrics(props, kafkaSourceReaderMetrics, consumer);
-        this.kafkaSourceReaderMetrics.registerNumBytesIn(consumer);
+    /**
+     * Returns the consumer, creating it on the calling thread on first use.
+     *
+     * <p>The reader is constructed on the source-reader (or, when a fetcher is re-created for an
+     * offset commit, the checkpoint) thread, while the consumer is used almost exclusively on the
+     * split fetcher thread. Creating the consumer eagerly in the constructor therefore puts it on
+     * the wrong thread. All consumer-touching {@link SplitReader} methods run on the fetcher
+     * thread, so deferring creation to the first such call keeps construction and use on the same
+     * thread. The only cross-thread entry point remains {@link #wakeUp()}, which is the one call
+     * {@link KafkaConsumer} documents as thread-safe.
+     */
+    private KafkaConsumer<byte[], byte[]> ensureConsumer() {
+        KafkaConsumer<byte[], byte[]> currentConsumer = this.consumer;
+        if (currentConsumer != null) {
+            return currentConsumer;
+        }
+        synchronized (consumerLock) {
+            currentConsumer = this.consumer;
+            if (currentConsumer == null) {
+                currentConsumer = createConsumer(consumerProps);
+                maybeRegisterKafkaConsumerMetrics(
+                        consumerProps, kafkaSourceReaderMetrics, currentConsumer);
+                kafkaSourceReaderMetrics.registerNumBytesIn(currentConsumer);
+                if (pendingWakeup) {
+                    // A wakeUp() arrived before the consumer existed. Apply it now so that the
+                    // first blocking call still observes it, matching the behavior of a wakeup
+                    // against an eagerly-created consumer.
+                    currentConsumer.wakeup();
+                    pendingWakeup = false;
+                }
+                this.consumer = currentConsumer;
+            }
+            return currentConsumer;
+        }
+    }
+
+    /** Creates the {@link KafkaConsumer}. Overridable for tests to observe the creation. */
+    @VisibleForTesting
+    protected KafkaConsumer<byte[], byte[]> createConsumer(Properties consumerProps) {
+        return new KafkaConsumer<>(consumerProps);
     }
 
     @Override
     public RecordsWithSplitIds<ConsumerRecord<byte[], byte[]>> fetch() throws IOException {
+        final KafkaConsumer<byte[], byte[]> consumer = ensureConsumer();
         ConsumerRecords<byte[], byte[]> consumerRecords;
         try {
             consumerRecords = consumer.poll(Duration.ofMillis(POLL_TIMEOUT));
@@ -180,6 +234,7 @@ public class KafkaPartitionSplitReader
                             "The SplitChange type of %s is not supported.",
                             splitsChange.getClass()));
         }
+        final KafkaConsumer<byte[], byte[]> consumer = ensureConsumer();
 
         // Assignment.
         List<TopicPartition> newPartitionAssignments = new ArrayList<>();
@@ -228,18 +283,34 @@ public class KafkaPartitionSplitReader
 
     @Override
     public void wakeUp() {
-        consumer.wakeup();
+        // The only method called from a thread other than the fetcher thread, relying on
+        // KafkaConsumer.wakeup() being the one documented thread-safe consumer call. If the
+        // consumer does not exist yet, record the wakeup and apply it on creation.
+        synchronized (consumerLock) {
+            KafkaConsumer<byte[], byte[]> currentConsumer = this.consumer;
+            if (currentConsumer != null) {
+                currentConsumer.wakeup();
+            } else {
+                pendingWakeup = true;
+            }
+        }
     }
 
     @Override
     public void close() throws Exception {
-        consumer.close();
+        synchronized (consumerLock) {
+            KafkaConsumer<byte[], byte[]> currentConsumer = this.consumer;
+            if (currentConsumer != null) {
+                currentConsumer.close();
+            }
+        }
     }
 
     @Override
     public void pauseOrResumeSplits(
             Collection<KafkaPartitionSplit> splitsToPause,
             Collection<KafkaPartitionSplit> splitsToResume) {
+        final KafkaConsumer<byte[], byte[]> consumer = ensureConsumer();
         // Filter against current assignment to avoid IllegalStateException when a partition
         // was concurrently unassigned by fetch() or removeEmptySplits().
         Set<TopicPartition> assigned = consumer.assignment();
@@ -270,12 +341,12 @@ public class KafkaPartitionSplitReader
     public void notifyCheckpointComplete(
             Map<TopicPartition, OffsetAndMetadata> offsetsToCommit,
             OffsetCommitCallback offsetCommitCallback) {
-        consumer.commitAsync(offsetsToCommit, offsetCommitCallback);
+        ensureConsumer().commitAsync(offsetsToCommit, offsetCommitCallback);
     }
 
     @VisibleForTesting
     KafkaConsumer<byte[], byte[]> consumer() {
-        return consumer;
+        return ensureConsumer();
     }
 
     // --------------- private helper method ----------------------
@@ -295,7 +366,7 @@ public class KafkaPartitionSplitReader
     }
 
     long getConsumerPosition(TopicPartition tp, String msg) {
-        return retryOnWakeup(() -> consumer.position(tp), msg);
+        return retryOnWakeup(() -> ensureConsumer().position(tp), msg);
     }
 
     private void parseStartingOffsets(
@@ -348,30 +419,31 @@ public class KafkaPartitionSplitReader
 
         if (!partitionsStartingFromEarliest.isEmpty()) {
             LOG.trace("Seeking starting offsets to beginning: {}", partitionsStartingFromEarliest);
-            consumer.seekToBeginning(partitionsStartingFromEarliest);
+            ensureConsumer().seekToBeginning(partitionsStartingFromEarliest);
         }
 
         if (!partitionsStartingFromLatest.isEmpty()) {
             LOG.trace("Seeking starting offsets to end: {}", partitionsStartingFromLatest);
-            consumer.seekToEnd(partitionsStartingFromLatest);
+            ensureConsumer().seekToEnd(partitionsStartingFromLatest);
         }
 
         if (!partitionsStartingFromSpecifiedOffsets.isEmpty()) {
             LOG.trace(
                     "Seeking starting offsets to specified offsets: {}",
                     partitionsStartingFromSpecifiedOffsets);
-            partitionsStartingFromSpecifiedOffsets.forEach(consumer::seek);
+            partitionsStartingFromSpecifiedOffsets.forEach(ensureConsumer()::seek);
         }
     }
 
     private void acquireAndSetStoppingOffsets(
             List<TopicPartition> partitionsStoppingAtLatest,
             Set<TopicPartition> partitionsStoppingAtCommitted) {
-        Map<TopicPartition, Long> endOffset = consumer.endOffsets(partitionsStoppingAtLatest);
+        Map<TopicPartition, Long> endOffset =
+                ensureConsumer().endOffsets(partitionsStoppingAtLatest);
         stoppingOffsets.putAll(endOffset);
         if (!partitionsStoppingAtCommitted.isEmpty()) {
             retryOnWakeup(
-                            () -> consumer.committed(partitionsStoppingAtCommitted),
+                            () -> ensureConsumer().committed(partitionsStoppingAtCommitted),
                             "getting committed offset as stopping offsets")
                     .forEach(
                             (tp, offsetAndMetadata) -> {
@@ -389,7 +461,7 @@ public class KafkaPartitionSplitReader
     private void removeEmptySplits() {
         List<TopicPartition> emptyPartitions = new ArrayList<>();
         // If none of the partitions have any records,
-        for (TopicPartition tp : consumer.assignment()) {
+        for (TopicPartition tp : ensureConsumer().assignment()) {
             long startingOffset =
                     getConsumerPosition(tp, "getting starting offset to check if split is empty");
             if (startingOffset >= getStoppingOffset(tp)) {
@@ -414,7 +486,7 @@ public class KafkaPartitionSplitReader
             SplitsChange<KafkaPartitionSplit> splitsChange) {
         if (LOG.isDebugEnabled()) {
             StringJoiner splitsInfo = new StringJoiner(",");
-            Set<TopicPartition> assginment = consumer.assignment();
+            Set<TopicPartition> assginment = ensureConsumer().assignment();
             for (KafkaPartitionSplit split : splitsChange.splits()) {
                 if (!assginment.contains(split.getTopicPartition())) {
                     continue;
@@ -434,6 +506,7 @@ public class KafkaPartitionSplitReader
     }
 
     private void unassignPartitions(Collection<TopicPartition> partitionsToUnassign) {
+        final KafkaConsumer<byte[], byte[]> consumer = ensureConsumer();
         Collection<TopicPartition> newAssignment = new HashSet<>(consumer.assignment());
         newAssignment.removeAll(partitionsToUnassign);
         consumer.assign(newAssignment);

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -83,9 +84,12 @@ public class KafkaPartitionSplitReader
      * that uses it (FLINK-36434). Access outside {@link #ensureConsumer()} / {@link #wakeUp()} is
      * only safe after a call to {@link #ensureConsumer()} on the same thread.
      */
-    @Nullable private volatile KafkaConsumer<byte[], byte[]> consumer;
+    @GuardedBy("consumerLock")
+    @Nullable
+    private volatile KafkaConsumer<byte[], byte[]> consumer;
 
-    /** Set when {@link #wakeUp()} is called before the consumer exists; guarded by the lock. */
+    /** Set when {@link #wakeUp()} is called before the consumer exists. */
+    @GuardedBy("consumerLock")
     private boolean pendingWakeup;
 
     // Tracking empty splits that has not been added to finished splits in fetch()
@@ -150,9 +154,9 @@ public class KafkaPartitionSplitReader
         }
     }
 
-    /** Creates the {@link KafkaConsumer}. Overridable for tests to observe the creation. */
+    /** Creates the {@link KafkaConsumer}. Overridable by same-package tests to observe creation. */
     @VisibleForTesting
-    protected KafkaConsumer<byte[], byte[]> createConsumer(Properties consumerProps) {
+    KafkaConsumer<byte[], byte[]> createConsumer(Properties consumerProps) {
         return new KafkaConsumer<>(consumerProps);
     }
 

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -134,8 +134,12 @@ public class KafkaPartitionSplitReader
         return currentConsumer;
     }
 
-    /** Creates the {@link KafkaConsumer}. Overridable by same-package tests to observe creation. */
-    @VisibleForTesting
+    /**
+     * Creates the {@link KafkaConsumer}. Overridable by same-package tests to observe creation.
+     *
+     * <p>Deliberately not annotated with {@code @VisibleForTesting}: the freezing ArchUnit rule
+     * flags new uses of the internal annotation in connector production code.
+     */
     KafkaConsumer<byte[], byte[]> createConsumer(Properties consumerProps) {
         return new KafkaConsumer<>(consumerProps);
     }

--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -43,7 +43,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -74,23 +73,15 @@ public class KafkaPartitionSplitReader
 
     private final KafkaSourceReaderMetrics kafkaSourceReaderMetrics;
 
-    /** Guards lazy creation of {@link #consumer} and the {@link #pendingWakeup} flag. */
-    private final Object consumerLock = new Object();
-
     /**
      * The Kafka consumer. Created lazily on the first thread that actually uses it — the split
      * fetcher thread — rather than on the thread constructing this reader (the source-reader or
      * checkpoint thread). {@link KafkaConsumer} is not thread-safe, so it must live on the thread
-     * that uses it (FLINK-36434). Access outside {@link #ensureConsumer()} / {@link #wakeUp()} is
-     * only safe after a call to {@link #ensureConsumer()} on the same thread.
+     * that uses it (FLINK-36434). Only ever written by {@link #ensureConsumer()} on the fetcher
+     * thread; {@code volatile} solely for the cross-thread reads in {@link #wakeUp()} and {@link
+     * #close()}.
      */
-    @GuardedBy("consumerLock")
-    @Nullable
-    private volatile KafkaConsumer<byte[], byte[]> consumer;
-
-    /** Set when {@link #wakeUp()} is called before the consumer exists. */
-    @GuardedBy("consumerLock")
-    private boolean pendingWakeup;
+    @Nullable private volatile KafkaConsumer<byte[], byte[]> consumer;
 
     // Tracking empty splits that has not been added to finished splits in fetch()
     private final Set<String> emptySplits = new HashSet<>();
@@ -130,28 +121,17 @@ public class KafkaPartitionSplitReader
      * {@link KafkaConsumer} documents as thread-safe.
      */
     private KafkaConsumer<byte[], byte[]> ensureConsumer() {
+        // Single-writer: only the fetcher thread calls this, so the creation branch needs no
+        // guard; the field is volatile solely for the cross-thread reads in wakeUp() and close().
         KafkaConsumer<byte[], byte[]> currentConsumer = this.consumer;
-        if (currentConsumer != null) {
-            return currentConsumer;
+        if (currentConsumer == null) {
+            currentConsumer = createConsumer(consumerProps);
+            maybeRegisterKafkaConsumerMetrics(
+                    consumerProps, kafkaSourceReaderMetrics, currentConsumer);
+            kafkaSourceReaderMetrics.registerNumBytesIn(currentConsumer);
+            this.consumer = currentConsumer;
         }
-        synchronized (consumerLock) {
-            currentConsumer = this.consumer;
-            if (currentConsumer == null) {
-                currentConsumer = createConsumer(consumerProps);
-                maybeRegisterKafkaConsumerMetrics(
-                        consumerProps, kafkaSourceReaderMetrics, currentConsumer);
-                kafkaSourceReaderMetrics.registerNumBytesIn(currentConsumer);
-                if (pendingWakeup) {
-                    // A wakeUp() arrived before the consumer existed. Apply it now so that the
-                    // first blocking call still observes it, matching the behavior of a wakeup
-                    // against an eagerly-created consumer.
-                    currentConsumer.wakeup();
-                    pendingWakeup = false;
-                }
-                this.consumer = currentConsumer;
-            }
-            return currentConsumer;
-        }
+        return currentConsumer;
     }
 
     /** Creates the {@link KafkaConsumer}. Overridable by same-package tests to observe creation. */
@@ -288,25 +268,26 @@ public class KafkaPartitionSplitReader
     @Override
     public void wakeUp() {
         // The only method called from a thread other than the fetcher thread, relying on
-        // KafkaConsumer.wakeup() being the one documented thread-safe consumer call. If the
-        // consumer does not exist yet, record the wakeup and apply it on creation.
-        synchronized (consumerLock) {
-            KafkaConsumer<byte[], byte[]> currentConsumer = this.consumer;
-            if (currentConsumer != null) {
-                currentConsumer.wakeup();
-            } else {
-                pendingWakeup = true;
-            }
+        // KafkaConsumer.wakeup() being the one documented thread-safe consumer call.
+        //
+        // wakeUp() only ever targets a running fetch task (see SplitReader#wakeUp javadoc), which
+        // the base SplitFetcher can only schedule after handleSplitsChanges() — and therefore
+        // ensureConsumer() — has run at least once on the fetcher thread. So the consumer is
+        // always non-null here in practice; a pre-creation wakeup has nothing to interrupt and is
+        // safely dropped. Note this leans on an implementation invariant of
+        // SplitFetcher/AddSplitsTask rather than a documented contract beyond wakeUp()'s own
+        // javadoc scoping.
+        KafkaConsumer<byte[], byte[]> currentConsumer = this.consumer;
+        if (currentConsumer != null) {
+            currentConsumer.wakeup();
         }
     }
 
     @Override
     public void close() throws Exception {
-        synchronized (consumerLock) {
-            KafkaConsumer<byte[], byte[]> currentConsumer = this.consumer;
-            if (currentConsumer != null) {
-                currentConsumer.close();
-            }
+        KafkaConsumer<byte[], byte[]> currentConsumer = this.consumer;
+        if (currentConsumer != null) {
+            currentConsumer.close();
         }
     }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderConsumerThreadTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderConsumerThreadTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.reader;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.kafka.source.KafkaSourceOptions;
+import org.apache.flink.connector.kafka.source.metrics.KafkaSourceReaderMetrics;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Unit tests for FLINK-36434: the {@link KafkaConsumer} inside {@link KafkaPartitionSplitReader}
+ * must be created lazily on the thread that uses it (the split fetcher thread), not on the thread
+ * that constructs the reader (the source-reader or checkpoint thread), because the consumer is not
+ * thread-safe.
+ *
+ * <p>These tests need no running Kafka cluster: constructing a {@link KafkaConsumer} performs no
+ * network I/O, and {@link KafkaPartitionSplitReader#fetch()} tolerates the {@code
+ * IllegalStateException}/{@code WakeupException} that polling without an assignment raises.
+ */
+class KafkaPartitionSplitReaderConsumerThreadTest {
+
+    /** Records the thread the consumer was created on and every {@code wakeup()} call. */
+    private static class CreationRecordingReader extends KafkaPartitionSplitReader {
+        private final AtomicReference<Thread> creationThread = new AtomicReference<>();
+        private final AtomicInteger wakeups = new AtomicInteger();
+
+        CreationRecordingReader() {
+            super(
+                    testProperties(),
+                    new TestingReaderContext(
+                            new Configuration(),
+                            UnregisteredMetricsGroup.createSourceReaderMetricGroup()),
+                    new KafkaSourceReaderMetrics(
+                            UnregisteredMetricsGroup.createSourceReaderMetricGroup()));
+        }
+
+        @Override
+        protected KafkaConsumer<byte[], byte[]> createConsumer(Properties consumerProps) {
+            creationThread.set(Thread.currentThread());
+            return new KafkaConsumer<byte[], byte[]>(consumerProps) {
+                @Override
+                public void wakeup() {
+                    wakeups.incrementAndGet();
+                    super.wakeup();
+                }
+            };
+        }
+    }
+
+    private static Properties testProperties() {
+        Properties props = new Properties();
+        // Never contacted: the consumer performs no network I/O until the first poll-style call.
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1");
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "test-group");
+        // Keep close() from attempting an offset auto-commit against the unreachable broker.
+        props.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.setProperty(
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                ByteArrayDeserializer.class.getName());
+        props.setProperty(
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                ByteArrayDeserializer.class.getName());
+        props.setProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key(), "test-client");
+        return props;
+    }
+
+    @Test
+    void testConsumerIsCreatedLazilyOnTheUsingThread() throws Exception {
+        CreationRecordingReader reader = new CreationRecordingReader();
+
+        // Constructing the reader (source-reader / checkpoint thread) must not create a consumer.
+        assertThat(reader.creationThread.get()).isNull();
+
+        // First use on a different thread (standing in for the split fetcher thread).
+        Thread useThread =
+                CompletableFuture.runAsync(
+                                () -> {
+                                    try {
+                                        reader.fetch();
+                                    } catch (Exception e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                })
+                        .thenApply(ignored -> reader.creationThread.get())
+                        .get();
+
+        assertThat(useThread).isNotNull();
+        assertThat(useThread).isNotSameAs(Thread.currentThread());
+        reader.close();
+    }
+
+    @Test
+    void testWakeUpBeforeConsumerCreationIsAppliedOnCreation() throws Exception {
+        CreationRecordingReader reader = new CreationRecordingReader();
+
+        // wakeUp() before the consumer exists: no NPE, no consumer created.
+        assertThatCode(reader::wakeUp).doesNotThrowAnyException();
+        assertThat(reader.creationThread.get()).isNull();
+        assertThat(reader.wakeups.get()).isZero();
+
+        // First use creates the consumer and applies the pending wakeup.
+        CompletableFuture.runAsync(
+                        () -> {
+                            try {
+                                reader.fetch();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                .get();
+
+        assertThat(reader.creationThread.get()).isNotNull();
+        assertThat(reader.wakeups.get()).isEqualTo(1);
+        reader.close();
+    }
+
+    @Test
+    void testWakeUpAfterCreationDelegatesDirectly() throws Exception {
+        CreationRecordingReader reader = new CreationRecordingReader();
+        // Trigger creation on this thread via the test accessor.
+        reader.consumer();
+        assertThat(reader.wakeups.get()).isZero();
+
+        reader.wakeUp();
+        assertThat(reader.wakeups.get()).isEqualTo(1);
+        reader.close();
+    }
+
+    @Test
+    void testCloseWithoutUseNeverCreatesConsumer() {
+        CreationRecordingReader reader = new CreationRecordingReader();
+        assertThatCode(reader::close).doesNotThrowAnyException();
+        assertThat(reader.creationThread.get()).isNull();
+    }
+}

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderLazyConsumerCreationTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderLazyConsumerCreationTest.java
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
  * network I/O, and {@link KafkaPartitionSplitReader#fetch()} tolerates the {@code
  * IllegalStateException}/{@code WakeupException} that polling without an assignment raises.
  */
-class KafkaPartitionSplitReaderConsumerThreadTest {
+class KafkaPartitionSplitReaderLazyConsumerCreationTest {
 
     /** Records the thread the consumer was created on and every {@code wakeup()} call. */
     private static class CreationRecordingReader extends KafkaPartitionSplitReader {
@@ -65,7 +65,7 @@ class KafkaPartitionSplitReaderConsumerThreadTest {
         }
 
         @Override
-        protected KafkaConsumer<byte[], byte[]> createConsumer(Properties consumerProps) {
+        KafkaConsumer<byte[], byte[]> createConsumer(Properties consumerProps) {
             creationThread.set(Thread.currentThread());
             return new KafkaConsumer<byte[], byte[]>(consumerProps) {
                 @Override

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderLazyConsumerCreationTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderLazyConsumerCreationTest.java
@@ -120,15 +120,18 @@ class KafkaPartitionSplitReaderLazyConsumerCreationTest {
     }
 
     @Test
-    void testWakeUpBeforeConsumerCreationIsAppliedOnCreation() throws Exception {
+    void testWakeUpBeforeConsumerCreationIsSafelyDropped() throws Exception {
         CreationRecordingReader reader = new CreationRecordingReader();
 
-        // wakeUp() before the consumer exists: no NPE, no consumer created.
+        // wakeUp() before the consumer exists: no NPE, no consumer created. The base
+        // SplitFetcher only wakes a running fetch task, which cannot exist before
+        // handleSplitsChanges() has created the consumer, so a pre-creation wakeup has
+        // nothing to interrupt and is dropped rather than deferred.
         assertThatCode(reader::wakeUp).doesNotThrowAnyException();
         assertThat(reader.creationThread.get()).isNull();
         assertThat(reader.wakeups.get()).isZero();
 
-        // First use creates the consumer and applies the pending wakeup.
+        // First use creates the consumer; the dropped wakeup is NOT replayed against it.
         CompletableFuture.runAsync(
                         () -> {
                             try {
@@ -140,7 +143,7 @@ class KafkaPartitionSplitReaderLazyConsumerCreationTest {
                 .get();
 
         assertThat(reader.creationThread.get()).isNotNull();
-        assertThat(reader.wakeups.get()).isEqualTo(1);
+        assertThat(reader.wakeups.get()).isZero();
         reader.close();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes [FLINK-36434](https://issues.apache.org/jira/browse/FLINK-36434): the `KafkaPartitionSplitReader` is constructed on the source-reader thread — or, when `KafkaSourceFetcherManager#commitOffsets` re-creates a fetcher after an idle shutdown, on the checkpoint thread — and its constructor eagerly created the `KafkaConsumer` (and registered consumer metrics) there. The consumer is then used almost exclusively on the split fetcher thread, but `KafkaConsumer` is not thread-safe; as described in the ticket, this broken threading model blocks Kafka client upgrades (sporadic `CorrelationIdMismatchException`).

This PR makes the consumer lazy inside the reader, so it is created on the first consumer-touching call — which by construction happens on the split fetcher thread (`fetch`, `handleSplitsChanges`, `pauseOrResumeSplits`, the offset-commit task, and `close()` in the fetcher's shutdown path all run there). Design points, as discussed on the ticket and in review:

- The constructor only computes `consumerProps` (client-id derivation unchanged) and stores them; no consumer, no metric registration.
- A private `ensureConsumer()` runs at the entry of every consumer-touching method; consumer metric registration moves there as well. The creation branch needs no guard: only the fetcher thread calls it, so the field is single-writer.
- `wakeUp()` remains the only cross-thread entry point (the one call `KafkaConsumer` documents as thread-safe). No lock is needed: `wakeUp()` only ever targets a running fetch task (see `SplitReader#wakeUp`'s javadoc), and the base `SplitFetcher` can only schedule a fetch task after `handleSplitsChanges()` — and therefore `ensureConsumer()` — has run at least once on the fetcher thread. So a plain `volatile` field covers the cross-thread reads, and a pre-creation wakeup has nothing to interrupt and is safely dropped. A code comment records that this leans on a `SplitFetcher`/`AddSplitsTask` implementation invariant rather than a documented contract.
- `close()` before first use is a no-op.

`KafkaPartitionSplitReaderWrapper` (DynamicKafkaSource) subclasses this reader and only wraps `fetch()` output, so the fix covers the `DynamicKafkaSource` path as well.

Deferring `splitReaderFactory.get()` itself onto the fetcher thread in flink-connector-base would fix this class of issue for all connectors; with the lazy consumer this connector no longer depends on that, so I will file it as a separate ticket (as discussed on FLINK-36434, it is orthogonal).

## Brief change log

  - `KafkaPartitionSplitReader` no longer creates the `KafkaConsumer` (nor registers consumer metrics) in its constructor; both happen in a new `ensureConsumer()` on the first consumer-touching call, i.e. on the split fetcher thread
  - `wakeUp()` before the consumer exists is safely dropped — it can only fire against a running fetch task, which cannot exist before the consumer does; `close()` before first use is a no-op
  - A `@VisibleForTesting createConsumer(Properties)` seam allows tests to observe consumer creation

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

  - Added `KafkaPartitionSplitReaderLazyConsumerCreationTest` (pure unit tests, no Kafka cluster needed): the consumer is not created at construction time and is created on the thread that first uses the reader; a `wakeUp()` arriving before creation neither throws nor creates a consumer, and is not replayed after creation; a `wakeUp()` after creation delegates directly; `close()` without prior use never creates a consumer
  - Existing `KafkaPartitionSplitReaderTest` covers the eager-path behaviors against a real cluster and passes unchanged in CI (not run locally: no Docker environment on this machine); `mvn test` for the module (compilation, checkstyle, spotless, and the new tests) passes locally

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no — `KafkaPartitionSplitReader` is `@Internal`)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no — `fetch()` gains a single volatile read on its fast path; consumer creation is one-time)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Claude Code