### PR TITLE
[FLINK-40615][Connectors/Kafka] Fix duplicate partition assignment in KafkaSourceEnumerator

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -133,6 +133,12 @@ public class KafkaSourceEnumerator
     private final Map<Integer, Set<KafkaPartitionSplit>> pendingPartitionSplitAssignment =
             new HashMap<>();
 
+    /**
+     * Partitions with split initialization in flight on the worker thread. Discovery skips these
+     * partitions to avoid duplicate assignments. Accessed only from the coordinator thread.
+     */
+    private final Set<TopicPartition> partitionsBeingInitialized = new HashSet<>();
+
     private final SplitOwnerSelector splitOwnerSelector;
 
     /** The consumer group id used for this KafkaSource. */
@@ -368,9 +374,19 @@ public class KafkaSourceEnumerator
         if (partitionChange.isEmpty()) {
             return;
         }
+        // Track in-flight partitions to avoid duplicate discovery.
+        final Set<TopicPartition> partitionsInThisBatch = new HashSet<>();
+        partitionsInThisBatch.addAll(partitionChange.getInitialPartitions());
+        partitionsInThisBatch.addAll(partitionChange.getNewPartitions());
+        partitionsBeingInitialized.addAll(partitionsInThisBatch);
+
         context.callAsync(
                 () -> initializePartitionSplits(partitionChange),
-                this::handlePartitionSplitChanges);
+                (result, error) -> {
+                    // Clear in-flight state on the success and failure paths.
+                    partitionsBeingInitialized.removeAll(partitionsInThisBatch);
+                    handlePartitionSplitChanges(result, error);
+                });
     }
 
     /**
@@ -565,6 +581,8 @@ public class KafkaSourceEnumerator
                 (reader, splits) ->
                         splits.forEach(
                                 split -> dedupOrMarkAsRemoved.accept(split.getTopicPartition())));
+        // Skip partitions with initialization in flight to avoid duplicate assignments.
+        newPartitions.removeAll(partitionsBeingInitialized);
 
         if (!newPartitions.isEmpty()) {
             LOG.info("Discovered new partitions: {}", newPartitions);
@@ -580,7 +598,8 @@ public class KafkaSourceEnumerator
         }
         // migration path, ensure that partitions without offset are properly initialized
         for (KafkaPartitionSplit split : unassignedSplits.values()) {
-            if (split.isMigrated()) {
+            if (split.isMigrated()
+                    && !partitionsBeingInitialized.contains(split.getTopicPartition())) {
                 initialPartitions.add(split.getTopicPartition());
             }
         }

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumeratorTest.java
@@ -632,6 +632,100 @@ public class KafkaSourceEnumeratorTest {
         }
     }
 
+    /** Verifies that in-flight partitions are not rediscovered as new on the next cycle. */
+    @Test
+    public void testInFlightPartitionsNotRediscoveredAsNew() throws Throwable {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(context, ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
+            enumerator.start();
+
+            // Register readers so partitions can be assigned.
+            registerReader(context, enumerator, READER0);
+            registerReader(context, enumerator, READER1);
+            registerReader(context, enumerator, READER2);
+
+            // Run discovery once and leave the worker callable pending to simulate a slow
+            // worker.
+            context.runPeriodicCallable(PARTITION_DISCOVERY_CALLABLE_INDEX);
+
+            // The worker callable is now pending.
+            assertThat(context.getOneTimeCallables())
+                    .as("initializePartitionSplits should be pending on the worker")
+                    .hasSize(1);
+
+            // Fire a second cycle before the first init completes.
+            context.runPeriodicCallable(PARTITION_DISCOVERY_CALLABLE_INDEX);
+
+            // The second cycle dispatches nothing because partitions are in flight.
+            assertThat(context.getOneTimeCallables())
+                    .as(
+                            "No additional initializePartitionSplits should be dispatched while partitions are in flight")
+                    .hasSize(1);
+
+            // Run the pending init.
+            context.runNextOneTimeCallable();
+
+            // Verify a single assignment without duplicates.
+            List<SplitsAssignment<KafkaPartitionSplit>> assignments =
+                    context.getSplitsAssignmentSequence();
+            assertThat(assignments).as("Exactly one assignment batch expected").hasSize(1);
+
+            // Count assigned partitions across topics.
+            int totalAssignedPartitions =
+                    assignments.get(0).assignment().values().stream().mapToInt(List::size).sum();
+            int expectedPartitions =
+                    KafkaSourceTestEnv.getPartitionsForTopics(PRE_EXISTING_TOPICS).size();
+            assertThat(totalAssignedPartitions)
+                    .as("Each partition should be assigned exactly once, not duplicated")
+                    .isEqualTo(expectedPartitions);
+        }
+    }
+
+    /** Verifies that a migrated split in flight is not rediscovered on the next cycle. */
+    @Test
+    public void testMigratedSplitInFlightNotRediscovered() throws Throwable {
+        TopicPartition migratedTp = new TopicPartition(TOPIC2, 0);
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(
+                                context,
+                                1L,
+                                OffsetsInitializer.earliest(),
+                                PRE_EXISTING_TOPICS,
+                                Collections.emptySet(),
+                                List.of(new KafkaPartitionSplit(migratedTp, MIGRATED)),
+                                false,
+                                new Properties())) {
+            enumerator.start();
+
+            // Register readers so partitions can be assigned.
+            registerReader(context, enumerator, READER0);
+            registerReader(context, enumerator, READER1);
+            registerReader(context, enumerator, READER2);
+
+            // First cycle dispatches init for migrated and fresh partitions.
+            context.runPeriodicCallable(PARTITION_DISCOVERY_CALLABLE_INDEX);
+            assertThat(context.getOneTimeCallables())
+                    .as("First discovery should dispatch init")
+                    .hasSize(1);
+
+            // Second cycle before init completes dispatches nothing.
+            context.runPeriodicCallable(PARTITION_DISCOVERY_CALLABLE_INDEX);
+            assertThat(context.getOneTimeCallables())
+                    .as("Migrated split in flight should not trigger a second dispatch")
+                    .hasSize(1);
+
+            // Run the pending init and verify the migrated split is assigned.
+            context.runNextOneTimeCallable();
+            assertThat(getAllAssignSplits(context, PRE_EXISTING_TOPICS))
+                    .extracting(KafkaPartitionSplit::getTopicPartition)
+                    .contains(migratedTp);
+        }
+    }
+
     // -------------- some common startup sequence ---------------
 
     private void startEnumeratorAndRegisterReaders(


### PR DESCRIPTION
## What is the purpose of the change

`KafkaSourceEnumerator` can assign the same partition to two readers when the discovery interval is shorter than the time `initializePartitionSplits` takes on the worker thread ([FLINK-40615](https://issues.apache.org/jira/browse/FLINK-40615)).

`getPartitionChange()` deduplicates against `assignedSplits` and `pendingPartitionSplitAssignment` only. Neither covers partitions whose split initialization is still in flight, so a discovery pass that fires before `handlePartitionSplitChanges` runs sees those partitions as new, dispatches a second `initializePartitionSplits`, and assigns them twice.

Impact: a job whose `partition.discovery.interval.ms` is below the broker metadata response time can silently consume duplicate records.

Observed in CI: `SourceTopicIntegrityTest.testTopicIntegritySuccess[PATTERN]` read 120 records instead of 100, with partitions 7 and 8 assigned twice ([run 34200551453](https://github.com/apache/flink-connector-kafka/actions/runs/34200551453/job/101978105599)). The test is now named `SourceTopicIntegrityITCase` (FLINK-40618).

## Brief change log

- `KafkaSourceEnumerator.java`: adds a `partitionsBeingInitialized` set. `checkPartitionChanges` fills it before dispatching `callAsync`, the handler wrapper clears it on the success and failure paths, and `getPartitionChange` deduplicates against it with `removeAll`. The migration path for `isMigrated()` splits skips partitions that are already in flight.
- `KafkaSourceEnumeratorTest.java`: adds `testInFlightPartitionsNotRediscoveredAsNew` and `testMigratedSplitInFlightNotRediscovered`. Each test runs two discovery cycles without executing the pending `initializePartitionSplits` callable between them, then asserts a single dispatch. The migration test fails without the guard (`Expected size: 1 but was: 2`).
- Trims long comments and Javadoc in both files; the trimming changes no behavior.

`SourceTopicIntegrityITCase` is unchanged. Its 50 ms discovery interval is what exposed the race, so it stays as the regression guard rather than being tuned away.

## Verifying this change

The new unit tests reproduce the race directly: each drives two periodic discovery passes while the first initialization is still pending, which is the ordering the enumerator previously mishandled. Existing `KafkaSourceEnumeratorTest` cases pass unmodified.

Verified on the rebased branch: `mvn -pl flink-connector-kafka verify -Dtest='KafkaSourceEnumeratorTest,SourceTopicIntegrityITCase'` → 33 tests, 0 failures in each surefire execution, including the nine `SourceTopicIntegrityITCase` cases at the unchanged 50 ms interval. That is one local run; the original failure was intermittent, so CI is the stronger signal.

## Does this pull request potentially affect one of the following parts

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code
