### PR TITLE
[FLINK-40579][ci] Make weekly branch lines independent and run one JDK per release line

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -39,7 +39,7 @@ jobs:
           branch: v5.0,
           jdk: '17'
         }, {
-          flink: 2.1.2,
+          flink: 2.1.3,
           branch: v5.0,
           jdk: '17'
         }, {
@@ -47,7 +47,7 @@ jobs:
           branch: v4.0,
           jdk: '17'
         }, {
-          flink: 1.20.4,
+          flink: 1.20.5,
           branch: v3.4,
           jdk: '11'
         }]

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -28,22 +28,28 @@ jobs:
   compile_and_test:
     if: github.repository_owner == 'apache'
     strategy:
+      fail-fast: false
       matrix:
+        # Release lines run a single JDK to stay under the ASF limit of 20 concurrent jobs.
         flink_branches: &flink_branches_matrix [{
           flink: 2.2-SNAPSHOT,
           branch: main
         }, {
           flink: 2.2.1,
-          branch: v5.0
+          branch: v5.0,
+          jdk: '17'
         }, {
           flink: 2.1.2,
-          branch: v5.0
+          branch: v5.0,
+          jdk: '17'
         }, {
           flink: 2.0.2,
-          branch: v4.0
+          branch: v4.0,
+          jdk: '17'
         }, {
           flink: 1.20.4,
-          branch: v3.4
+          branch: v3.4,
+          jdk: '11'
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
@@ -54,10 +60,11 @@ jobs:
   python_test:
     if: github.repository_owner == 'apache'
     strategy:
+      fail-fast: false
       matrix:
         flink_branches: *flink_branches_matrix
     uses: apache/flink-connector-shared-utils/.github/workflows/python_ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink_branches.flink }}
       connector_branch: ${{ matrix.flink_branches.branch }}
-      jdk_version: ${{ matrix.flink_branches.jdk || '11, 17, 21' }}
+      jdk_version: '17'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -57,6 +57,7 @@ jobs:
       connector_branch: ${{ matrix.flink_branches.branch }}
       jdk_version: ${{ matrix.flink_branches.jdk || '11, 17, 21' }}
       run_dependency_convergence: false
+      timeout_test: 45
   python_test:
     if: github.repository_owner == 'apache'
     strategy:


### PR DESCRIPTION
## What is the purpose of the change

Every scheduled weekly run since at least October 2025 has failed with the same shape: one Java failure, one Python failure, ~28 cancelled jobs. The outer `flink_branches` matrix uses the default `fail-fast`, so the first failing line cancels the other four (example: run [34002024546](https://github.com/apache/flink-connector-kafka/actions/runs/34002024546); run [27484280508](https://github.com/apache/flink-connector-kafka/actions/runs/27484280508) shows the Java matrix fully green while Python alone made the run red). Since all 30 jobs start together and a flake surfaces late in a ~31-minute job, cancelling saves almost no minutes. The workflow also runs 30 concurrent jobs, above the [ASF limit](https://infra.apache.org/github-actions-policy.html) of 20.

## Brief change log

- `fail-fast: false` on the outer matrix of both jobs; release lines run one JDK (17 for 2.x, 11 for 1.20), `main` keeps 11/17/21, Python runs JDK 17. 12 concurrent jobs instead of 30. The per-JDK `fail-fast` in `flink-connector-shared-utils` is unchanged.
- `timeout_test: 45` for the Java step (green jobs finish within ~36 minutes).
- Flink 1.20.4 -> 1.20.5, 2.1.2 -> 2.1.3.

## Verifying this change

Workflow file only. YAML validated (anchor/alias resolve, 7 Java + 5 Python jobs); all six Flink binaries exist on dlcdn. After merge, a `workflow_dispatch` should show every branch line reaching a conclusion with at most 12 jobs running concurrently.

## Does this pull request potentially affect one of the following parts

- Dependencies: no
- The public API: no
- The serializers: no
- The runtime per-record code paths: no
- Anything that affects deployment or recovery: no

## Documentation

- Does this pull request introduce a new feature? no

## Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code 2.1.263 (Claude Fable 5.1)
