### PR TITLE
[FLINK-40570][source/tests] Cancel testTopicIntegritySuccess jobs on completion

### DIFF
--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/SourceTopicIntegrityTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/SourceTopicIntegrityTest.java
@@ -270,6 +270,10 @@ public class SourceTopicIntegrityTest {
 
         // Expect the job has run and produced the extra records to the sink
         KafkaSourceTestEnv.waitForRecordsInTopic(SINK_TOPIC_NAME, expectedTotalRecords);
+
+        // cancel the job and wait fot its termination
+        miniCluster.cancelJob(secondJobId).get();
+        miniCluster.requestJobResult(secondJobId).get();
     }
 
     private enum SourceSubscriptionMode {


### PR DESCRIPTION
`testTopicIntegritySuccess` test completion is followed by a kafka teardown while the submitted job is still running, which doesn't cause a test failure but pollutes CI logs with +1400 benign error traces, distracting authors from actual failures. Cancelling the job to avoid the exceptions during teardown and to release minicluster slots for next tests faster

Examples
- https://github.com/apache/flink-connector-kafka/actions/runs/33749050730/job/100628141595?pr=285
- https://github.com/apache/flink-connector-kafka/actions/runs/33780517843/job/101106906200?pr=295
