### PR TITLE
[hotfix] Update copyright year to 2026

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Flink Kafka Connector
-Copyright 2014-2025 The Apache Software Foundation
+Copyright 2014-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-connector-kafka
-Copyright 2014-2024 The Apache Software Foundation
+Copyright 2014-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
## Summary
- Bump the copyright year to 2026 in the root `NOTICE` and in `flink-sql-connector-kafka`'s `NOTICE`, which had drifted out of sync (root was last bumped to 2025, the sql-connector one was still at 2024).

## Test plan
- N/A (text-only change to NOTICE files)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (claude-sonnet-5)
