### PR TITLE
[BP-5.0][FLINK-39699][tests] Stabilize KafkaSinkITCase, KafkaWriterFaultToleranceITCase and KafkaTableITCase

### DIFF
--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
@@ -73,9 +73,7 @@ import org.apache.flink.testutils.junit.SharedReference;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterAll;
@@ -125,6 +123,7 @@ import java.util.stream.Stream;
 import static org.apache.flink.configuration.StateRecoveryOptions.SAVEPOINT_PATH;
 import static org.apache.flink.connector.kafka.testutils.KafkaUtil.checkProducerLeak;
 import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createKafkaContainer;
+import static org.apache.flink.connector.kafka.testutils.KafkaUtil.createNewTopicAndWaitForPartitionAssignment;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -176,9 +175,14 @@ class KafkaSinkITCase {
     }
 
     @BeforeEach
-    void setUp() throws ExecutionException, InterruptedException {
+    void setUp() {
         topic = UUID.randomUUID().toString();
-        createTestTopic(topic, 1, TOPIC_REPLICATION_FACTOR);
+        Properties adminProperties = new Properties();
+        adminProperties.put(
+                CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
+                KAFKA_CONTAINER.getBootstrapServers());
+        createNewTopicAndWaitForPartitionAssignment(
+                topic, 1, TOPIC_REPLICATION_FACTOR, adminProperties);
     }
 
     @AfterEach
@@ -761,15 +765,6 @@ class KafkaSinkITCase {
         standardProps.put("zookeeper.session.timeout.ms", ZK_TIMEOUT_MILLIS);
         standardProps.put("zookeeper.connection.timeout.ms", ZK_TIMEOUT_MILLIS);
         return standardProps;
-    }
-
-    private void createTestTopic(String topic, int numPartitions, short replicationFactor)
-            throws ExecutionException, InterruptedException {
-        final CreateTopicsResult result =
-                admin.createTopics(
-                        Collections.singletonList(
-                                new NewTopic(topic, numPartitions, replicationFactor)));
-        result.all().get();
     }
 
     private void deleteTestTopic(String topic) throws ExecutionException, InterruptedException {

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
@@ -55,7 +55,6 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
-import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -117,6 +116,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -137,6 +137,8 @@ class KafkaSinkITCase {
     private static final Network NETWORK = Network.newNetwork();
     private static final int ZK_TIMEOUT_MILLIS = 30000;
     private static final short TOPIC_REPLICATION_FACTOR = 1;
+    private static final long CHECKPOINT_PATH_LOOKUP_TIMEOUT_SECONDS = 10;
+    private static final long CHECKPOINT_PATH_LOOKUP_POLL_INTERVAL_MILLIS = 200;
     private static AdminClient admin;
 
     private String topic;
@@ -325,11 +327,7 @@ class KafkaSinkITCase {
         } catch (Exception e) {
             assertThat(e).hasStackTraceContaining("Exceeded checkpoint tolerable failure");
         }
-        final Optional<String> completedCheckpoint =
-                CommonTestUtils.getLatestCompletedCheckpointPath(firstJobId, miniCluster);
-
-        assertThat(completedCheckpoint).isPresent();
-        config.set(SAVEPOINT_PATH, completedCheckpoint.get());
+        config.set(SAVEPOINT_PATH, waitForCompletedCheckpointPath(miniCluster, firstJobId));
 
         // Run a second job which aborts all lingering transactions and new consumer should
         // immediately see the newly written records
@@ -422,7 +420,7 @@ class KafkaSinkITCase {
                         "firstPrefix",
                         clusterClient);
 
-        config.set(SAVEPOINT_PATH, getCheckpointPath(miniCluster, firstJobId));
+        config.set(SAVEPOINT_PATH, waitForCompletedCheckpointPath(miniCluster, firstJobId));
         config.set(CoreOptions.DEFAULT_PARALLELISM, newParallelsm);
 
         // Run a second job which aborts all lingering transactions and new consumer should
@@ -437,7 +435,7 @@ class KafkaSinkITCase {
                         "secondPrefix",
                         clusterClient);
 
-        config.set(SAVEPOINT_PATH, getCheckpointPath(miniCluster, secondJobId));
+        config.set(SAVEPOINT_PATH, waitForCompletedCheckpointPath(miniCluster, secondJobId));
         config.set(CoreOptions.DEFAULT_PARALLELISM, oldParallelism);
 
         SharedReference<AtomicBoolean> failed = sharedObjects.add(new AtomicBoolean(true));
@@ -455,12 +453,27 @@ class KafkaSinkITCase {
         assertThat(committedRecords).containsExactlyInAnyOrderElementsOf(checkpointedRecords.get());
     }
 
-    private String getCheckpointPath(MiniCluster miniCluster, JobID secondJobId)
-            throws InterruptedException, ExecutionException, FlinkJobNotFoundException {
-        final Optional<String> completedCheckpoint =
-                CommonTestUtils.getLatestCompletedCheckpointPath(secondJobId, miniCluster);
-
-        assertThat(completedCheckpoint).isPresent();
+    private String waitForCompletedCheckpointPath(MiniCluster miniCluster, JobID jobId)
+            throws Exception {
+        // The CompletedCheckpointStats can briefly lag behind requestJobResult() returning,
+        // so poll with a bounded timeout instead of asserting on the first miss.
+        final long deadline =
+                System.nanoTime()
+                        + TimeUnit.SECONDS.toNanos(CHECKPOINT_PATH_LOOKUP_TIMEOUT_SECONDS);
+        Optional<String> completedCheckpoint = Optional.empty();
+        while (System.nanoTime() < deadline) {
+            completedCheckpoint =
+                    CommonTestUtils.getLatestCompletedCheckpointPath(jobId, miniCluster);
+            if (completedCheckpoint.isPresent()) {
+                return completedCheckpoint.get();
+            }
+            Thread.sleep(CHECKPOINT_PATH_LOOKUP_POLL_INTERVAL_MILLIS);
+        }
+        assertThat(completedCheckpoint)
+                .as(
+                        "Job %s did not expose a completed checkpoint within %ds",
+                        jobId, CHECKPOINT_PATH_LOOKUP_TIMEOUT_SECONDS)
+                .isPresent();
         return completedCheckpoint.get();
     }
 
@@ -495,7 +508,7 @@ class KafkaSinkITCase {
                         clusterClient);
 
         // Run a second job which switching to POOLING
-        config.set(SAVEPOINT_PATH, getCheckpointPath(miniCluster, firstJobId));
+        config.set(SAVEPOINT_PATH, waitForCompletedCheckpointPath(miniCluster, firstJobId));
         config.set(CoreOptions.DEFAULT_PARALLELISM, 5);
         JobID secondJobId2 =
                 executeWithMapper(
@@ -508,7 +521,7 @@ class KafkaSinkITCase {
                         clusterClient);
 
         // Run a third job with downscaling
-        config.set(SAVEPOINT_PATH, getCheckpointPath(miniCluster, secondJobId2));
+        config.set(SAVEPOINT_PATH, waitForCompletedCheckpointPath(miniCluster, secondJobId2));
         config.set(CoreOptions.DEFAULT_PARALLELISM, 3);
         JobID thirdJobId =
                 executeWithMapper(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
@@ -63,10 +63,12 @@ public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
                         new SinkInitContext(metricGroup, timeService, null))) {
 
             writer.write(1, SINK_WRITER_CONTEXT);
+            writer.getCurrentProducer().flush();
 
             KAFKA_CONTAINER.stop();
 
             try {
+                writer.write(1, SINK_WRITER_CONTEXT);
                 writer.getCurrentProducer().flush();
                 assertThatCode(() -> writer.write(1, SINK_WRITER_CONTEXT))
                         .rootCause()
@@ -86,9 +88,11 @@ public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
                         DeliveryGuarantee.AT_LEAST_ONCE,
                         new SinkInitContext(metricGroup, timeService, null))) {
             writer.write(1, SINK_WRITER_CONTEXT);
+            writer.flush(false);
 
             KAFKA_CONTAINER.stop();
             try {
+                writer.write(1, SINK_WRITER_CONTEXT);
                 assertThatCode(() -> writer.flush(false))
                         .rootCause()
                         .isInstanceOfAny(NetworkException.class, TimeoutException.class);
@@ -108,10 +112,12 @@ public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
                         new SinkInitContext(metricGroup, timeService, null));
 
         writer.write(1, SINK_WRITER_CONTEXT);
+        writer.getCurrentProducer().flush();
 
         KAFKA_CONTAINER.stop();
 
         try {
+            writer.write(1, SINK_WRITER_CONTEXT);
             writer.getCurrentProducer().flush();
             // closing producer resource throws exception first
             assertThatCode(() -> writer.close())

--- a/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableTestBase.java
@@ -29,7 +29,6 @@ import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.RecordsToDelete;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.admin.TopicListing;
@@ -125,21 +124,10 @@ abstract class KafkaTableTestBase extends AbstractTestBase {
     }
 
     public void createTestTopic(String topic, int numPartitions, int replicationFactor) {
-        Map<String, Object> properties = new HashMap<>();
+        Properties properties = new Properties();
         properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, getBootstrapServers());
-        try (AdminClient admin = AdminClient.create(properties)) {
-            admin.createTopics(
-                            Collections.singletonList(
-                                    new NewTopic(topic, numPartitions, (short) replicationFactor)))
-                    .all()
-                    .get();
-        } catch (Exception e) {
-            throw new IllegalStateException(
-                    String.format(
-                            "Fail to create topic [%s partitions: %d replication factor: %d].",
-                            topic, numPartitions, replicationFactor),
-                    e);
-        }
+        KafkaUtil.createNewTopicAndWaitForPartitionAssignment(
+                topic, numPartitions, replicationFactor, properties);
     }
 
     public Map<TopicPartition, OffsetAndMetadata> getConsumerOffset(String groupId) {


### PR DESCRIPTION
Backport of FLINK-39699 (PR #254) and FLINK-39723 (PR #261) from `main` to `v5.0`.

## Why

The weekly connector CI on `v5.0` (Flink 2.1.x and 2.2.x) keeps failing on tests that were stabilized on `main` but never backported:

- `KafkaWriterFaultToleranceITCase.testFlush/testCloseExceptionWhenKafkaUnavailable`: "Expecting actual not to be null" (2026-08-02, 2026-08-09).
- `KafkaSinkITCase`: "Expecting Optional to contain a value but it was empty" from `getCheckpointPath` (2026-07-12, 2026-08-23).
- `KafkaTableITCase.testExactlyOnceSink`: "Failed to wait job finish" (2026-08-23).

## What

Four clean cherry-picks, in the original order:

- `887d5941` [hotfix] Stabilize KafkaWriterFaultToleranceITCase exception-on-unavailable tests
- `2d441987` [FLINK-39699][tests] Wait for completed checkpoint stats in KafkaSinkITCase
- `443c0f32` [FLINK-39699][tests] Wait for partitions assignment in KafkaSinkITCase
- `84d2ee7a` [FLINK-39723][tests] Wait for partition assignment in KafkaTableTestBase.createTestTopic

Unlike the `v4.0` backport (#259), the partition-assignment commit is included: `v5.0` already has `KafkaUtil.createNewTopicAndWaitForPartitionAssignment` via FLINK-39234.

## Verification

- `mvn -pl flink-connector-kafka -Dtest='KafkaWriterFaultToleranceITCase,KafkaSinkITCase,KafkaTableITCase' test` on `v5.0` with Flink 2.1.0: 117 tests, 0 failures.
- `spotless:check` passes.

## Brief change log

- Test-only changes, no production code touched.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

## AI disclosure

- [x] This pull request was created with the help of an AI tool (Claude Code). The cherry-picks were selected and verified locally by the author.
