### PR TITLE
[FLINK-40622][Connectors/Kafka] Stop readers recreating the deleted topic in SourceTopicIntegrityTest

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -515,6 +515,15 @@ public class KafkaSourceBuilder<OUT> {
             maybeOverride(KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(), "-1", true);
         }
 
+        // A source that checks topic integrity must not recreate the topic it is checking. Both
+        // the broker and the consumer allow topic auto-creation by default, so a reader polling a
+        // deleted topic recreates it, and the check then reports it as recreated rather than
+        // missing. Users who want the Kafka default back can still set the property themselves.
+        if (Boolean.parseBoolean(
+                props.getProperty(KafkaSourceOptions.TOPIC_INTEGRITY_CHECK_ENABLED.key()))) {
+            maybeOverride(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false", false);
+        }
+
         // If the client id prefix is not set, reuse the consumer group id as the client id prefix,
         // or generate a random string if consumer group id is not specified.
         maybeOverride(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilderTest.java
@@ -324,6 +324,38 @@ public class KafkaSourceBuilderTest {
                         "Topic integrity check is not supported for non TopicMetadataSettable subscriber");
     }
 
+    @Test
+    public void testTopicIntegrityCheckDisablesTopicAutoCreation() {
+        final KafkaSource<String> kafkaSource =
+                getBasicBuilder().enableTopicIntegrityCheck().build();
+        assertThat(getAllowAutoCreateTopics(kafkaSource)).isFalse();
+    }
+
+    @Test
+    public void testTopicAutoCreationUntouchedWithoutIntegrityCheck() {
+        final KafkaSource<String> kafkaSource = getBasicBuilder().build();
+        assertThat(getAllowAutoCreateTopics(kafkaSource)).isNull();
+    }
+
+    @Test
+    public void testExplicitTopicAutoCreationSurvivesIntegrityCheck() {
+        final KafkaSource<String> kafkaSource =
+                getBasicBuilder()
+                        .enableTopicIntegrityCheck()
+                        .setProperty(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "true")
+                        .build();
+        assertThat(getAllowAutoCreateTopics(kafkaSource)).isTrue();
+    }
+
+    private Boolean getAllowAutoCreateTopics(KafkaSource<?> kafkaSource) {
+        return kafkaSource
+                .getConfiguration()
+                .get(
+                        ConfigOptions.key(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG)
+                                .booleanType()
+                                .noDefaultValue());
+    }
+
     private KafkaSourceBuilder<String> getBasicBuilder() {
         return new KafkaSourceBuilder<String>()
                 .setBootstrapServers("testServer")

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/SourceTopicIntegrityITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/SourceTopicIntegrityITCase.java
@@ -37,9 +37,13 @@ import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkFixedPartiti
 import org.apache.flink.test.junit5.InjectMiniCluster;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.ResourceLock;
@@ -52,11 +56,14 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Integration tests for topic integrity checking in KafkaSource. */
 @ResourceLock("KafkaTestBase")
@@ -192,6 +199,15 @@ public class SourceTopicIntegrityITCase {
         tearDown();
         setupKafka(recreateTopic);
 
+        // Guard the precondition the deleted-topic cases depend on. If anything recreates the
+        // topic before the job resumes, the integrity check reports it as recreated and the wait
+        // below can only time out, which says nothing about why. Fail here instead.
+        if (!recreateTopic) {
+            assertThat(KafkaSourceTestEnv.getAdminClient().listTopics().names().get())
+                    .as("source topic must stay deleted for the \"is missing\" case")
+                    .doesNotContain(SOURCE_TOPIC_NAME);
+        }
+
         // resume from savepoint
         Configuration configuration = new Configuration();
         configuration.set(StateRecoveryOptions.SAVEPOINT_PATH, savepointPath);
@@ -274,6 +290,47 @@ public class SourceTopicIntegrityITCase {
         // cancel the job and wait fot its termination
         miniCluster.cancelJob(secondJobId).get();
         miniCluster.requestJobResult(secondJobId).get();
+    }
+
+    /**
+     * Pins the mechanism behind FLINK-40622 without depending on the savepoint race: a consumer
+     * configured the way the source configures its readers must not create a topic that does not
+     * exist. Both the broker and the Kafka consumer allow topic auto-creation by default, so before
+     * the builder disabled it a reader polling a deleted topic brought it back with a fresh id, and
+     * the integrity check then reported "was recreated" rather than "is missing".
+     *
+     * <p>Uses a name nothing else creates, so it needs neither a broker restart nor the cluster.
+     */
+    @Test
+    public void testSourceReaderDoesNotCreateMissingTopic() throws Exception {
+        final String missingTopic = "SourceTopicIntegrityITCase_never-created";
+        final KafkaSource<String> source =
+                KafkaSource.<String>builder()
+                        .setBootstrapServers(KafkaSourceTestEnv.brokerConnectionStrings)
+                        .setValueOnlyDeserializer(new SimpleStringSchema())
+                        .enableTopicIntegrityCheck()
+                        .setTopics(missingTopic)
+                        .setProperties(getSourceProperties())
+                        .build();
+
+        final Properties consumerProps = new Properties();
+        consumerProps.putAll(source.getConfiguration().toMap());
+        consumerProps.setProperty(
+                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                KafkaSourceTestEnv.brokerConnectionStrings);
+        consumerProps.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "integrity-autocreate-probe");
+
+        // Mirror KafkaPartitionSplitReader: assign explicit partitions, then poll.
+        try (KafkaConsumer<String, String> consumer =
+                new KafkaConsumer<>(
+                        consumerProps, new StringDeserializer(), new StringDeserializer())) {
+            consumer.assign(Collections.singletonList(new TopicPartition(missingTopic, 0)));
+            consumer.poll(Duration.ofSeconds(3));
+        }
+
+        assertThat(KafkaSourceTestEnv.getAdminClient().listTopics().names().get())
+                .as("a source reader must not create the topic whose integrity it checks")
+                .doesNotContain(missingTopic);
     }
 
     private enum SourceSubscriptionMode {


### PR DESCRIPTION
## What is the purpose of the change

`SourceTopicIntegrityITCase.testTopicIntegrityFailure` times out in its deleted-topic cases ([FLINK-40622](https://issues.apache.org/jira/browse/FLINK-40622)). The cause is production behavior, not test timing.

The broker and the Kafka consumer both auto-create topics by default, and the connector overrides neither. After the restart, a restored reader polls its checkpointed partitions and brings the deleted topic back with a fresh id. The check then reports `was recreated`, so the awaited `is missing` never arrives. Whether the check or the readers get there first is a race, so the test failed only under load, and raising the wait in FLINK-40589 could not help.

Production has the same defect: the connector recreates a topic you deleted, then reports the deletion as a recreation. Full evidence is in the JIRA.

## Brief change log

- `KafkaSourceBuilder`: default `allow.auto.create.topics` to `false` when the integrity check is enabled. It goes through the existing `maybeOverride(key, value, false)` path, so an explicit user value stands.
- `KafkaSourceBuilderTest`: pin the default, the non-integrity case, and the explicit override.
- `SourceTopicIntegrityITCase`: add a reader-level test of the mechanism that needs no savepoint race, and a precondition guard so a lost race fails where it happens.

Rebased onto FLINK-40618. Moving the class to the integration-test execution lowers how often the race is lost, but does not remove it.

## A choice for the reviewer

The regression guard sits at two levels, and either one alone is enough:

- `KafkaSourceBuilderTest.testTopicIntegrityCheckDisablesTopicAutoCreation` runs in milliseconds without a broker.
- `SourceTopicIntegrityITCase.testSourceReaderDoesNotCreateMissingTopic` drives a real consumer, so it pins behavior rather than configuration.

Both are included because dropping one now costs less than adding it later. Say which you prefer and I'll remove the other.

## Verifying this change

Both guards fail against the unfixed builder.

Verified: `mvn -pl flink-connector-kafka -Dtest=SourceTopicIntegrityITCase,KafkaSourceBuilderTest verify` → 10 and 25 tests, 0 failures, run twice. One unloaded machine is weak ground for a load-dependent race, so CI is the stronger signal.

Unrelated and not addressed here: `testTopicIntegrityFailure` never cancels its second job, unlike `testTopicIntegritySuccess` since FLINK-40570. Adding one test to the class was enough to exhaust the MiniCluster slots. That needs its own ticket.

## Does this pull request potentially affect one of the following parts?

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Behavior of a source with `enableTopicIntegrityCheck()`: yes, it no longer auto-creates topics unless you set the property

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

*This change was created with AI assistance.*
