### PR TITLE
[FLINK-31006][Connectors/Kafka] Signal no more splits after a restored bounded enumerator finds no partition changes

### DIFF
--- a/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -365,7 +365,18 @@ public class KafkaSourceEnumerator
 
         final PartitionChange partitionChange =
                 getPartitionChange(fetchedPartitions, !initialDiscoveryFinished);
-        if (partitionChange.isEmpty()) {
+        // A bounded source that has just run its only discovery must reach
+        // handlePartitionSplitChanges even when nothing changed: that is the only place that sets
+        // noMoreNewPartitionSplits, and so the only path that signals the readers. After a restore
+        // every subscribed partition is already assigned, which makes the change empty
+        // (FLINK-31006). initializePartitionSplits performs no broker I/O for an empty change.
+        // Periodic discovery and unbounded sources keep returning early. Neither can act on an
+        // empty change, and treating it as a finished discovery would make the partitions that a
+        // later discovery finds resolve against the earliest offset rather than the configured
+        // one.
+        final boolean boundedSourceFinishedDiscovery =
+                boundedness == Boundedness.BOUNDED && partitionDiscoveryIntervalMs <= 0;
+        if (partitionChange.isEmpty() && !boundedSourceFinishedDiscovery) {
             return;
         }
         context.callAsync(

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorTest.java
@@ -2467,7 +2467,8 @@ public class DynamicKafkaSourceEnumeratorTest {
             return new TestKafkaEnumContextProxy(
                     kafkaClusterId,
                     kafkaMetadataService,
-                    (MockSplitEnumeratorContext<DynamicKafkaSourceSplit>) enumContext);
+                    (MockSplitEnumeratorContext<DynamicKafkaSourceSplit>) enumContext,
+                    signalNoMoreSplitsCallback);
         }
     }
 
@@ -2479,7 +2480,15 @@ public class DynamicKafkaSourceEnumeratorTest {
                 String kafkaClusterId,
                 KafkaMetadataService kafkaMetadataService,
                 MockSplitEnumeratorContext<DynamicKafkaSourceSplit> enumContext) {
-            super(kafkaClusterId, kafkaMetadataService, enumContext, null);
+            this(kafkaClusterId, kafkaMetadataService, enumContext, null);
+        }
+
+        public TestKafkaEnumContextProxy(
+                String kafkaClusterId,
+                KafkaMetadataService kafkaMetadataService,
+                MockSplitEnumeratorContext<DynamicKafkaSourceSplit> enumContext,
+                Runnable signalNoMoreSplitsCallback) {
+            super(kafkaClusterId, kafkaMetadataService, enumContext, signalNoMoreSplitsCallback);
             this.enumContext = enumContext;
         }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/dynamic/source/enumerator/DynamicKafkaSourceEnumeratorTest.java
@@ -2023,6 +2023,56 @@ public class DynamicKafkaSourceEnumeratorTest {
                 applyPropertiesConsumer);
     }
 
