### PR TITLE
[FLINK-39712][Connectors/Kafka] Avoid duplicate bounded-source completion notifications

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumerator.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumerator.java
@@ -115,6 +115,8 @@ public class DynamicKafkaSourceEnumerator
             retainedClusterEnumeratorStates;
     private boolean firstDiscoveryComplete;
     private final ReaderRecoveryGate readerRecoveryGate;
+    private final Set<Integer> readersWithNoMoreSplits;
+    private boolean splitAssignmentInProgress;
 
     public DynamicKafkaSourceEnumerator(
             KafkaStreamSubscriber kafkaStreamSubscriber,
@@ -218,6 +220,7 @@ public class DynamicKafkaSourceEnumerator
         this.splitAssignmentStrategy = createSplitAssignmentStrategy(properties);
         this.readerRecoveryGate =
                 new ReaderRecoveryGate(hasRestoredEnumeratorState(dynamicKafkaSourceEnumState));
+        this.readersWithNoMoreSplits = new HashSet<>();
 
         if (!dynamicKafkaSourceEnumState.getClusterEnumeratorStates().isEmpty()) {
             logger.info("Dynamic Kafka source restored from checkpointed enumerator state");
@@ -382,6 +385,10 @@ public class DynamicKafkaSourceEnumerator
     }
 
     private void handleNoMoreSplits() {
+        // A cluster callback may run before other clusters have assigned their splits.
+        if (splitAssignmentInProgress || readerRecoveryGate.hasPendingRecovery()) {
+            return;
+        }
         if (Boundedness.BOUNDED.equals(boundedness)) {
             boolean allEnumeratorsHaveSignalledNoMoreSplits = true;
             for (StoppableKafkaEnumContextProxy context : clusterEnumContextMap.values()) {
@@ -390,10 +397,12 @@ public class DynamicKafkaSourceEnumerator
             }
 
             if (firstDiscoveryComplete && allEnumeratorsHaveSignalledNoMoreSplits) {
-                logger.info(
-                        "Signal no more splits to all readers: {}",
-                        enumContext.registeredReaders().keySet());
-                enumContext.registeredReaders().keySet().forEach(enumContext::signalNoMoreSplits);
+                for (int readerId : enumContext.registeredReaders().keySet()) {
+                    if (readersWithNoMoreSplits.add(readerId)) {
+                        logger.info("Signal no more splits to reader {}", readerId);
+                        enumContext.signalNoMoreSplits(readerId);
+                    }
+                }
             } else {
                 logger.info("Not ready to notify no more splits to readers.");
             }
@@ -723,8 +732,13 @@ public class DynamicKafkaSourceEnumerator
     @Override
     public void addSplitsBack(List<DynamicKafkaSourceSplit> splits, int subtaskId) {
         logger.debug("Adding splits back for {}", subtaskId);
-        splitAssignmentStrategy.onSplitsBack(splits, subtaskId);
-        addSplitsBackToClusterEnumerators(splits, subtaskId, false);
+        splitAssignmentInProgress = true;
+        try {
+            splitAssignmentStrategy.onSplitsBack(splits, subtaskId);
+            addSplitsBackToClusterEnumerators(splits, subtaskId, false);
+        } finally {
+            splitAssignmentInProgress = false;
+        }
         handleNoMoreSplits();
     }
 
@@ -763,6 +777,7 @@ public class DynamicKafkaSourceEnumerator
     @Override
     public void addReader(int subtaskId) {
         logger.debug("Adding reader {}", subtaskId);
+        readersWithNoMoreSplits.remove(subtaskId);
         ReaderInfo readerInfo = enumContext.registeredReaders().get(subtaskId);
         if (readerInfo != null) {
             readerRecoveryGate.recordReportedSplits(
@@ -773,7 +788,12 @@ public class DynamicKafkaSourceEnumerator
             return;
         }
 
-        addReaderToClusterEnumerators(subtaskId);
+        splitAssignmentInProgress = true;
+        try {
+            addReaderToClusterEnumerators(subtaskId);
+        } finally {
+            splitAssignmentInProgress = false;
+        }
         handleNoMoreSplits();
     }
 
@@ -785,11 +805,17 @@ public class DynamicKafkaSourceEnumerator
             return true;
         }
 
-        readerRecoveryGate.markInitialRegistrationComplete();
-        if (readerRecoveryGate.hasReportedSplits()) {
-            reassignReportedSplits();
-        } else {
-            flushPendingSplitAssignmentsForRegisteredReaders();
+        // Draining the gate clears its pending state before reassignment finishes.
+        splitAssignmentInProgress = true;
+        try {
+            readerRecoveryGate.markInitialRegistrationComplete();
+            if (readerRecoveryGate.hasReportedSplits()) {
+                reassignReportedSplits();
+            } else {
+                flushPendingSplitAssignmentsForRegisteredReaders();
+            }
+        } finally {
+            splitAssignmentInProgress = false;
         }
         handleNoMoreSplits();
         flushPendingMetadataUpdateEvents();

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorTest.java
@@ -127,6 +127,158 @@ public class DynamicKafkaSourceEnumeratorTest {
     }
 
     @Test
+    public void testBoundedSourceSignalsNoMoreSplitsOncePerReader() throws Throwable {
+        try (RecordingSplitEnumeratorContext context = new RecordingSplitEnumeratorContext();
+                DynamicKafkaSourceEnumerator enumerator = createBoundedEnumerator(context)) {
+            enumerator.start();
+            for (int reader = 0; reader < NUM_SUBTASKS; reader++) {
+                mockRegisterReaderAndSendReaderStartupEvent(context, enumerator, reader);
+            }
+
+            assertThat(context.splitsAtCompletion).isEmpty();
+            runAllOneTimeCallables(context);
+
+            for (int reader = 0; reader < NUM_SUBTASKS; reader++) {
+                context.assertReaderCompleted(reader, 1);
+            }
+            verifyAllSplitsHaveBeenAssigned(
+                    context.getSplitsAssignmentSequence(),
+                    DynamicKafkaSourceTestHelper.getKafkaStream(TOPIC));
+        }
+    }
+
+    @Test
+    public void testBoundedSourceAssignsAllClustersBeforeCompletingLateReaders() throws Throwable {
+        try (RecordingSplitEnumeratorContext context = new RecordingSplitEnumeratorContext();
+                DynamicKafkaSourceEnumerator enumerator = createBoundedEnumerator(context)) {
+            enumerator.start();
+            mockRegisterReaderAndSendReaderStartupEvent(context, enumerator, 0);
+            runAllOneTimeCallables(context);
+
+            context.assertReaderCompleted(0, 1);
+            assertThat(context.splitsAtCompletion).containsOnlyKeys(0);
+
+            for (int reader = 1; reader < NUM_SUBTASKS; reader++) {
+                mockRegisterReaderAndSendReaderStartupEvent(context, enumerator, reader);
+                for (int registeredReader = 0; registeredReader <= reader; registeredReader++) {
+                    context.assertReaderCompleted(registeredReader, 1);
+                }
+            }
+            verifyAllSplitsHaveBeenAssigned(
+                    context.getSplitsAssignmentSequence(),
+                    DynamicKafkaSourceTestHelper.getKafkaStream(TOPIC));
+        }
+    }
+
+    @Test
+    public void testBoundedSourceCompletesRestartedReaderAfterReturnedSplits() throws Throwable {
+        try (RecordingSplitEnumeratorContext context = new RecordingSplitEnumeratorContext();
+                DynamicKafkaSourceEnumerator enumerator = createBoundedEnumerator(context)) {
+            enumerator.start();
+            for (int reader = 0; reader < NUM_SUBTASKS; reader++) {
+                mockRegisterReaderAndSendReaderStartupEvent(context, enumerator, reader);
+            }
+            runAllOneTimeCallables(context);
+
+            List<DynamicKafkaSourceSplit> returnedSplits = context.getAssignedSplits(0);
+            context.getSplitsAssignmentSequence().clear();
+            context.unregisterReader(0);
+            enumerator.addSplitsBack(returnedSplits, 0);
+
+            assertThat(context.getSplitsAssignmentSequence()).isEmpty();
+            context.splitsAtCompletion
+                    .values()
+                    .forEach(completions -> assertThat(completions).hasSize(1));
+
+            mockRegisterReaderAndSendReaderStartupEvent(context, enumerator, 0);
+
+            assertThat(context.getAssignedSplits(0))
+                    .containsExactlyInAnyOrderElementsOf(returnedSplits);
+            context.assertReaderCompleted(0, 2);
+            for (int reader = 1; reader < NUM_SUBTASKS; reader++) {
+                assertThat(context.splitsAtCompletion.get(reader)).hasSize(1);
+            }
+        }
+    }
+
+    @Test
+    public void testBoundedSourceReassignsReportedSplitsBeforeCompletingReader() throws Throwable {
+        try (RecordingSplitEnumeratorContext context = new RecordingSplitEnumeratorContext();
+                DynamicKafkaSourceEnumerator enumerator = createBoundedEnumerator(context)) {
+            enumerator.start();
+            for (int reader = 0; reader < NUM_SUBTASKS; reader++) {
+                mockRegisterReaderAndSendReaderStartupEvent(context, enumerator, reader);
+            }
+            runAllOneTimeCallables(context);
+
+            List<DynamicKafkaSourceSplit> reportedSplits = context.getAssignedSplits(0);
+            context.getSplitsAssignmentSequence().clear();
+            context.unregisterReader(0);
+            context.registerReader(ReaderInfo.createReaderInfo(0, "restarted", reportedSplits));
+            enumerator.addReader(0);
+
+            assertThat(context.getAssignedSplits(0))
+                    .containsExactlyInAnyOrderElementsOf(reportedSplits);
+            context.assertReaderCompleted(0, 2);
+            for (int reader = 1; reader < NUM_SUBTASKS; reader++) {
+                assertThat(context.splitsAtCompletion.get(reader)).hasSize(1);
+            }
+        }
+    }
+
+    @Test
+    public void testBoundedSourceCompletesReadersAfterActiveAndRetainedReassignment()
+            throws Throwable {
+        try (RecordingSplitEnumeratorContext context = new RecordingSplitEnumeratorContext();
+                DynamicKafkaSourceEnumerator enumerator = createBoundedEnumerator(context)) {
+            enumerator.start();
+            for (int reader = 0; reader < NUM_SUBTASKS; reader++) {
+                mockRegisterReaderAndSendReaderStartupEvent(context, enumerator, reader);
+            }
+            runAllOneTimeCallables(context);
+
+            Map<Integer, List<DynamicKafkaSourceSplit>> reportedSplitsByReader = new HashMap<>();
+            for (int reader = 0; reader < 2; reader++) {
+                reportedSplitsByReader.put(reader, context.getAssignedSplits(reader));
+                context.unregisterReader(reader);
+            }
+            reportedSplitsByReader
+                    .get(0)
+                    .add(
+                            new DynamicKafkaSourceSplit(
+                                    "removed-cluster",
+                                    new KafkaPartitionSplit(
+                                            new TopicPartition("removed-topic", 0), 5),
+                                    Long.MAX_VALUE));
+            context.getSplitsAssignmentSequence().clear();
+            context.splitsAtCompletion.clear();
+
+            context.registerReader(
+                    ReaderInfo.createReaderInfo(0, "restarted", reportedSplitsByReader.get(0)));
+            enumerator.addReader(0);
+            assertThat(context.getSplitsAssignmentSequence()).isEmpty();
+            assertThat(context.splitsAtCompletion).isEmpty();
+
+            context.registerReader(
+                    ReaderInfo.createReaderInfo(1, "restarted", reportedSplitsByReader.get(1)));
+            enumerator.addReader(1);
+
+            assertThat(context.splitsAtCompletion).containsOnlyKeys(0, 1);
+            for (int reader = 0; reader < 2; reader++) {
+                List<DynamicKafkaSourceSplit> reportedSplits = reportedSplitsByReader.get(reader);
+                assertThat(context.getAssignedSplits(reader))
+                        .containsExactlyInAnyOrderElementsOf(reportedSplits);
+                assertThat(context.splitsAtCompletion.get(reader))
+                        .singleElement()
+                        .isEqualTo(
+                                reportedSplits.stream()
+                                        .map(DynamicKafkaSourceSplit::splitId)
+                                        .collect(Collectors.toSet()));
+            }
+        }
+    }
+
+    @Test
     public void testStartupWithContinuousDiscovery() throws Throwable {
         try (MockSplitEnumeratorContext<DynamicKafkaSourceSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
@@ -1998,6 +2150,25 @@ public class DynamicKafkaSourceEnumeratorTest {
         }
     }
 
+    private DynamicKafkaSourceEnumerator createBoundedEnumerator(
+            SplitEnumeratorContext<DynamicKafkaSourceSplit> context) {
+        Properties properties = new Properties();
+        properties.setProperty(KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(), "0");
+        properties.setProperty(
+                DynamicKafkaSourceOptions.STREAM_METADATA_DISCOVERY_INTERVAL_MS.key(), "0");
+        return new DynamicKafkaSourceEnumerator(
+                new KafkaStreamSetSubscriber(Collections.singleton(TOPIC)),
+                new MockKafkaMetadataService(
+                        Collections.singleton(DynamicKafkaSourceTestHelper.getKafkaStream(TOPIC))),
+                context,
+                OffsetsInitializer.earliest(),
+                OffsetsInitializer.latest(),
+                properties,
+                Boundedness.BOUNDED,
+                new DynamicKafkaSourceEnumState(),
+                new TestKafkaEnumContextProxyFactory());
+    }
+
     private DynamicKafkaSourceEnumerator createEnumerator(
             SplitEnumeratorContext<DynamicKafkaSourceSplit> context) {
         return createEnumerator(
@@ -2467,7 +2638,8 @@ public class DynamicKafkaSourceEnumeratorTest {
             return new TestKafkaEnumContextProxy(
                     kafkaClusterId,
                     kafkaMetadataService,
-                    (MockSplitEnumeratorContext<DynamicKafkaSourceSplit>) enumContext);
+                    (MockSplitEnumeratorContext<DynamicKafkaSourceSplit>) enumContext,
+                    signalNoMoreSplitsCallback);
         }
     }
 
@@ -2479,7 +2651,15 @@ public class DynamicKafkaSourceEnumeratorTest {
                 String kafkaClusterId,
                 KafkaMetadataService kafkaMetadataService,
                 MockSplitEnumeratorContext<DynamicKafkaSourceSplit> enumContext) {
-            super(kafkaClusterId, kafkaMetadataService, enumContext, null);
+            this(kafkaClusterId, kafkaMetadataService, enumContext, null);
+        }
+
+        private TestKafkaEnumContextProxy(
+                String kafkaClusterId,
+                KafkaMetadataService kafkaMetadataService,
+                MockSplitEnumeratorContext<DynamicKafkaSourceSplit> enumContext,
+                Runnable signalNoMoreSplitsCallback) {
+            super(kafkaClusterId, kafkaMetadataService, enumContext, signalNoMoreSplitsCallback);
             this.enumContext = enumContext;
         }
 
@@ -2593,6 +2773,52 @@ public class DynamicKafkaSourceEnumeratorTest {
         @Override
         public void close() throws Exception {
             throw new Exception("test close failure");
+        }
+    }
+
+    private static class RecordingSplitEnumeratorContext
+            extends MockSplitEnumeratorContext<DynamicKafkaSourceSplit> {
+        private final Map<Integer, List<Set<String>>> splitsAtCompletion = new HashMap<>();
+
+        private RecordingSplitEnumeratorContext() {
+            super(NUM_SUBTASKS);
+        }
+
+        @Override
+        public void signalNoMoreSplits(int subtask) {
+            super.signalNoMoreSplits(subtask);
+            splitsAtCompletion
+                    .computeIfAbsent(subtask, ignored -> new ArrayList<>())
+                    .add(
+                            getAssignedSplits(subtask).stream()
+                                    .map(DynamicKafkaSourceSplit::splitId)
+                                    .collect(Collectors.toSet()));
+        }
+
+        private List<DynamicKafkaSourceSplit> getAssignedSplits(int reader) {
+            return getSplitsAssignmentSequence().stream()
+                    .flatMap(
+                            assignment ->
+                                    assignment
+                                            .assignment()
+                                            .getOrDefault(reader, Collections.emptyList())
+                                            .stream())
+                    .collect(Collectors.toList());
+        }
+
+        private void assertReaderCompleted(int reader, int times) {
+            List<DynamicKafkaSourceSplit> assignedSplits = getAssignedSplits(reader);
+            assertThat(assignedSplits).hasSize(DynamicKafkaSourceTestHelper.NUM_KAFKA_CLUSTERS);
+            Set<String> assignedSplitIds =
+                    assignedSplits.stream()
+                            .map(DynamicKafkaSourceSplit::splitId)
+                            .collect(Collectors.toSet());
+            assertThat(splitsAtCompletion.get(reader))
+                    .hasSize(times)
+                    .allSatisfy(
+                            splitIds ->
+                                    assertThat(splitIds)
+                                            .containsExactlyInAnyOrderElementsOf(assignedSplitIds));
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes FLINK-39712: a bounded `DynamicKafkaSource` could send `NoMoreSplitsEvent` more than once to a reader. A later registration or returned-split callback could signal a task that had already finished, causing the runtime to fail the job.

The observed failure includes:

```text
An OperatorEvent from an OperatorCoordinator to a task was lost
TaskNotRunningException: Task is not running, but in state FINISHED
```

Signal each reader once per registration, after all split assignments for the operation are complete. Deduplication and deferral are needed together: a cluster callback must not consume the reader's completion signal before the remaining clusters or retained recovery splits have been assigned.

## Brief change log

- Track readers that have received completion and reset a reader's entry when it registers again.
- Defer completion during pending recovery and across returned-split assignment, reader registration, and reported-split recovery.
- Centralize the synchronous assignment guard in a private `Runnable` helper, resetting it in `finally`.
- Recheck completion after each successful assignment operation, preserving the ordering before deferred metadata-event delivery.
- Wire the completion callback into the enumerator test context and assert the assigned split IDs at each completion signal.

## Verifying this change

Five new tests in `DynamicKafkaSourceEnumeratorTest` cover signal counts and assignment-before-completion ordering:

- `testBoundedSourceSignalsNoMoreSplitsOncePerReader`: initial completion is sent once per reader.
- `testBoundedSourceAssignsAllClustersBeforeCompletingLateReaders`: all clusters assign their splits before a late reader completes.
- `testBoundedSourceCompletesRestartedReaderAfterReturnedSplits`: a restarted reader receives its returned splits and a fresh completion signal without re-signalling other readers.
- `testBoundedSourceReassignsReportedSplitsBeforeCompletingReader`: reported splits are reassigned before completion.
- `testBoundedSourceCompletesReadersAfterActiveAndRetainedReassignment`: active and retained splits are assigned before recovered readers complete.

The branch is rebased onto Apache `main` at `9c0ccf3b1b52ccd98ccd9cd714330a522b19850b`, preserving the pending-recovery restoration from #295 and the upstream enumerator-test concurrency fix.

For current head `0f703b136bb28540ba529eef607f99bf565fa262`:

- Static inspection confirmed assignment/completion ordering and preservation of all five regression tests.
- `git diff --check` passed, and GitHub reports no merge conflicts.
- Fresh unit-test, Spotless and Checkstyle results have not yet been independently verified.
- Repeated runs of `DynamicKafkaSourceITTest.IntegrationTests.testIdleReader`: no verified run count is recorded yet.
- The latest inspected CI run is awaiting maintainer approval.

The maintainer's earlier verification established that the five regression tests fail against the pre-fix enumerator and pass at `07fa07e7a97862d084e079db24f7e09fe83bf3f7`, with Spotless and Checkstyle clean on JDK 17. Those results predate the helper extraction and rebase.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency, including `kafka.version` or `flink.version`): no.
- The public API, i.e., is any changed class annotated with `@Public(Evolving)` or `@Experimental`, or are the Table options or the PyFlink wrappers changed: no.
- Checkpointed state, its serializers, or exactly-once delivery (splits, enumerator state, writer state, committables, transactions): yes, completion ordering during split recovery; checkpoint state formats and serializers are unchanged.
- The per-record code paths (split reader, record emitter, writer, serialization schemas; performance sensitive): no.

## Documentation

- Does this pull request introduce a new feature? no; this is a bounded-source correctness fix.
- If yes, how is the feature documented? not applicable.
- If the docs changed, are both `docs/content` and `docs/content.zh` updated? not applicable; no documentation files changed.

## Scope and merge order

The prerequisites #289 and #291 are already merged and included in this branch's base.

This PR does not reset completion signalling after a metadata change. The normal bounded-source builder configuration disables periodic metadata discovery; the reset is planned in #309 (FLINK-40586), which should follow this PR.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: OpenAI Codex (GPT-6)