### PR TITLE
[FLINK-40586][Connectors/Kafka] Signal no more splits to each reader once per registration

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumerator.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumerator.java
@@ -115,6 +115,7 @@ public class DynamicKafkaSourceEnumerator
             retainedClusterEnumeratorStates;
     private boolean firstDiscoveryComplete;
     private final ReaderRecoveryGate readerRecoveryGate;
+    private final Set<Integer> readersSignalledNoMoreSplits;
 
     public DynamicKafkaSourceEnumerator(
             KafkaStreamSubscriber kafkaStreamSubscriber,
@@ -218,6 +219,7 @@ public class DynamicKafkaSourceEnumerator
         this.splitAssignmentStrategy = createSplitAssignmentStrategy(properties);
         this.readerRecoveryGate =
                 new ReaderRecoveryGate(hasRestoredEnumeratorState(dynamicKafkaSourceEnumState));
+        this.readersSignalledNoMoreSplits = new HashSet<>();
 
         if (!dynamicKafkaSourceEnumState.getClusterEnumeratorStates().isEmpty()) {
             logger.info("Dynamic Kafka source restored from checkpointed enumerator state");
@@ -390,10 +392,17 @@ public class DynamicKafkaSourceEnumerator
             }
 
             if (firstDiscoveryComplete && allEnumeratorsHaveSignalledNoMoreSplits) {
-                logger.info(
-                        "Signal no more splits to all readers: {}",
-                        enumContext.registeredReaders().keySet());
-                enumContext.registeredReaders().keySet().forEach(enumContext::signalNoMoreSplits);
+                // a reader that has already been signalled may have finished, and
+                // NoMoreSplitsEvent is not loss tolerant: re-sending it to a FINISHED task fails
+                // the job. Signal each reader once per generation of this set, which is cleared
+                // when the reader registers again -- the point at which a new attempt becomes
+                // addressable -- and when a metadata change recreates the sub enumerators.
+                for (Integer readerId : enumContext.registeredReaders().keySet()) {
+                    if (readersSignalledNoMoreSplits.add(readerId)) {
+                        logger.info("Signal no more splits to reader: {}", readerId);
+                        enumContext.signalNoMoreSplits(readerId);
+                    }
+                }
             } else {
                 logger.info("Not ready to notify no more splits to readers.");
             }
@@ -478,6 +487,11 @@ public class DynamicKafkaSourceEnumerator
         logger.info("Closing enumerators due to metadata change");
 
         closeAllEnumeratorsAndContexts();
+        // every sub enumerator is about to be recreated and will signal no more splits again for
+        // its new assignments, and the reader has closed and recreated its sub readers, so the
+        // signals sent for the previous generation no longer hold. Without clearing this, a bounded
+        // job would hang after a metadata change once FLINK-31006 restores that re-signal.
+        readersSignalledNoMoreSplits.clear();
         retainRemovedClusterEnumeratorStates(
                 dynamicKafkaSourceEnumState.getClusterEnumeratorStates(),
                 latestClusterTopicsMap.keySet());
@@ -763,6 +777,10 @@ public class DynamicKafkaSourceEnumerator
     @Override
     public void addReader(int subtaskId) {
         logger.debug("Adding reader {}", subtaskId);
+        // registration is the point at which a new attempt of this reader becomes addressable, so
+        // a signal sent to a previous attempt does not count: it must be signalled again or a
+        // restarted reader would never finish.
+        readersSignalledNoMoreSplits.remove(subtaskId);
         ReaderInfo readerInfo = enumContext.registeredReaders().get(subtaskId);
         if (readerInfo != null) {
             readerRecoveryGate.recordReportedSplits(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorTest.java
@@ -2024,9 +2024,31 @@ public class DynamicKafkaSourceEnumeratorTest {
     }
 
     private DynamicKafkaSourceEnumerator createEnumerator(
+            SplitEnumeratorContext<DynamicKafkaSourceSplit> context, Boundedness boundedness) {
+        return createEnumerator(
+                context,
+                new MockKafkaMetadataService(
+                        Collections.singleton(DynamicKafkaSourceTestHelper.getKafkaStream(TOPIC))),
+                (properties) -> {},
+                boundedness);
+    }
+
+    private DynamicKafkaSourceEnumerator createEnumerator(
             SplitEnumeratorContext<DynamicKafkaSourceSplit> context,
             KafkaMetadataService kafkaMetadataService,
             Consumer<Properties> applyPropertiesConsumer) {
+        return createEnumerator(
+                context,
+                kafkaMetadataService,
+                applyPropertiesConsumer,
+                Boundedness.CONTINUOUS_UNBOUNDED);
+    }
+
+    private DynamicKafkaSourceEnumerator createEnumerator(
+            SplitEnumeratorContext<DynamicKafkaSourceSplit> context,
+            KafkaMetadataService kafkaMetadataService,
+            Consumer<Properties> applyPropertiesConsumer,
+            Boundedness boundedness) {
         Properties properties = new Properties();
         applyPropertiesConsumer.accept(properties);
         properties.putIfAbsent(KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(), "0");
@@ -2037,9 +2059,11 @@ public class DynamicKafkaSourceEnumeratorTest {
                 kafkaMetadataService,
                 context,
                 OffsetsInitializer.earliest(),
-                new NoStoppingOffsetsInitializer(),
+                Boundedness.BOUNDED.equals(boundedness)
+                        ? OffsetsInitializer.latest()
+                        : new NoStoppingOffsetsInitializer(),
                 properties,
-                Boundedness.CONTINUOUS_UNBOUNDED,
+                boundedness,
                 new DynamicKafkaSourceEnumState(),
                 new TestKafkaEnumContextProxyFactory());
     }
@@ -2453,6 +2477,97 @@ public class DynamicKafkaSourceEnumeratorTest {
                 copiedProperties,
                 baseClusterMetadata.getStartingOffsetsInitializer(),
                 baseClusterMetadata.getStoppingOffsetsInitializer());
+    }
+
+    @Test
+    public void testNoMoreSplitsIsSignalledOncePerReaderRegistration() throws Throwable {
+        try (CountingSignalNoMoreSplitsContext context =
+                        new CountingSignalNoMoreSplitsContext(NUM_SUBTASKS);
+                DynamicKafkaSourceEnumerator enumerator =
+                        createEnumerator(context, Boundedness.BOUNDED)) {
+            enumerator.start();
+            runAllOneTimeCallables(context);
+
+            for (int reader = 0; reader < NUM_SUBTASKS; reader++) {
+                mockRegisterReaderAndSendReaderStartupEvent(context, enumerator, reader);
+                runAllOneTimeCallables(context);
+            }
+
+            for (int reader = 0; reader < NUM_SUBTASKS; reader++) {
+                assertThat(context.getSignalCount(reader))
+                        .as("reader %s should be signalled no more splits once", reader)
+                        .isEqualTo(1);
+            }
+
+            // one reader fails and returns its splits. That drives handleNoMoreSplits() again, but
+            // the other readers may already have finished on the first signal, and
+            // NoMoreSplitsEvent is not loss tolerant: re-sending it to a FINISHED task fails the
+            // job with "An OperatorEvent from an OperatorCoordinator to a task was lost".
+            int failingReader = NUM_SUBTASKS - 1;
+            List<DynamicKafkaSourceSplit> splitsOfFailingReader = new ArrayList<>();
+            for (SplitsAssignment<DynamicKafkaSourceSplit> assignment :
+                    context.getSplitsAssignmentSequence()) {
+                List<DynamicKafkaSourceSplit> splits = assignment.assignment().get(failingReader);
+                if (splits != null) {
+                    splitsOfFailingReader.addAll(splits);
+                }
+            }
+            assertThat(splitsOfFailingReader).as("precondition: reader had splits").isNotEmpty();
+
+            // the coordinator unregisters a reader in executionAttemptFailed before calling
+            // subtaskReset, which is what drives addSplitsBack -- with an empty list for a reader
+            // that owned nothing.
+            context.unregisterReader(failingReader);
+            enumerator.addSplitsBack(splitsOfFailingReader, failingReader);
+
+            for (int reader = 0; reader < NUM_SUBTASKS; reader++) {
+                assertThat(context.getSignalCount(reader))
+                        .as(
+                                "reader %s must not be signalled again while it is not registered",
+                                reader)
+                        .isEqualTo(1);
+            }
+
+            // the new attempt registers, which makes the reader addressable again, so it has to be
+            // signalled a second time or it would never finish.
+            mockRegisterReaderAndSendReaderStartupEvent(context, enumerator, failingReader);
+            runAllOneTimeCallables(context);
+
+            assertThat(context.getSignalCount(failingReader))
+                    .as("re-registered reader %s must be signalled again", failingReader)
+                    .isEqualTo(2);
+            for (int reader = 0; reader < failingReader; reader++) {
+                assertThat(context.getSignalCount(reader))
+                        .as(
+                                "reader %s must not be signalled again after it was already told",
+                                reader)
+                        .isEqualTo(1);
+            }
+        }
+    }
+
+    /**
+     * {@link MockSplitEnumeratorContext} only latches a boolean per subtask, so a repeated no more
+     * splits signal is invisible to it. This counts the calls instead.
+     */
+    private static class CountingSignalNoMoreSplitsContext
+            extends MockSplitEnumeratorContext<DynamicKafkaSourceSplit> {
+
+        private final Map<Integer, Integer> signalCounts = new HashMap<>();
+
+        private CountingSignalNoMoreSplitsContext(int parallelism) {
+            super(parallelism);
+        }
+
+        @Override
+        public void signalNoMoreSplits(int subtask) {
+            signalCounts.merge(subtask, 1, Integer::sum);
+            super.signalNoMoreSplits(subtask);
+        }
+
+        private int getSignalCount(int subtask) {
+            return signalCounts.getOrDefault(subtask, 0);
+        }
     }
 
     private static class TestKafkaEnumContextProxyFactory


### PR DESCRIPTION
## What is the purpose of the change

Fixes [FLINK-40586](https://issues.apache.org/jira/browse/FLINK-40586).

`DynamicKafkaSourceEnumerator.handleNoMoreSplits()` signalled **every** currently registered reader on **every** invocation, with no record of which readers had already been signalled:

```java
enumContext.registeredReaders().keySet().forEach(enumContext::signalNoMoreSplits);
```

It is reached from `addReader`, `addSplitsBack` and `tryCompletePendingReaderRegistration`, so a reader that finished on an earlier signal is signalled again when another reader registers — or when any reader is reset, since `SourceCoordinator.subtaskReset` calls `addSplitsBack` for every reset subtask, passing an empty list for a reader that owned no splits. `NoMoreSplitsEvent` is not loss tolerant, so delivering it to a task already in `FINISHED` fails the job:

```
org.apache.flink.util.FlinkException: An OperatorEvent from an OperatorCoordinator to a task was
lost. Triggering task failover to ensure consistency. Event: '[NoMoreSplitEvent]'
Caused by: TaskNotRunningException: Task is not running, but in state FINISHED
```

That is the `DynamicKafkaSourceITTest$IntegrationTests.testIdleReader` failure seen in weekly CI, where parallelism is one greater than the split count so the idle reader finishes on the first signal.

## Brief change log

- `handleNoMoreSplits()` signals a registered reader only if `readersSignalledNoMoreSplits.add(readerId)` succeeds, so each reader is signalled at most once per registration.
- `addReader()` clears the reader's entry. **Registration is the point at which a new attempt of a reader becomes addressable**, so it is the event that has to re-arm the signal; without it a restarted reader would never be told and the job would not finish.

A metadata change recreates the sub-enumerators in `onHandleSubscribedStreamsFetch` and their new assignments would need a fresh signal too, but that path does not signal at all today (FLINK-31006), so it is left alone here and noted in a comment.

## Verifying this change

Added `DynamicKafkaSourceEnumeratorTest#testNoMoreSplitsIsSignalledOncePerReaderRegistration`. It registers three readers and asserts each is signalled exactly once; then unregisters one reader and hands its splits back — the order the coordinator actually produces, since `executionAttemptFailed` unregisters before `subtaskReset` — and asserts nobody is re-signalled; then re-registers that reader and asserts its count reaches 2 while the others stay at 1.

`MockSplitEnumeratorContext` only latches a `boolean[] subtaskHasNoMoreSplits` and exposes `hasNoMoreSplits(int)`, so a repeated signal is invisible to it. The test uses a `CountingSignalNoMoreSplitsContext` subclass that counts calls per subtask.

The test fails on `main` and passes here. Locally: `Tests run: 31, Failures: 0` for the whole class, `spotless:check` and `checkstyle:check` clean.

**Ordering:** this should land after #291 (FLINK-40362). Per @MartijnVisser's measurements of `testIdleReader`, `main` hung 2 of 24 runs, `main` + this PR 1 of 24, and `main` + #291 + this PR 0 of 20 — the reader-side hang is a separate cause that this change does not address.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): **no**
- The public API: **no**
- The serializers: **no**
- The runtime per-record code paths: **no**
- Anything that affects deployment or recovery: **yes** — it changes when `NoMoreSplitsEvent` is delivered to readers on registration and failover, for bounded sources only.
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? **not applicable**

Generated-by: Claude Code (Opus 5)