+    /**
+     * A bounded DynamicKafkaSource restored with every partition already assigned must still tell
+     * its readers that no more splits are coming. Each sub-enumerator runs its one-time discovery,
+     * finds nothing new, and before FLINK-31006 returned early without ever marking the discovery
+     * as finished, so the readers waited forever and the job never finished.
+     */
+    @Test
+    public void testBoundedRestoreSignalsNoMoreSplitsWithoutPartitionChanges() throws Throwable {
+        final DynamicKafkaSourceEnumState restoredState = getCheckpointState();
+
+        Properties properties = new Properties();
+        // A bounded source never runs periodic discovery; DynamicKafkaSourceBuilder forces this.
+        properties.setProperty(KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(), "-1");
+        properties.setProperty(
+                DynamicKafkaSourceOptions.STREAM_METADATA_DISCOVERY_INTERVAL_MS.key(), "-1");
+
+        try (MockSplitEnumeratorContext<DynamicKafkaSourceSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                DynamicKafkaSourceEnumerator enumerator =
+                        new DynamicKafkaSourceEnumerator(
+                                new KafkaStreamSetSubscriber(Collections.singleton(TOPIC)),
+                                new MockKafkaMetadataService(
+                                        Collections.singleton(
+                                                DynamicKafkaSourceTestHelper.getKafkaStream(
+                                                        TOPIC))),
+                                context,
+                                OffsetsInitializer.earliest(),
+                                new NoStoppingOffsetsInitializer(),
+                                properties,
+                                Boundedness.BOUNDED,
+                                restoredState,
+                                new TestKafkaEnumContextProxyFactory())) {
+            enumerator.start();
+
+            for (int reader = 0; reader < NUM_SUBTASKS; reader++) {
+                mockRegisterReaderAndSendReaderStartupEvent(context, enumerator, reader);
+            }
+            runAllOneTimeCallables(context);
+
+            assertThat(context.getSplitsAssignmentSequence())
+                    .as("Every partition is already assigned, so nothing may be assigned again")
+                    .isEmpty();
+            for (int reader = 0; reader < NUM_SUBTASKS; reader++) {
+                assertThat(context.hasNoMoreSplits(reader))
+                        .as("Reader %s must be told that no more splits are coming", reader)
+                        .isTrue();
+            }
+        }
+    }
+
     private DynamicKafkaSourceEnumerator createEnumerator(
             SplitEnumeratorContext<DynamicKafkaSourceSplit> context,
             KafkaMetadataService kafkaMetadataService,

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceBoundedRestoreITCase.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceBoundedRestoreITCase.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestartStrategyOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.connector.kafka.testutils.KafkaSourceTestEnv;
+import org.apache.flink.core.execution.SavepointFormatType;
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.executiongraph.ErrorInfo;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
+import org.apache.flink.test.junit5.InjectMiniCluster;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A bounded {@link KafkaSource} must still finish when the job is restored from a savepoint, a
+ * retained checkpoint, or after a JobManager failover.
+ *
+ * <p>All three recreate the enumerator from state, and the recreated enumerator finds every
+ * subscribed partition already assigned. On an unfixed enumerator that empty partition change makes
+ * {@code checkPartitionChanges} return before it reaches the only place that marks the discovery as
+ * finished, so the restored readers consume up to their stopping offset and then wait forever for a
+ * {@code NoMoreSplitsEvent} that is never sent (FLINK-31006).
+ *
+ * <p>Do not weaken this test by enabling partition discovery, by putting the stopping offset within
+ * the records produced before the savepoint, or by running it in batch mode: the first two stop the
+ * restored partition change from being empty, and the third removes the checkpoint coordinator that
+ * the savepoint needs.
+ */
+@ResourceLock("KafkaTestBase")
+public class KafkaSourceBoundedRestoreITCase {
+
+    private static final String TOPIC = "KafkaSourceBoundedRestoreITCase-topic";
+
+    /** Records produced before the savepoint. */
+    private static final int RECORDS_BEFORE_SAVEPOINT = 10;
+
+    /** Records produced while the job is stopped, which the restored job must still consume. */
+    private static final int RECORDS_AFTER_SAVEPOINT = 5;
+
+    private static final int TOTAL_RECORDS = RECORDS_BEFORE_SAVEPOINT + RECORDS_AFTER_SAVEPOINT;
+    private static final Duration TIMEOUT = Duration.ofMinutes(2);
+
+    /** Values seen by the pipeline, across both runs of the job. */
+    private static final Set<Integer> COLLECTED = ConcurrentHashMap.newKeySet();
+
+    @TempDir private Path savepointBasePath;
+
+    @RegisterExtension
+    public static final MiniClusterExtension MINI_CLUSTER =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(2)
+                            .build());
+
+    @BeforeEach
+    public void setup() throws Throwable {
+        COLLECTED.clear();
+        KafkaSourceTestEnv.setup();
+        KafkaSourceTestEnv.createTestTopic(TOPIC, 1, 1);
+        produce(0, RECORDS_BEFORE_SAVEPOINT);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        KafkaSourceTestEnv.tearDown();
+    }
+
+    private static void produce(int fromValue, int count) throws Throwable {
+        List<ProducerRecord<String, Integer>> records = new ArrayList<>();
+        for (int i = fromValue; i < fromValue + count; i++) {
+            records.add(new ProducerRecord<>(TOPIC, 0, "key-" + i, i));
+        }
+        KafkaSourceTestEnv.produceToKafka(records);
+    }
+
+    /**
+     * The job graph is built by one helper for both runs so that the restored job has the identical
+     * topology, and therefore the identical operator IDs, as the job the savepoint was taken from.
+     */
+    private JobGraph getJobGraph(Configuration extraConf) {
+        KafkaSource<Integer> source =
+                KafkaSource.<Integer>builder()
+                        .setBootstrapServers(KafkaSourceTestEnv.brokerConnectionStrings)
+                        .setTopics(TOPIC)
+                        .setGroupId("KafkaSourceBoundedRestoreITCase")
+                        .setStartingOffsets(OffsetsInitializer.earliest())
+                        // Beyond what has been produced so far, so the first run cannot finish on
+                        // its own and the savepoint is always taken from a running source.
+                        .setBounded(
+                                OffsetsInitializer.offsets(
+                                        Collections.singletonMap(
+                                                new TopicPartition(TOPIC, 0),
+                                                (long) TOTAL_RECORDS)))
+                        .setDeserializer(
+                                KafkaRecordDeserializationSchema.valueOnly(
+                                        IntegerDeserializer.class))
+                        .build();
+
+        Configuration configuration = new Configuration();
+        configuration.addAll(extraConf);
+        // A hang must surface as a timeout on the job, not as restart churn.
+        configuration.set(RestartStrategyOptions.RESTART_STRATEGY, "disable");
+
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setParallelism(1);
+        DataStream<Integer> stream =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "kafka-source")
+                        .uid("kafka-source")
+                        .map(
+                                (MapFunction<Integer, Integer>)
+                                        value -> {
+                                            COLLECTED.add(value);
+                                            return value;
+                                        })
+                        .uid("collector");
+        stream.sinkTo(new DiscardingSink<>()).uid("sink");
+        return env.getStreamGraph().getJobGraph();
+    }
+
+    /**
+     * Waits for the job to finish, failing immediately if it reaches any other terminal state so
+     * that an unrelated failure is reported as itself rather than as the hang under test.
+     */
+    private static void awaitJobFinished(MiniCluster miniCluster, JobID jobId) throws Exception {
+        CommonTestUtils.waitUtil(
+                () -> {
+                    final JobStatus status;
+                    try {
+                        status = miniCluster.getJobStatus(jobId).get();
+                    } catch (Exception e) {
+                        // The job may not be known to the cluster yet.
+                        return false;
+                    }
+                    if (status == JobStatus.FINISHED) {
+                        return true;
+                    }
+                    if (status.isGloballyTerminalState()) {
+                        throw new IllegalStateException(
+                                String.format(
+                                        "The job reached %s instead of finishing. %s",
+                                        status, failureCause(miniCluster, jobId)));
+                    }
+                    return false;
+                },
+                TIMEOUT,
+                Duration.ofMillis(50),
+                "The restored bounded job did not finish; the readers were never told that no "
+                        + "more splits are coming (FLINK-31006)");
+    }
+
+    private static String failureCause(MiniCluster miniCluster, JobID jobId) {
+        try {
+            final ErrorInfo failureInfo =
+                    miniCluster.getArchivedExecutionGraph(jobId).get().getFailureInfo();
+            return failureInfo == null ? "No failure info." : failureInfo.getExceptionAsString();
+        } catch (Exception e) {
+            return "Failure info unavailable: " + e;
+        }
+    }
+
+    @Test
+    public void testBoundedSourceFinishesAfterRestoreFromSavepoint(
+            @InjectMiniCluster MiniCluster miniCluster) throws Throwable {
+        JobGraph firstJobGraph = getJobGraph(new Configuration());
+        JobID firstJobId = firstJobGraph.getJobID();
+        miniCluster.submitJob(firstJobGraph).get();
+
+        CommonTestUtils.waitUtil(
+                () -> COLLECTED.size() >= RECORDS_BEFORE_SAVEPOINT,
+                TIMEOUT,
+                Duration.ofMillis(50),
+                "The first run did not consume the records produced before the savepoint");
+
+        String savepointPath =
+                miniCluster
+                        .stopWithSavepoint(
+                                firstJobId,
+                                savepointBasePath.toFile().toString(),
+                                false,
+                                SavepointFormatType.CANONICAL)
+                        .get();
+        assertThat(savepointPath).isNotBlank();
+
+        produce(RECORDS_BEFORE_SAVEPOINT, RECORDS_AFTER_SAVEPOINT);
+
+        Configuration restoreConf = new Configuration();
+        restoreConf.set(StateRecoveryOptions.SAVEPOINT_PATH, savepointPath);
+        JobGraph secondJobGraph = getJobGraph(restoreConf);
+        JobID secondJobId = secondJobGraph.getJobID();
+        miniCluster.submitJob(secondJobGraph).get();
+
+        // The restored source reaches its stopping offset and then needs the enumerator to tell it
+        // that no more splits are coming. Without that signal the job hangs here.
+        awaitJobFinished(miniCluster, secondJobId);
+
+        assertThat(COLLECTED)
+                .as("Every produced record must be consumed across the two runs")
+                .containsExactlyInAnyOrderElementsOf(
+                        IntStream.range(0, TOTAL_RECORDS).boxed().collect(Collectors.toList()));
+    }
+}

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumeratorTest.java
@@ -765,6 +765,29 @@ public class KafkaSourceEnumeratorTest {
             Properties overrideProperties,
             OffsetsInitializer startingOffsetsInitializer,
             boolean initialDiscoveryFinished) {
+        return createEnumerator(
+                enumContext,
+                partitionDiscoveryIntervalMs,
+                topicsToSubscribe,
+                assignedSplits,
+                unassignedInitialSplits,
+                overrideProperties,
+                startingOffsetsInitializer,
+                Boundedness.CONTINUOUS_UNBOUNDED,
+                initialDiscoveryFinished);
+    }
+
+    /** Create the enumerator, controlling the boundedness of the source. */
+    private KafkaSourceEnumerator createEnumerator(
+            MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
+            long partitionDiscoveryIntervalMs,
+            Collection<String> topicsToSubscribe,
+            Collection<KafkaPartitionSplit> assignedSplits,
+            Collection<KafkaPartitionSplit> unassignedInitialSplits,
+            Properties overrideProperties,
+            OffsetsInitializer startingOffsetsInitializer,
+            Boundedness boundedness,
+            boolean initialDiscoveryFinished) {
         // Use a TopicPatternSubscriber so that no exception if a subscribed topic hasn't been
         // created yet.
         StringJoiner topicNameJoiner = new StringJoiner("|");
@@ -787,7 +810,7 @@ public class KafkaSourceEnumeratorTest {
                 stoppingOffsetsInitializer,
                 props,
                 enumContext,
-                Boundedness.CONTINUOUS_UNBOUNDED,
+                boundedness,
                 new KafkaSourceEnumState(
                         assignedSplits, unassignedInitialSplits, initialDiscoveryFinished));
     }
