### PR TITLE
[FLINK-40629][build] Bump Maven from 3.8.6 to 3.9.16

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -18,7 +18,7 @@
 wrapperVersion=3.3.4
 
 # updating the Maven version requires updates to certain documentation and verification logic
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
-distributionSha256Sum=ccf20a80e75a17ffc34d47c5c95c98c39d426ca17d670f09cd91e877072a9309
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+distributionSha256Sum=5af3b743dd8b876b5c45da33b676251e5f1687712644abb4ee519ca56e1d89ce
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar
 wrapperSha256Sum=4e2fbf6554bc8a4702cdfdd3bef464f423393d784ddbb037216320ce55d5e4e1

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prerequisites:
 
 * Unix-like environment (we use Linux, Mac OS X)
 * Git
-* Maven (we recommend version 3.8.6)
+* Maven (we recommend version 3.9.16)
 * Java 11
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -642,4 +642,39 @@ under the License.
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<!-- Mirrors the activation of the release profile in flink-connector-parent,
+			which is activated by the property rather than by -P. -->
+			<id>release</id>
+			<activation>
+				<property>
+					<name>release</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-enforcer-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>enforce-maven</id>
+								<configuration>
+									<rules>
+										<requireMavenVersion>
+											<!-- Releases must use the Maven version from
+											.mvn/wrapper/maven-wrapper.properties -->
+											<version>[3.9.16]</version>
+										</requireMavenVersion>
+									</rules>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
## What is the purpose of the change

FLINK-40459 moved Flink and flink-shaded from Maven 3.8.6 to 3.9.16. This does the same for the Kafka connector.

The shared connector CI derives the Maven version it installs from `distributionUrl` in `.mvn/wrapper/maven-wrapper.properties`, so bumping the wrapper moves CI along with local builds.

## Brief change log

- `.mvn/wrapper/maven-wrapper.properties`: Maven 3.9.16, with the checksum published on Maven Central. The wrapper scripts are already at 3.3.4 and are unchanged.
- `README.md`: recommend 3.9.16.
- `pom.xml`: pin the exact version in the `release` profile, mirroring what flink-shaded does. The profile repeats the parent's activation because `flink-connector-parent` activates its `release` profile on the property rather than on `-P`; without that, a `-Drelease` build silently keeps the inherited `[3.2.5,)`.

## Verifying this change

- `./mvnw --version` reports 3.9.16, which also verifies the new checksum.
- `./mvnw clean verify` passes on JDK 11, 17 and 21; `flink-connector-kafka` unit tests pass (436 tests).
- `./mvnw help:effective-pom -Drelease` shows `[3.9.16]` in the executing enforcer block and retains the parent's `requireJavaVersion`; a plain build still shows `[3.1.1,)`.
- Red/green on the pin: with Maven 3.8.6, `mvn -Drelease validate` now fails with `Detected Maven Version: 3.8.6 is not in the allowed range [3.9.16,3.9.16]`; with 3.9.16 it passes; plain builds are unaffected on both.

## Note for reviewers

Maven 3.9 prints mojo banners using the plugin's goal prefix (`deploy:3.1.4:deploy`) instead of its artifactId (`maven-deploy-plugin:3.1.4:deploy`). `flink-ci-tools`' `DeployParser` and `DependencyParser` match only the artifactId spelling, and no released `flink-ci-tools` carries the parser fix from FLINK-40459 (newest on Central is 2.3.0; this repo uses 2.2.1). On Maven 3.9 the checker therefore extracts 0 deployed modules, demotes every NOTICE entry to a TOLERATED "not bundled, but listed" warning, and still exits 0. Measured on this repo:

```
Maven 3.8.6   -> Extracted 4 modules that were deployed and 7 modules which bundle dependencies
Maven 3.9.16  -> Extracted 0 modules that were deployed and 7 modules which bundle dependencies
```

Both exit 0. A companion change to `flink-connector-shared-utils` (`ci_utils`) normalises those banners and asserts a non-zero module count so a check that inspected nothing fails instead of passing. **That should be merged first** — until it is, CI here will be green with the NOTICE half of the license check not actually running.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **no**
- The public API: **no**
- The serializers: **no**
- The runtime per-record code paths: **no**
- Anything that affects deployment or recovery: **no**
- The S3 file system connector: **no**

## Documentation

- Does this pull request introduce a new feature? **no**

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code 2.1.267 (Claude Opus 5)