### PR TITLE
[FLINK-40589][source/tests] Increase job failure timeout

### DIFF
--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/SourceTopicIntegrityTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/SourceTopicIntegrityTest.java
@@ -66,7 +66,7 @@ public class SourceTopicIntegrityTest {
     private static final String SOURCE_TOPIC_PATTERN = "SourceTopicIntegrityTest_source.*";
     private static final String SINK_TOPIC_NAME = "SourceTopicIntegrityTest_sink-topic";
     private static final long DISCOVERY_INTERVAL = 50L;
-    private static final Duration ERROR_DISCOVERY_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration ERROR_DISCOVERY_TIMEOUT = Duration.ofSeconds(20);
     @TempDir private Path savepointBasePath;
 
     @RegisterExtension


### PR DESCRIPTION
Slow CI pipelines might not be able to schedule the job within the current 2s timeout