### PR TITLE
[FLINK-40621][Connectors/Kafka] Flush before fencing in producer reset test

### DIFF
--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/FlinkKafkaInternalProducerITCase.java
@@ -159,6 +159,12 @@ class FlinkKafkaInternalProducerITCase {
             fenced.initTransactions();
             fenced.beginTransaction();
             fenced.send(new ProducerRecord<>(topic, "test-value"));
+            // Await the produce before fencing. An in-flight ProduceRequest that reaches the
+            // broker after the epoch bump below is rejected with INVALID_PRODUCER_EPOCH, and the
+            // finalizer then throws InvalidProducerEpochException, a sibling of
+            // ProducerFencedException rather than a subtype. Flushing keeps the fencing on the
+            // EndTxn path, which is the case this test pins.
+            fenced.flush();
             // Start a second producer that fences the first one
             try (FlinkKafkaInternalProducer<String, String> producer =
                     new FlinkKafkaInternalProducer<>(getProperties(), "dummy")) {


### PR DESCRIPTION
## What is the purpose of the change

`FlinkKafkaInternalProducerITCase.testResetInnerTransactionIfFinalizingTransactionFailed` is flaky ([FLINK-40621](https://issues.apache.org/jira/browse/FLINK-40621)). It sends a record without flushing, then fences that producer with a second one using the same transactional id, and asserts that the finalizer throws `ProducerFencedException`.

Which exception arrives depends on where the first producer's `ProduceRequest` lands relative to the epoch bump:

- The record is accepted first, so the fencing surfaces on the `EndTxn` path as `PRODUCER_FENCED`, and the assertion holds.
- The `ProduceRequest` arrives after the bump, so the broker rejects it with `INVALID_PRODUCER_EPOCH` and the finalizer throws `InvalidProducerEpochException`.

In kafka-clients 4.2.0 both are siblings under `ApplicationRecoverableException`, neither a subtype of the other, so the second ordering fails the assertion. The reported failure carries the produce-path message, `attempted to produce with an old epoch`.

## Brief change log

- `FlinkKafkaInternalProducerITCase`: flush the fenced producer before the second producer starts, so the failure is always discovered on the `EndTxn` path. A comment records why the flush must stay.

No production code and no assertion change: widening the assertion to the shared supertype would also be green, but would stop pinning which path failed.

## Verifying this change

Verified on the rebased branch: `mvn -pl flink-connector-kafka verify -Dtest='FlinkKafkaInternalProducerITCase#testResetInnerTransactionIfFinalizingTransactionFailed'` → 2 tests, 0 failures, both parameterizations.

That is one local run against a passing ordering, so it does not by itself prove the race is gone; the argument for that is the flush removing the interleaving rather than the run.

## Does this pull request potentially affect one of the following parts

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Opus 5)
