### PR TITLE
[BP-3.4][FLINK-39699][tests] Stabilize KafkaWriterFaultToleranceITCase exception-on-unavailable tests

### DIFF
--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterFaultToleranceITCase.java
@@ -68,13 +68,16 @@ public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
                         properties, DeliveryGuarantee.AT_LEAST_ONCE, metricGroup)) {
 
             writer.write(1, SINK_WRITER_CONTEXT);
+            writer.getCurrentProducer().flush();
 
             KAFKA_CONTAINER.stop();
 
             try {
+                writer.write(1, SINK_WRITER_CONTEXT);
                 writer.getCurrentProducer().flush();
                 assertThatCode(() -> writer.write(1, SINK_WRITER_CONTEXT))
-                        .hasRootCauseExactlyInstanceOf(NetworkException.class);
+                        .rootCause()
+                        .isInstanceOfAny(NetworkException.class, TimeoutException.class);
             } finally {
                 KAFKA_CONTAINER.start();
             }
@@ -91,11 +94,14 @@ public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
                 createWriterWithConfiguration(
                         properties, DeliveryGuarantee.AT_LEAST_ONCE, metricGroup)) {
             writer.write(1, SINK_WRITER_CONTEXT);
+            writer.flush(false);
 
             KAFKA_CONTAINER.stop();
             try {
+                writer.write(1, SINK_WRITER_CONTEXT);
                 assertThatCode(() -> writer.flush(false))
-                        .hasRootCauseExactlyInstanceOf(NetworkException.class);
+                        .rootCause()
+                        .isInstanceOfAny(NetworkException.class, TimeoutException.class);
             } finally {
                 KAFKA_CONTAINER.start();
             }
@@ -113,14 +119,17 @@ public class KafkaWriterFaultToleranceITCase extends KafkaWriterTestBase {
                         properties, DeliveryGuarantee.AT_LEAST_ONCE, metricGroup);
 
         writer.write(1, SINK_WRITER_CONTEXT);
+        writer.getCurrentProducer().flush();
 
         KAFKA_CONTAINER.stop();
 
         try {
+            writer.write(1, SINK_WRITER_CONTEXT);
             writer.getCurrentProducer().flush();
             // closing producer resource throws exception first
             assertThatCode(() -> writer.close())
-                    .hasRootCauseExactlyInstanceOf(NetworkException.class);
+                    .rootCause()
+                    .isInstanceOfAny(NetworkException.class, TimeoutException.class);
         } catch (Exception e) {
             writer.close();
             throw e;


### PR DESCRIPTION
Manual backport of the `KafkaWriterFaultToleranceITCase` part of FLINK-39699 (PR #254) and the FLINK-37611 assertion loosening to `v3.4`.

## Why

The weekly connector CI on `v3.4` (Flink 1.20.x) failed on `KafkaWriterFaultToleranceITCase.testCloseExceptionWhenKafkaUnavailable` on 2026-09-06 with "Expecting actual not to be null". The `main` fix (`887d5941`) does not cherry-pick because the `v3.4` test still uses `createWriterWithConfiguration(...)` and `hasRootCauseExactlyInstanceOf(NetworkException.class)`.

## What

One commit, ported by hand:

- The warm-up `write` and `flush` before `KAFKA_CONTAINER.stop()` plus a second `write` after the stop in the three `...WhenKafkaUnavailable` tests, as in `887d5941`.
- The assertion change from FLINK-37611 (`d74a7bd8`, `2b199b0c`): `.rootCause().isInstanceOfAny(NetworkException.class, TimeoutException.class)`. Without it a `TimeoutException` after the broker stop would only move the flake.

`KafkaSinkITCase` on `v3.4` is the older class without `rescaleListing`, so the other FLINK-39699 commits have nothing to port.

## Verification

- `mvn -pl flink-connector-kafka spotless:check test-compile` passes on `v3.4`.
- `KafkaWriterFaultToleranceITCase` passes locally (4/4) on `v3.4` with Flink 1.20.0, five consecutive runs green.

## Brief change log

- Test-only change, no production code touched.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

## AI disclosure

- [x] This pull request was created with the help of an AI tool (Claude Code). The port was reviewed and verified locally by the author.