@@ -976,6 +999,241 @@ public class KafkaSourceEnumeratorTest {
             // Verify that the properties value is used
             assertThat(propertiesCheckSourceIntegrity)
                     .isEqualTo(enumerator.topicIntegrityCheckEnabled());
+        }
+    }
+
+    /**
+     * A bounded enumerator that is restored with every subscribed partition already assigned must
+     * still tell its readers that no more splits are coming. The restored enumerator runs its
+     * one-time discovery, finds nothing new, and on an unfixed enumerator returns early before
+     * reaching the only place that sets {@code noMoreNewPartitionSplits}, so the readers wait for a
+     * {@code NoMoreSplitsEvent} that never arrives and the job never finishes (FLINK-31006).
+     *
+     * <p>Do not weaken this test by enabling partition discovery or by leaving a partition out of
+     * the restored state: either makes the partition change non-empty and the early return is no
+     * longer taken.
+     */
+    @Test
+    public void testRestoredBoundedEnumeratorSignalsNoMoreSplitsWithoutPartitionChanges()
+            throws Throwable {
+        Set<KafkaPartitionSplit> restoredAssignedSplits =
+                KafkaSourceTestEnv.getPartitionsForTopics(PRE_EXISTING_TOPICS).stream()
+                        .map(tp -> new KafkaPartitionSplit(tp, 0L))
+                        .collect(Collectors.toSet());
+        assertThat(restoredAssignedSplits).isNotEmpty();
+
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(
+                                context,
+                                -1,
+                                PRE_EXISTING_TOPICS,
+                                restoredAssignedSplits,
+                                Collections.emptySet(),
+                                new Properties(),
+                                OffsetsInitializer.earliest(),
+                                Boundedness.BOUNDED,
+                                true)) {
+            enumerator.start();
+
+            // A reader that re-registers before the discovery callback returns.
+            registerReader(context, enumerator, READER0);
+            runOneTimePartitionDiscovery(context);
+            // A reader that re-registers after it.
+            registerReader(context, enumerator, READER1);
+
+            assertThat(context.getSplitsAssignmentSequence())
+                    .as("Every partition is already assigned, so nothing may be assigned again")
+                    .isEmpty();
+            SoftAssertions.assertSoftly(
+                    softly -> {
+                        softly.assertThat(context.hasNoMoreSplits(READER0))
+                                .as("Reader registered before the discovery callback")
+                                .isTrue();
+                        softly.assertThat(context.hasNoMoreSplits(READER1))
+                                .as("Reader registered after the discovery callback")
+                                .isTrue();
+                    });
+        }
+    }
+
+    /**
+     * The mirror of the two tests above. An unbounded source with one-time discovery cannot act on
+     * an empty partition change: it has no readers to tell that the input ended, and treating the
+     * discovery as finished would make a later restore initialise the partitions that appeared
+     * meanwhile from the earliest offset instead of the configured one. It must keep returning
+     * early, and this test fails if the condition in checkPartitionChanges is ever widened past
+     * bounded sources.
+     */
+    @Test
+    public void testUnboundedSourceKeepsSkippingAnEmptyPartitionChange() throws Throwable {
+        Collection<String> noSuchTopic = Collections.singleton("topic-that-does-not-exist");
+
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(
+                                context,
+                                -1,
+                                noSuchTopic,
+                                Collections.emptySet(),
+                                Collections.emptySet(),
+                                new Properties(),
+                                OffsetsInitializer.earliest(),
+                                Boundedness.CONTINUOUS_UNBOUNDED,
+                                false)) {
+            enumerator.start();
+            registerReader(context, enumerator, READER0);
+            runOneTimePartitionDiscovery(context);
+
+            SoftAssertions.assertSoftly(
+                    softly -> {
+                        try {
+                            softly.assertThat(
+                                            enumerator.snapshotState(1L).initialDiscoveryFinished())
+                                    .as("An empty change must not mark the discovery as finished")
+                                    .isFalse();
+                        } catch (Exception e) {
+                            throw new IllegalStateException(e);
+                        }
+                        softly.assertThat(context.hasNoMoreSplits(READER0))
+                                .as("An unbounded source never runs out of splits")
+                                .isFalse();
+                        softly.assertThat(context.getSplitsAssignmentSequence())
+                                .as("There is no partition to assign")
+                                .isEmpty();
+                    });
+        }
+    }
+
+    /**
+     * The same early return leaves a bounded source that subscribes to no existing partition
+     * hanging on a fresh start: the partition change is empty from the first discovery on, so the
+     * readers are never told that no more splits are coming (FLINK-31006).
+     */
+    @Test
+    public void testBoundedSourceWithoutPartitionsSignalsNoMoreSplits() throws Throwable {
+        // A single explicit name, because the helper joins the names into a pattern and an empty
+        // collection would compile to a pattern that matches every topic.
+        Collection<String> noSuchTopic = Collections.singleton("topic-that-does-not-exist");
+
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(
+                                context,
+                                -1,
+                                noSuchTopic,
+                                Collections.emptySet(),
+                                Collections.emptySet(),
+                                new Properties(),
+                                OffsetsInitializer.earliest(),
+                                Boundedness.BOUNDED,
+                                false)) {
+            enumerator.start();
+
+            registerReader(context, enumerator, READER0);
+            runOneTimePartitionDiscovery(context);
+            registerReader(context, enumerator, READER1);
+
+            assertThat(context.getSplitsAssignmentSequence())
+                    .as("There is no partition to assign")
+                    .isEmpty();
+            SoftAssertions.assertSoftly(
+                    softly -> {
+                        softly.assertThat(context.hasNoMoreSplits(READER0))
+                                .as("Reader registered before the discovery callback")
+                                .isTrue();
+                        softly.assertThat(context.hasNoMoreSplits(READER1))
+                                .as("Reader registered after the discovery callback")
+                                .isTrue();
+                    });
+        }
+    }
+
+    /**
+     * A restored bounded enumerator must not tell a reader that the input ended before the
+     * discovery that follows the restore has assigned that reader its splits. A partition created
+     * while the job was down is only found by that discovery, so signalling from addReader on the
+     * strength of the restored initialDiscoveryFinished flag would finish the reader first and
+     * assign to it afterwards. That is the failure that apache/flink#21909 was rejected for, and
+     * this test pins the ordering that avoids it.
+     */
+    @Test
+    public void testRestoredBoundedEnumeratorAssignsBeforeItSignals() throws Throwable {
+        // Only TOPIC1 was assigned before the savepoint; TOPIC2 stands in for the partitions that
+        // appeared while the job was down and that only the post-restore discovery can find.
+        Set<KafkaPartitionSplit> restoredAssignedSplits =
+                KafkaSourceTestEnv.getPartitionsForTopics(Collections.singleton(TOPIC1)).stream()
+                        .map(tp -> new KafkaPartitionSplit(tp, 0L))
+                        .collect(Collectors.toSet());
+        assertThat(restoredAssignedSplits).isNotEmpty();
+
+        try (RecordingSplitEnumeratorContext context =
+                        new RecordingSplitEnumeratorContext(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(
+                                context,
+                                -1,
+                                PRE_EXISTING_TOPICS,
+                                restoredAssignedSplits,
+                                Collections.emptySet(),
+                                new Properties(),
+                                OffsetsInitializer.earliest(),
+                                Boundedness.BOUNDED,
+                                true)) {
+            enumerator.start();
+            // Registers before the discovery callback, which is the ordering a restore produces.
+            registerReader(context, enumerator, READER0);
+            runOneTimePartitionDiscovery(context);
+
+            assertThat(context.events)
+                    .as("The reader must be assigned its splits before it is told the input ended")
+                    .isNotEmpty();
+            final int firstSignal = context.events.indexOf("signalNoMoreSplits:" + READER0);
+            final int lastAssign = context.events.lastIndexOf("assignSplits:" + READER0);
+            assertThat(firstSignal)
+                    .as(
+                            "Reader %s was never told that no more splits are coming: %s",
+                            READER0, context.events)
+                    .isNotNegative();
+            assertThat(lastAssign)
+                    .as(
+                            "Reader %s was never assigned the partitions discovered after the "
+                                    + "restore: %s",
+                            READER0, context.events)
+                    .isNotNegative();
+            assertThat(lastAssign)
+                    .as(
+                            "Reader %s was told the input ended before its splits arrived: %s",
+                            READER0, context.events)
+                    .isLessThan(firstSignal);
+        }
+    }
+
+    /** Records the order in which splits are assigned and no-more-splits is signalled. */
+    private static class RecordingSplitEnumeratorContext
+            extends MockSplitEnumeratorContext<KafkaPartitionSplit> {
+        private final List<String> events = new ArrayList<>();
+
+        private RecordingSplitEnumeratorContext(int parallelism) {
+            super(parallelism);
+        }
+
+        @Override
+        public void assignSplits(SplitsAssignment<KafkaPartitionSplit> newSplitAssignments) {
+            newSplitAssignments
+                    .assignment()
+                    .keySet()
+                    .forEach(subtask -> events.add("assignSplits:" + subtask));
+            super.assignSplits(newSplitAssignments);
+        }
+
+        @Override
+        public void signalNoMoreSplits(int subtask) {
+            events.add("signalNoMoreSplits:" + subtask);
+            super.signalNoMoreSplits(subtask);
         }
     }
 

--- a/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumeratorTest.java
+++ b/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumeratorTest.java
@@ -748,7 +748,8 @@ public class KafkaSourceEnumeratorTest {
                 assignedSplits,
                 unassignedInitialSplits,
                 overrideProperties,
-                startingOffsetsInitializer);
+                startingOffsetsInitializer,
+                initialDiscoveryFinished);
     }
 
     /**
@@ -762,7 +763,8 @@ public class KafkaSourceEnumeratorTest {
             Collection<KafkaPartitionSplit> assignedSplits,
             Collection<KafkaPartitionSplit> unassignedInitialSplits,
             Properties overrideProperties,
-            OffsetsInitializer startingOffsetsInitializer) {
+            OffsetsInitializer startingOffsetsInitializer,
+            boolean initialDiscoveryFinished) {
         // Use a TopicPatternSubscriber so that no exception if a subscribed topic hasn't been
         // created yet.
         StringJoiner topicNameJoiner = new StringJoiner("|");
@@ -786,7 +788,8 @@ public class KafkaSourceEnumeratorTest {
                 props,
                 enumContext,
                 Boundedness.CONTINUOUS_UNBOUNDED,
-                new KafkaSourceEnumState(assignedSplits, unassignedInitialSplits, false));
+                new KafkaSourceEnumState(
+                        assignedSplits, unassignedInitialSplits, initialDiscoveryFinished));
     }
 
     // ---------------------


### PR DESCRIPTION
## What is the purpose of the change

A bounded `KafkaSource` never finishes once the job has been restored from a savepoint or a retained checkpoint, or after a JobManager failover. All three recreate the enumerator from state. The recreated enumerator runs its one-time discovery, finds every subscribed partition already in `assignedSplits`, and `checkPartitionChanges` returns on the empty `PartitionChange` before it reaches `handlePartitionSplitChanges`, which is the only place that sets `noMoreNewPartitionSplits`. The restored readers consume up to their stopping offset and then wait forever for a `NoMoreSplitsEvent`, which the runtime never re-sends on its own. The same early return hangs a bounded source that subscribes to no existing partition on a fresh start.

The early return came in with `0b38d1a9` (FLINK-22147). Before that refactor, discovery and split initialisation shared one callable whose callback always ran, so a restored bounded source did signal correctly. The Pulsar enumerator does not have this bug, because its split assigner marks the discovery finished on every discovery rather than only on a change.

## Brief change log

  - `KafkaSourceEnumerator.checkPartitionChanges` lets an empty partition change through when a bounded source has run its only discovery, so that it reaches `handlePartitionSplitChanges` and signals the registered readers
  - Periodic discovery and unbounded sources keep returning early; neither can act on an empty change, and treating one as a finished discovery would make the partitions a later discovery finds resolve against the earliest offset rather than the configured one
  - `[hotfix][tests]` the `createEnumerator` helper in `KafkaSourceEnumeratorTest` dropped its `initialDiscoveryFinished` argument
  - `[hotfix][tests]` the context proxy in `DynamicKafkaSourceEnumeratorTest` passed `null` where production passes `DynamicKafkaSourceEnumerator::handleNoMoreSplits`, so no test could observe that wiring

Signalling from `addReader` on the strength of the restored `initialDiscoveryFinished` flag would need no new state, but it finishes a reader before the post-restore discovery assigns it a partition created while the job was down. That is what apache/flink#21909 was rejected for. The reasoning is written up on FLINK-31006, answering the question left open on FLINK-33466 in 2023.

## Verifying this change

This change added tests and can be verified as follows:

  - Added `testRestoredBoundedEnumeratorSignalsNoMoreSplitsWithoutPartitionChanges` and `testBoundedSourceWithoutPartitionsSignalsNoMoreSplits` to `KafkaSourceEnumeratorTest` for the restore and the empty-subscription paths
  - Added `testBoundedRestoreSignalsNoMoreSplitsWithoutPartitionChanges` to `DynamicKafkaSourceEnumeratorTest` for the same restore through the sub-enumerators
  - Added `KafkaSourceBoundedRestoreITCase`, which produces to a single partition, takes a savepoint with `stopWithSavepoint`, produces more records and restores; no existing test restored a bounded `KafkaSource`
  - Each of those four fails without the production change. The ITCase times out after two minutes on the base and passes in about six seconds with the fix
  - Added `testUnboundedSourceKeepsSkippingAnEmptyPartitionChange` and `testRestoredBoundedEnumeratorAssignsBeforeItSignals`, which pass on both sides by design: the first fails if the condition is ever widened past bounded sources, the second fails under the `addReader` variant described above
  - `mvn verify` on the module with no skips: 443 unit tests and 326 integration tests, no failures, spotless, checkstyle, enforcer and japicmp clean, plus `apache-rat:check` at the root
  - Ran the new ITCase 20 consecutive times, all passing

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency, including `kafka.version` or `flink.version`): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)` or `@Experimental`, or are the Table options or the PyFlink wrappers changed: no
  - Checkpointed state, its serializers, or exactly-once delivery (splits, enumerator state, writer state, committables, transactions): yes. There is no state format change and no serializer change, and `noMoreNewPartitionSplits` stays derived rather than checkpointed. What does change is the value a bounded source snapshots for the existing `initialDiscoveryFinished` field when its only discovery finds nothing: previously it stayed `false`, now it becomes `true`, which is what the readers are signalled from. On the restore path the restored value is already `true`, so nothing moves there.
  - The per-record code paths (split reader, record emitter, writer, serialization schemas; performance sensitive): no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable. The documented behaviour, that a bounded source exits once all partitions reach their stopping offsets, is what this restores.
  - If the docs changed, are both `docs/content` and `docs/content.zh` updated? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code 2.1.267 (Claude Opus 5)
