### PR TITLE
[FLINK-40618][tests] Run SourceTopicIntegrity test in the integration-test phase

### DIFF
--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/SourceTopicIntegrityITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/SourceTopicIntegrityITCase.java
@@ -60,11 +60,11 @@ import java.util.stream.Stream;
 
 /** Integration tests for topic integrity checking in KafkaSource. */
 @ResourceLock("KafkaTestBase")
-public class SourceTopicIntegrityTest {
-    private static final Logger LOG = LoggerFactory.getLogger(SourceTopicIntegrityTest.class);
-    private static final String SOURCE_TOPIC_NAME = "SourceTopicIntegrityTest_source-topic";
-    private static final String SOURCE_TOPIC_PATTERN = "SourceTopicIntegrityTest_source.*";
-    private static final String SINK_TOPIC_NAME = "SourceTopicIntegrityTest_sink-topic";
+public class SourceTopicIntegrityITCase {
+    private static final Logger LOG = LoggerFactory.getLogger(SourceTopicIntegrityITCase.class);
+    private static final String SOURCE_TOPIC_NAME = "SourceTopicIntegrityITCase_source-topic";
+    private static final String SOURCE_TOPIC_PATTERN = "SourceTopicIntegrityITCase_source.*";
+    private static final String SINK_TOPIC_NAME = "SourceTopicIntegrityITCase_sink-topic";
     private static final long DISCOVERY_INTERVAL = 50L;
     private static final Duration ERROR_DISCOVERY_TIMEOUT = Duration.ofSeconds(20);
     @TempDir private Path savepointBasePath;


### PR DESCRIPTION
## What is the purpose of the change

`SourceTopicIntegrityTest` is a heavyweight integration test — it starts a Testcontainers Kafka broker and a 3-TaskManager MiniCluster and drives savepoint/restore — but its `*Test` suffix routes it into the unit-test surefire execution (`forkCount=4`, 1GB heap) rather than the integration-test execution. Its heavyweight siblings in the same package, `KafkaSourceITCase` and `KafkaSourceMigrationITCase`, are already named `*ITCase`.

This is a test-classification cleanup, justified by that precedence. See FLINK-40618.

## Brief change log

- Rename `SourceTopicIntegrityTest` → `SourceTopicIntegrityITCase` so it runs in the integration-test execution (`forkCount=2`, 2GB heap, `reuseForks=false`) instead of the 4-way-parallel unit-test execution. No test logic changes.

## Verifying this change

- `mvn -pl flink-connector-kafka -am test-compile` passes.
- CI will now run the test in the integration-test phase.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API: **no**
- The serializers: **no**
- The runtime per-record code paths: **no**
- Anything that affects deployment or recovery: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **no**

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (claude-opus-4-8)
