### PR TITLE
[BP-5.0][FLINK-40362][connector/kafka] Fix idle reader hang when no-more-splits precedes metadata update

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReader.java
@@ -337,6 +337,10 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
             clustersProperties.putAll(newClustersProperties);
         }
 
+        // Captured before the flag flips below, so the no-more-splits replay can tell the
+        // reader's first metadata update from a later metadata change.
+        final boolean firstMetadataUpdate = !isActivelyConsumingSplits;
+
         // finally mark the reader as active, if not already and add pending splits
         if (!isActivelyConsumingSplits) {
             isActivelyConsumingSplits = true;
@@ -366,9 +370,15 @@ public class DynamicKafkaSourceReader<T> implements SourceReader<T, DynamicKafka
 
             addSplits(validPendingSplits);
             pendingSplits.clear();
-            if (isNoMoreSplits) {
-                notifyNoMoreSplits();
-            }
+        }
+
+        // Replay only on the first metadata update. On a later metadata change the reader must
+        // wait for the enumerator to signal again after the new assignments (that re-signal is
+        // currently missing for a sub-enumerator recreated with partitions already assigned; see
+        // FLINK-31006), so replaying here would finish an active reader before the new topic's
+        // splits arrive.
+        if (isNoMoreSplits && firstMetadataUpdate) {
+            notifyNoMoreSplits();
         }
     }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/reader/DynamicKafkaSourceReaderTest.java
@@ -245,6 +245,67 @@ public class DynamicKafkaSourceReaderTest extends SourceReaderTestBase<DynamicKa
     }
 
     @Test
+    void testIdleReaderFinishesWhenNoMoreSplitsArrivesBeforeMetadata() throws Exception {
+        TestingReaderContext context = new TestingReaderContext();
+        try (DynamicKafkaSourceReader<Integer> reader = createReaderWithoutStart(context)) {
+            TrackingReaderOutput<Integer> readerOutput = new TrackingReaderOutput<>();
+            reader.start();
+
+            // The enumerator signals no more splits before the reader receives the metadata
+            // update event, e.g. when an idle reader registers after all bounded
+            // sub-enumerators have already finished split discovery.
+            reader.notifyNoMoreSplits();
+
+            MetadataUpdateEvent metadata =
+                    DynamicKafkaSourceTestHelper.getMetadataUpdateEvent(TOPIC);
+            CompletableFuture<Void> availableBeforeMetadata = reader.isAvailable();
+            reader.handleSourceEvents(metadata);
+
+            assertThat(availableBeforeMetadata)
+                    .as("the metadata update must wake up a task parked on the earlier future")
+                    .isDone();
+            assertThat(reader.pollNext(readerOutput))
+                    .as(
+                            "idle reader must reach END_OF_INPUT even when no-more-splits precedes the metadata update event")
+                    .isEqualTo(InputStatus.END_OF_INPUT);
+        }
+    }
+
+    @Test
+    void testActiveReaderWaitsForNewSplitsAfterMetadataChange() throws Exception {
+        TestingReaderContext context = new TestingReaderContext();
+        try (DynamicKafkaSourceReader<Integer> reader = createReaderWithoutStart(context)) {
+            TrackingReaderOutput<Integer> readerOutput = new TrackingReaderOutput<>();
+            reader.start();
+
+            // First metadata update: only cluster 0 is known, so the reader goes active with a
+            // single sub-reader.
+            KafkaStream clusterZeroOnly = DynamicKafkaSourceTestHelper.getKafkaStream(TOPIC);
+            clusterZeroOnly.getClusterMetadataMap().remove(kafkaClusterId1);
+            reader.handleSourceEvents(
+                    new MetadataUpdateEvent(Collections.singleton(clusterZeroOnly)));
+
+            // The enumerator finished discovery for that metadata epoch.
+            reader.notifyNoMoreSplits();
+
+            // Cluster 1 appears. The reader holds no splits, so the metadata change recreates every
+            // sub-reader and only the reader-level flag still remembers the earlier signal. Splits
+            // and a fresh no-more-splits signal for the new metadata arrive after this event.
+            reader.handleSourceEvents(DynamicKafkaSourceTestHelper.getMetadataUpdateEvent(TOPIC));
+
+            assertThat(reader.pollNext(readerOutput))
+                    .as(
+                            "reader must not finish on the stale no-more-splits signal while a newly added cluster still awaits its splits")
+                    .isEqualTo(InputStatus.NOTHING_AVAILABLE);
+
+            reader.notifyNoMoreSplits();
+            assertThat(reader.pollNext(readerOutput))
+                    .as("reader finishes once the enumerator signals again for the new metadata")
+                    .isEqualTo(InputStatus.END_OF_INPUT);
+        }
+    }
+
+    @Test
     void testAvailabilityFutureUpdates() throws Exception {
         TestingReaderContext context = new TestingReaderContext();
         try (DynamicKafkaSourceReader<Integer> reader = createReaderWithoutStart(context)) {


### PR DESCRIPTION
Backport of #291 to v5.0, requested in https://github.com/apache/flink-connector-kafka/pull/291#issuecomment-5618687965.

*This change was created with AI assistance.*
